### PR TITLE
feat: Sprint 3 — temporal date-filtered retrieval (v0.7.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,27 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-*Phase 8: procedural NDCG improvement (target ≥ 0.55, current 0.389 in R1).*
+*Next: keyword regression investigation, Dex CRM chunking (TMP-3), temporal benchmark expansion (TMP-6).*
+
+## [0.7.0] - 2026-04-10 — Sprint 3: Temporal Retrieval + Date Infrastructure
+
+### Added
+- **TMP-1**: `chunk_date` column in `content_vectors` — idempotent migration via `schema.py:ensure_vec_table`. Stores the date extracted from each chunk's source document.
+- **TMP-1**: `mnemosyne/embed/date_extract.py` — date extraction at embed time from (1) frontmatter `date`/`created`/`updated`/`created_at` fields (YYYY-MM-DD), (2) YYYY-MM year-month fields (mapped to first of month), (3) filename pattern `YYYY-MM-DD.md`. 24 tests.
+- **TMP-2**: `get_date_filtered_paths(db, start, end)` in `embed/schema.py` — returns `frozenset[str]` of document paths with `chunk_date` in the given window. Used by `hybrid.py` for TEMPORAL intent date-range filtering.
+- **TMP-2**: `is_relative_temporal(query)` in `temporal/rewriter.py` — returns `True` for relative temporal expressions (`last N days/weeks/months`, `recently`, `yesterday`, `today`, `this week/month`). Date filtering is only applied for relative expressions — absolute date references (`March 2026`, `2026-03-09`) query `about` a time period and must not be filtered by chunk_date.
+- **TMP-2**: Date-filtered retrieval in `hybrid.py` — BM25 results post-filtered via `_path_from_file_uri()` + `date_filter_paths`; vector results post-filtered directly on `path`. Both fallback gracefully (no filter applied) when `date_filter_paths` is `None` or empty.
+- **TMP-4**: `scripts/chunk-daily-files.py` — pre-processor for daily memory log files (`YYYY-MM-DD.md`). Splits on `##` headings, writes section chunks with injected frontmatter so each section inherits its parent document's date. 11 tests.
+- **TMP-5**: `scripts/audit-date-formats.py` — scans Obsidian vault `.md` frontmatter for date field coverage. Classifies values as ISO / YYYY-MM (year-month) / non-ISO / absent. 13 tests.
+- **TMP-5b**: YYYY-MM year-month frontmatter pattern in `date_extract.py` — maps `date: 2025-11` to `2025-11-01`. 6 additional tests.
+
+### Fixed
+- `mnemosyne/embed/embed.py` — replaced hardcoded Key Vault name in error messages with `$MNEMOSYNE_KV_NAME` env var reference.
+
+### Benchmark (R5 — 2026-04-10, 83 curated queries)
+- temporal NDCG: 0.369 → **0.382** (TMP-2 date filtering for relative temporal expressions)
+- entity: 0.751 · multi_hop: 0.549 · procedural: 0.564 · semantic: 0.519 · keyword: 0.439
+- **Overall NDCG@10: 0.5569** · Hit@5: 0.84 · MRR: 0.67
 
 ## [0.6.0] - 2026-04-07 — R1: Post-Refactor Benchmark + O-2 Enrichment
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Private, on-infrastructure contextual retrieval for human-agent teams. Your knowledge stays on your servers. Your agents and teammates query the same indexed knowledge base.
 
-**NDCG@10 0.58** on an 83-case curated real-world benchmark (strict NDCG@10, graded relevance) · **Hit@5 0.86** — a relevant document appears in the top 5 for 86% of queries. Procedural query boost raised how-to/runbook NDCG from 0.39 to 0.57.
+**NDCG@10 0.5569** on an 83-case curated real-world benchmark (strict NDCG@10, graded relevance) · **Hit@5 0.84**. Temporal date-filtered retrieval (Sprint 3) raised temporal NDCG from 0.37 to 0.38; procedural path boost raised how-to/runbook NDCG from 0.39 to 0.56.
 
 ---
 
@@ -99,7 +99,7 @@ All search and entity data is stored in SQLite — no separate vector database, 
 | `mnemosyne embed` | ✅ Shipped | Azure OpenAI `text-embedding-3-large` → sqlite-vec (1536-dim) |
 | `mnemosyne search` | ✅ Shipped | Hybrid BM25 + vector via RRF, token budget management |
 | `mnemosyne entity` | ✅ Shipped | Entity graph, alias resolution, entity boost, multi-hop query planning |
-| `mnemosyne temporal` | ✅ Shipped | Temporal query rewriting + date-aware chunking |
+| `mnemosyne temporal` | ✅ Shipped | Temporal query rewriting + date-filtered retrieval (TMP-2); `chunk_date` extraction at embed time (TMP-1/5b) |
 | `mnemosyne summarise` | ✅ Shipped | L0/L1 tiered context loading |
 | `mnemosyne wikilinks` | ✅ Shipped | Wikilink injection + entity resolver |
 | `mnemosyne brief` | ✅ Shipped | Session briefing synthesis via GPT-4o-mini |
@@ -113,22 +113,21 @@ See [ROADMAP.md](ROADMAP.md) for priorities and [ENGINEERING.md](ENGINEERING.md)
 
 ## Benchmark Results
 
-**Suite:** 263 cases across 7 query categories, scored with NDCG@10 using LLM-as-judge (GPT-4o-mini) relevance grading. Evaluated on a real-world personal knowledge base of ~2,800 documents.
+**Suite:** 83 curated queries across 6 categories (entity, keyword, multi_hop, procedural, semantic, temporal), scored with strict NDCG@10 using graded gold relevance. Evaluated on a real-world personal knowledge base of ~3,200 documents.
 
-### Current results (R1)
+### Current results (R5 — 2026-04-10)
 
 | Category | NDCG@10 | Cases | Notes |
 |---|---|---|---|
-| entity | 0.823 | 47 | Entity graph + alias resolution working well |
-| temporal | 0.810 | 39 | Date-aware chunking effective |
-| conceptual | 0.804 | 47 | Vector search carrying semantic load |
-| keyword | 0.800 | 32 | BM25 baseline solid |
-| recall | 0.788 | 49 | Known-document retrieval reliable |
-| multi_hop | 0.728 | 33 | QueryPlanner functional |
-| procedural | 0.554 | 16 | ✅ Phase 8-A path boost shipped |
-| **Overall** | **0.7756** | **263** | |
+| entity | 0.751 | 14 | Entity graph + alias resolution |
+| multi_hop | 0.549 | 10 | QueryPlanner, entity-aware sub-query decomposition |
+| procedural | 0.564 | 30 | Path boost for how-to/runbook queries |
+| semantic | 0.519 | 13 | Vector search carrying semantic load |
+| temporal | 0.382 | 8 | Date-filtered retrieval (TMP-2) |
+| keyword | 0.439 | 8 | BM25 baseline; keyword regression under investigation |
+| **Overall** | **0.5569** | **83** | |
 
-Production RAG systems on heterogeneous personal knowledge typically score 0.60–0.75.
+Production RAG systems on heterogeneous personal knowledge typically score 0.45–0.65 on strict curated suites.
 
 ### Score trajectory
 

--- a/mnemosyne/_azure.py
+++ b/mnemosyne/_azure.py
@@ -172,7 +172,7 @@ def embed_text(text: str) -> list[float]:
         return []
 
 
-def chat_completion(messages: list[dict], max_tokens: int = 800) -> str:
+def chat_completion(messages: list[dict[str, str]], max_tokens: int = 800) -> str:
     """
     Call GPT-4o-mini for synthesis via Azure OpenAI chat completions.
 

--- a/mnemosyne/embed/date_extract.py
+++ b/mnemosyne/embed/date_extract.py
@@ -1,0 +1,95 @@
+"""
+Extract a document date from frontmatter fields or filename patterns.
+
+Priority order:
+  1. YAML frontmatter (date / created / updated / created_at fields)
+  2. ISO date pattern YYYY-MM-DD in the file path
+
+Returns an ISO 8601 date string (e.g. "2026-04-09") or None if no reliable
+date signal is found.
+
+documents.modified_at is intentionally excluded -- that is the QMD index time,
+not the document date, and including it would pollute temporal queries with
+false signal.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, date, datetime, timedelta
+
+# Scan only the first 2 000 characters for frontmatter to keep extraction fast.
+_FRONTMATTER_HEAD = 2000
+
+# Fields recognised in YAML frontmatter (in priority order of appearance).
+_FRONTMATTER_PATTERN = re.compile(
+    r"^[ \t]*(?:date|created|updated|created_at)[ \t]*:[ \t]*[\"']?"
+    r"(\d{4}-\d{2}-\d{2})(?:[T ][\d:]+)?[\"']?[ \t]*$",
+    re.MULTILINE | re.IGNORECASE,
+)
+
+# ISO date anywhere in a path segment (filename or directory component).
+_PATH_DATE_PATTERN = re.compile(r"(\d{4}-\d{2}-\d{2})")
+
+# Year-month only (YYYY-MM) in frontmatter — not followed by a day component.
+# Maps to first day of month (YYYY-MM-01) for temporal filtering purposes.
+_FRONTMATTER_YEARMONTH_PATTERN = re.compile(
+    # Match YYYY-MM date fields but NOT YYYY-MM-DD (negative lookahead for -DD)
+    r"^[ \t]*(?:date|created|updated|created_at)[ \t]*:[ \t]*"
+    r"[\"']*([0-9]{4}-[0-9]{2})(?!-[0-9]{2})[\"'\s]*$",
+    re.MULTILINE | re.IGNORECASE,
+)
+
+# Inclusive validity window: dates must be >= 2000-01-01.
+_MIN_DATE = date(2000, 1, 1)
+
+
+def _is_valid_date(value: str) -> bool:
+    """
+    Return True if *value* is a real calendar date within the accepted window.
+
+    Accepts dates from 2000-01-01 up to today + 1 day (future-proof for edge
+    cases such as documents pre-dated by one day in a different timezone).
+    """
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError:
+        return False
+
+    max_date = datetime.now(UTC).date() + timedelta(days=1)
+    return _MIN_DATE <= parsed <= max_date
+
+
+def extract_chunk_date(doc: str, path: str) -> str | None:
+    """
+    Extract the best available document date.
+
+    Args:
+        doc:  Full document text (only the first 2 000 chars are scanned).
+        path: File path from the ``documents`` table.
+
+    Returns:
+        ISO 8601 date string (``"YYYY-MM-DD"``) or ``None``.
+    """
+    # 1. Frontmatter
+    head = doc[:_FRONTMATTER_HEAD]
+    for match in _FRONTMATTER_PATTERN.finditer(head):
+        candidate = match.group(1)
+        if _is_valid_date(candidate):
+            return candidate
+
+    # 2. Year-month frontmatter (YYYY-MM → YYYY-MM-01)
+    if not any(_FRONTMATTER_PATTERN.finditer(head)):
+        for match in _FRONTMATTER_YEARMONTH_PATTERN.finditer(head):
+            ym = match.group(1)  # "YYYY-MM"
+            candidate = ym + "-01"
+            if _is_valid_date(candidate):
+                return candidate
+
+    # 3. Filename / path
+    for match in _PATH_DATE_PATTERN.finditer(path):
+        candidate = match.group(1)
+        if _is_valid_date(candidate):
+            return candidate
+
+    return None

--- a/mnemosyne/embed/schema.py
+++ b/mnemosyne/embed/schema.py
@@ -16,9 +16,12 @@ See QMD_COMPAT.md for the full schema and upgrade procedure.
 """
 
 import json
+import logging
 import os
 import sqlite3
+from datetime import date
 from pathlib import Path
+from typing import Any
 
 # Known paths for the sqlite-vec extension (vec0.so)
 # QMD ships it as an npm package — these are the expected install locations
@@ -39,7 +42,7 @@ _SQLITE_VEC_ENV = "SQLITE_VEC_PATH"
 QMD_TESTED_VERSION = "1.1.2"
 
 # Expected columns in content_vectors
-EXPECTED_CONTENT_VECTORS_COLS = {"hash", "seq", "pos", "model", "embedded_at"}
+EXPECTED_CONTENT_VECTORS_COLS = {"hash", "seq", "pos", "model", "embedded_at", "chunk_date"}
 
 # Expected columns in content (source chunks — NB: text is in 'doc' column, NOT 'body')
 EXPECTED_CONTENT_COLS = {"hash", "doc", "created_at"}
@@ -173,7 +176,7 @@ def ensure_vec_table(db: sqlite3.Connection, dims: int = EMBED_VECTOR_DIMS) -> N
     db.commit()
 
 
-def get_pending_chunks(db: sqlite3.Connection) -> list[dict]:
+def get_pending_chunks(db: sqlite3.Connection) -> list[dict[str, Any]]:
     """
     Return chunks that need embedding.
     Mirrors QMD's getHashesNeedingEmbedding() logic.
@@ -205,7 +208,7 @@ def get_pending_chunks(db: sqlite3.Connection) -> list[dict]:
     return chunks
 
 
-def get_all_chunks_needing_embedding(db: sqlite3.Connection) -> list[dict]:
+def get_all_chunks_needing_embedding(db: sqlite3.Connection) -> list[dict[str, Any]]:
     """
     Return all (hash, seq, pos, text) tuples from content_vectors
     that exist in content_vectors but have no entry in vectors_vec.
@@ -223,7 +226,7 @@ def get_all_chunks_needing_embedding(db: sqlite3.Connection) -> list[dict]:
     return [{"hash": r[0], "seq": r[1], "pos": r[2], "body": r[3]} for r in rows]
 
 
-def save_run_log(entry: dict) -> None:
+def save_run_log(entry: dict[str, Any]) -> None:
     """Append run metadata to ~/.cache/qmd/azure-embed-runs.json."""
     log_path = Path.home() / ".cache" / "qmd" / "azure-embed-runs.json"
     runs = []
@@ -236,3 +239,75 @@ def save_run_log(entry: dict) -> None:
     # Keep last 90 runs
     runs = runs[-90:]
     log_path.write_text(json.dumps(runs, indent=2))
+
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate_content_vectors(db: sqlite3.Connection) -> None:
+    """
+    Idempotent migration: add chunk_date column to content_vectors if missing.
+
+    This migration is additive-only (ALTER TABLE ADD COLUMN). The column is
+    nullable with no default so existing rows are unaffected.
+
+    Safe to call on every startup -- it is a no-op when the column already
+    exists.
+    """
+    existing = {row[1] for row in db.execute("PRAGMA table_info(content_vectors)")}
+    if "chunk_date" in existing:
+        return
+
+    db.execute("ALTER TABLE content_vectors ADD COLUMN chunk_date TEXT")
+    db.commit()
+    _logger.info("Migration: added chunk_date column to content_vectors")
+
+
+def get_date_filtered_paths(
+    db: sqlite3.Connection,
+    start: date | None,
+    end: date | None,
+) -> frozenset[str]:
+    """
+    Return vault-relative paths whose chunk_date falls within [start, end].
+
+    Used by TMP-2 to pre-filter hybrid search results for TEMPORAL queries.
+    When both start and end are None, returns an empty frozenset immediately
+    (caller treats empty as no-filter to avoid zero-result searches during
+    the chunk_date backfill transition period).
+
+    Falls back to empty frozenset on any DB error rather than raising.
+
+    Args:
+        db:    Open sqlite3.Connection (QMD index — no sqlite-vec extension needed).
+        start: Lower bound (inclusive). None means no lower bound.
+        end:   Upper bound (inclusive). None means no upper bound.
+
+    Returns:
+        frozenset of vault-relative document paths with chunk_date in [start, end].
+        Empty frozenset means no dated chunks found; caller must not filter results.
+    """
+    if start is None and end is None:
+        return frozenset()
+
+    conditions = ["cv.chunk_date IS NOT NULL"]
+    params: list[str] = []
+    if start is not None:
+        conditions.append("cv.chunk_date >= ?")
+        params.append(start.isoformat())
+    if end is not None:
+        conditions.append("cv.chunk_date <= ?")
+        params.append(end.isoformat())
+
+    try:
+        rows = db.execute(
+            "SELECT DISTINCT d.path "
+            "FROM content_vectors cv "
+            "JOIN documents d ON d.hash = cv.hash "
+            "WHERE " + " AND ".join(conditions),
+            params,
+        ).fetchall()
+        return frozenset(r[0] for r in rows)
+    except Exception as exc:
+        _logger.warning("get_date_filtered_paths: query failed — %s", exc)
+        return frozenset()

--- a/mnemosyne/search/bm25.py
+++ b/mnemosyne/search/bm25.py
@@ -289,11 +289,26 @@ def _bm25_direct_db(
     return results
 
 
+def _path_from_file_uri(file_uri: str) -> str:
+    """Extract vault-relative path from a QMD file URI.
+
+    QMD file URIs have the format ``qmd://{collection}/{path}``.
+    Returns the vault-relative ``{path}`` component.
+    Falls back to returning the full URI unchanged for non-qmd URIs.
+    """
+    if "://" in file_uri:
+        after_scheme = file_uri.split("://", 1)[1]
+        parts = after_scheme.split("/", 1)
+        return parts[1] if len(parts) == 2 else after_scheme
+    return file_uri
+
+
 def bm25_search(
     query: str,
     collections: list[str] | None = None,
     limit: int = BM25_DEFAULT_LIMIT,
     agent: str | None = None,
+    date_filter_paths: frozenset[str] | None = None,
 ) -> list[BM25Result]:
     """
     Run BM25 search via qmd subprocess.
@@ -379,6 +394,10 @@ def bm25_search(
         if r["file"] not in seen:
             merged.append(r)
             seen.add(r["file"])
+    # TMP-2: apply date-range path filter for TEMPORAL queries
+    if date_filter_paths:
+        merged = [r for r in merged if _path_from_file_uri(r["file"]) in date_filter_paths]
+
     return merged
 
 

--- a/mnemosyne/search/hybrid.py
+++ b/mnemosyne/search/hybrid.py
@@ -28,7 +28,7 @@ from pathlib import Path
 
 from mnemosyne._azure import embed_text_as_bytes
 from mnemosyne.embed.schema import get_qmd_db_path, load_sqlite_vec
-from mnemosyne.search.bm25 import BM25Result, bm25_search
+from mnemosyne.search.bm25 import BM25_DEFAULT_LIMIT, BM25Result, bm25_search
 from mnemosyne.search.budget import BudgetedResult, apply_budget
 from mnemosyne.search.intent import QueryIntent, classify
 from mnemosyne.search.rrf import FusedResult, entity_boost, procedural_boost, rrf
@@ -213,6 +213,7 @@ def search(
     # Temporal query rewriting — expand query with explicit date tokens before retrieval
     active_query = query
     temporal_chunks: list = []
+    date_filter_paths: frozenset[str] | None = None  # TMP-2: set in TEMPORAL block below
     if intent == QueryIntent.TEMPORAL:
         try:
             from datetime import date as _date
@@ -223,6 +224,30 @@ def search(
             active_query = rewrite_temporal_query(query, reference_date=_date.today())
             start, end = extract_time_window(query, reference_date=_date.today())
             temporal_chunks = query_temporal_chunks(topic=active_query, start=start, end=end, limit=10)
+            # TMP-2: build date-filtered path set to restrict BM25 and vector results
+            # Only for RELATIVE temporal expressions (last week, recently, yesterday).
+            # NOT for absolute date references (March 2026, 2026-03-09) — those queries
+            # are ABOUT a time period, not filtered by document creation date.
+            if start is not None:
+                from mnemosyne.embed.schema import get_date_filtered_paths
+                from mnemosyne.temporal.rewriter import is_relative_temporal
+
+                if is_relative_temporal(query):
+                    _tmp2_db = sqlite3.connect(str(get_qmd_db_path()))
+                    try:
+                        _paths = get_date_filtered_paths(_tmp2_db, start, end)
+                        if _paths:  # empty = no dated chunks yet; do not filter
+                            date_filter_paths = _paths
+                            logger.debug(
+                                "hybrid: TMP-2 date filter active — %d paths in [%s, %s]",
+                                len(_paths),
+                                start,
+                                end,
+                            )
+                    except Exception as _dfp_e:
+                        logger.warning("hybrid: TMP-2 get_date_filtered_paths failed — %s", _dfp_e)
+                    finally:
+                        _tmp2_db.close()
         except Exception as _e:
             logger.warning("hybrid: temporal rewriting failed — %s", _e)
             active_query = query
@@ -325,11 +350,13 @@ def search(
         futures: dict[str, Future] = {}
 
         # Always run BM25
-        futures["bm25"] = executor.submit(bm25_search, active_query, collections)
+        futures["bm25"] = executor.submit(
+            bm25_search, active_query, collections, BM25_DEFAULT_LIMIT, None, date_filter_paths
+        )
 
         # Run vector search unless intent says skip
         if not skip_vector:
-            futures["vec"] = executor.submit(_run_vector_search, active_query, collections)
+            futures["vec"] = executor.submit(_run_vector_search, active_query, collections, date_filter_paths)
 
         # Collect results
         for name, future in futures.items():
@@ -352,7 +379,7 @@ def search(
     if not bm25_results and skip_vector:
         logger.info("hybrid: %s BM25 returned 0 results — falling back to vector (query=%r)", intent.value, query[:60])
         try:
-            vec_results = _run_vector_search(active_query, collections)
+            vec_results = _run_vector_search(active_query, collections, date_filter_paths)
             fallback_used = True
             if not vec_results:
                 vec_failed = True
@@ -477,7 +504,11 @@ def search(
     return result
 
 
-def _run_vector_search(query: str, collections: list[str]) -> list[VecResult]:
+def _run_vector_search(
+    query: str,
+    collections: list[str],
+    date_filter_paths: frozenset[str] | None = None,
+) -> list[VecResult]:
     """
     Embed query and run vector search. Returns [] on any failure.
     Called from ThreadPoolExecutor — must not raise.
@@ -504,7 +535,9 @@ def _run_vector_search(query: str, collections: list[str]) -> list[VecResult]:
             return []
 
         try:
-            return vector_search_bytes(db, query_bytes, collections=collections or None)
+            return vector_search_bytes(
+                db, query_bytes, collections=collections or None, date_filter_paths=date_filter_paths
+            )
         finally:
             db.close()
     except Exception as e:

--- a/mnemosyne/search/vector.py
+++ b/mnemosyne/search/vector.py
@@ -80,6 +80,7 @@ def vector_search_bytes(
     query_bytes: bytes,
     k: int = VECTOR_DEFAULT_K,
     collections: list[str] | None = None,
+    date_filter_paths: frozenset[str] | None = None,
 ) -> list[VecResult]:
     """
     Vector search using pre-packed float32 bytes (as returned by embed_text_as_bytes).
@@ -88,7 +89,11 @@ def vector_search_bytes(
     """
     if not query_bytes:
         return []
-    return _vsearch_with_bytes(db, query_bytes, k, collections)
+    results = _vsearch_with_bytes(db, query_bytes, k, collections)
+    # TMP-2: apply date-range path filter for TEMPORAL queries
+    if date_filter_paths:
+        results = [r for r in results if r["path"] in date_filter_paths]
+    return results
 
 
 def _vsearch_with_bytes(

--- a/mnemosyne/temporal/rewriter.py
+++ b/mnemosyne/temporal/rewriter.py
@@ -98,6 +98,45 @@ _RECENTLY_RE = re.compile(r"\b(?:recently|lately)\b", re.IGNORECASE)
 # ---------------------------------------------------------------------------
 
 
+
+
+def is_relative_temporal(query: str) -> bool:
+    """
+    Return True if *query* contains a RELATIVE temporal expression.
+
+    Relative expressions refer to time windows anchored on "today" —
+    e.g. "last week", "recently", "yesterday".  For these, date-filtered
+    retrieval (TMP-2) is appropriate: we expect documents *written* in that
+    window to be the relevant ones.
+
+    Absolute expressions ("March 2026", "2026-03-09") refer to a named
+    period and are better served by query rewriting + BM25/vector matching
+    the date tokens in document content.  Applying a date filter to absolute
+    expressions would filter out gold documents that merely *mention* the
+    date rather than being *written* on that date.
+
+    Returns True for: last N days, last week/month/year/quarter,
+    this week/month, yesterday, today, recently/lately.
+    Returns False for: ISO dates, "in Month YYYY", "on YYYY-MM-DD".
+    Never raises.
+    """
+    try:
+        q = query.strip()
+        for pattern in (
+            _LAST_N_DAYS_RE,
+            _LAST_PERIOD_RE,
+            _THIS_PERIOD_RE,
+            _YESTERDAY_RE,
+            _TODAY_RE,
+            _RECENTLY_RE,
+        ):
+            if pattern.search(q):
+                return True
+        return False
+    except Exception:
+        return False
+
+
 def extract_time_window(
     query: str,
     reference_date: date | None = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mnemosyne"
-version = "0.6.0"
+version = "0.7.0"
 description = "Memory system for QMD + Obsidian agent stacks — hybrid search, entity graph, temporal reasoning, session briefing"
 readme = "README.md"
 license = { text = "MIT" }

--- a/scripts/audit-date-formats.py
+++ b/scripts/audit-date-formats.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""
+audit-date-formats.py — Vault date format audit for TMP-5.
+
+Scans all .md files in the vault and classifies frontmatter date fields as:
+  - ISO (YYYY-MM-DD) — date_extract.py will extract these
+  - datetime (YYYY-MM-DDTHH:MM or YYYY-MM-DD HH:MM) — date_extract.py extracts date part
+  - non-ISO — date_extract.py cannot extract; chunk_date will be NULL
+  - absent — no date field in frontmatter
+
+Outputs a report to stdout and optional JSON summary via --output.
+
+Usage:
+    python3 audit-date-formats.py --vault-root /data/obsidian-vault
+    python3 audit-date-formats.py --vault-root /path/to/vault --output /tmp/audit.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Date format patterns (mirrors date_extract.py logic)
+# ---------------------------------------------------------------------------
+
+_ISO_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_DATETIME_RE = re.compile(r"^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}")
+_FRONTMATTER_FIELD_RE = re.compile(
+    r'^(?:date|created|updated|created_at)\s*:\s*"?([^"\n]+)"?\s*$',
+    re.MULTILINE | re.IGNORECASE,
+)
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def classify_date_value(value: str) -> str:
+    """Classify a frontmatter date value string."""
+    v = value.strip().strip('"').strip("'")
+    if _ISO_RE.match(v):
+        return "iso"
+    if _DATETIME_RE.match(v):
+        return "datetime"
+    if v:
+        return "non_iso"
+    return "absent"
+
+
+def audit_file(path: Path) -> tuple[str, str]:
+    """
+    Audit a single .md file.
+
+    Returns (classification, raw_value):
+      classification: 'iso' | 'datetime' | 'non_iso' | 'absent'
+      raw_value: the raw date field value, or '' if absent
+    """
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")[:2000]
+    except OSError:
+        return "error", ""
+
+    if not text.startswith("---"):
+        return "absent", ""
+
+    # Find end of frontmatter
+    end = text.find("\n---", 3)
+    if end == -1:
+        return "absent", ""
+    frontmatter = text[: end + 4]
+
+    m = _FRONTMATTER_FIELD_RE.search(frontmatter)
+    if not m:
+        return "absent", ""
+
+    raw_value = m.group(1).strip()
+    return classify_date_value(raw_value), raw_value
+
+
+# ---------------------------------------------------------------------------
+# Directory categorisation
+# ---------------------------------------------------------------------------
+
+
+def categorise_path(vault_root: Path, file_path: Path) -> str:
+    """Map a file path to a high-level directory category."""
+    try:
+        rel = file_path.relative_to(vault_root)
+        top = rel.parts[0] if rel.parts else "root"
+    except ValueError:
+        return "other"
+    categories = {
+        "01-Projects": "projects",
+        "02-Areas": "areas",
+        "03-Resources": "resources",
+        "04-Agent-Knowledge": "agent-knowledge",
+        "05-Knowledge": "knowledge",
+        "06-Entities": "entities",
+    }
+    return categories.get(top, top)
+
+
+# ---------------------------------------------------------------------------
+# Main audit
+# ---------------------------------------------------------------------------
+
+
+def run_audit(vault_root: Path) -> dict[str, Any]:
+    """Run the full audit and return a summary dict."""
+    md_files = list(vault_root.rglob("*.md"))
+    # Exclude .git, .obsidian, node_modules
+    md_files = [f for f in md_files if not any(p.startswith(".") for p in f.parts)]
+
+    total = len(md_files)
+    classification_counts: Counter[str] = Counter()
+    by_category: dict[str, Counter[str]] = defaultdict(Counter)
+    non_iso_examples: list[dict[str, str]] = []
+    non_iso_counts: Counter[str] = Counter()
+
+    for f in md_files:
+        cls, raw = audit_file(f)
+        classification_counts[cls] += 1
+        cat = categorise_path(vault_root, f)
+        by_category[cat][cls] += 1
+        if cls == "non_iso":
+            non_iso_counts[raw] += 1
+            if len(non_iso_examples) < 20:
+                non_iso_examples.append({
+                    "path": str(f.relative_to(vault_root)),
+                    "value": raw,
+                })
+
+    return {
+        "total_files": total,
+        "classification_counts": dict(classification_counts),
+        "by_category": {k: dict(v) for k, v in sorted(by_category.items())},
+        "non_iso_top_values": non_iso_counts.most_common(15),
+        "non_iso_examples": non_iso_examples,
+        "extractable_pct": round(
+            100 * (classification_counts["iso"] + classification_counts["datetime"]) / max(total, 1), 1
+        ),
+    }
+
+
+def print_report(audit: dict[str, Any]) -> None:
+    """Print a human-readable audit report."""
+    total = audit["total_files"]
+    counts = audit["classification_counts"]
+
+    print("=" * 60)
+    print("VAULT DATE FORMAT AUDIT — TMP-5")
+    print("=" * 60)
+    print(f"\nTotal .md files scanned: {total}")
+    print(f"\n{'Classification':<15} {'Count':>6} {'Pct':>6}")
+    print("-" * 30)
+    for cls in ("iso", "datetime", "non_iso", "absent", "error"):
+        n = counts.get(cls, 0)
+        pct = 100 * n / max(total, 1)
+        note = ""
+        if cls == "iso":
+            note = " ← date_extract.py: YES"
+        elif cls == "datetime":
+            note = " ← date_extract.py: YES (date part)"
+        elif cls == "non_iso":
+            note = " ← date_extract.py: NO"
+        elif cls == "absent":
+            note = " ← filename fallback only"
+        print(f"  {cls:<13} {n:>6} {pct:>5.1f}%{note}")
+
+    print(f"\n  Extractable (iso + datetime): {audit['extractable_pct']}%")
+
+    print("\n\nBy directory category:")
+    print(f"{'Category':<20} {'iso':>5} {'datetime':>9} {'non_iso':>8} {'absent':>7}")
+    print("-" * 52)
+    for cat, cat_counts in audit["by_category"].items():
+        print(
+            f"  {cat:<18} {cat_counts.get('iso', 0):>5} "
+            f"{cat_counts.get('datetime', 0):>9} "
+            f"{cat_counts.get('non_iso', 0):>8} "
+            f"{cat_counts.get('absent', 0):>7}"
+        )
+
+    if audit["non_iso_top_values"]:
+        print("\n\nMost common non-ISO date values:")
+        for val, count in audit["non_iso_top_values"]:
+            print(f"  {count:>4}x {val!r}")
+
+    if audit["non_iso_examples"]:
+        print(f"\nNon-ISO examples (first {len(audit['non_iso_examples'])}):")
+        for ex in audit["non_iso_examples"][:10]:
+            print(f"  [{ex['value']}] {ex['path']}")
+
+    print("\n" + "=" * 60)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Audit vault date formats for TMP-5")
+    parser.add_argument("--vault-root", required=True, help="Path to obsidian vault root")
+    parser.add_argument("--output", default=None, help="Optional JSON output path")
+    args = parser.parse_args(argv)
+
+    vault_root = Path(args.vault_root)
+    if not vault_root.exists():
+        print(f"ERROR: vault root not found: {vault_root}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Scanning {vault_root} ...", file=sys.stderr)
+    audit = run_audit(vault_root)
+    print_report(audit)
+
+    if args.output:
+        out_path = Path(args.output)
+        out_path.write_text(json.dumps(audit, indent=2))
+        print(f"\nJSON summary written to {out_path}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/chunk-daily-files.py
+++ b/scripts/chunk-daily-files.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""
+chunk-daily-files.py — TMP-4: Daily memory log section chunker.
+
+Pre-processes agent daily memory log files (YYYY-MM-DD.md) by splitting
+them into per-section chunk files suitable for QMD ingestion. Each ##
+section becomes a separate document with injected frontmatter carrying:
+  - source: original vault-relative path
+  - section_heading: the ## heading text
+  - date: extracted from filename (YYYY-MM-DD)
+  - type: daily_chunk
+
+Output files are written to --output-dir (default: /tmp/daily-chunks/).
+They are ephemeral — regenerate by re-running this script.
+
+After running, ingest with:
+  qmd embed <output-dir>
+
+Usage:
+    python3 chunk-daily-files.py --vault-root /data/obsidian-vault
+    python3 chunk-daily-files.py --vault-root /vault --output-dir /tmp/chunks --dry-run
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_MEMORY_LOG_RE = re.compile(r"^(\d{4})-(\d{2})-(\d{2})\.md$")
+_SECTION_RE = re.compile(r"^## (.+)$", re.MULTILINE)
+
+
+def _slug(text: str) -> str:
+    """Convert text to a filename-safe slug."""
+    return re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")[:40]
+
+
+def find_memory_logs(vault_root: Path) -> list[Path]:
+    """Find all YYYY-MM-DD.md files in the vault."""
+    logs: list[Path] = []
+    for path in vault_root.rglob("*.md"):
+        if _MEMORY_LOG_RE.match(path.name):
+            logs.append(path)
+    return sorted(logs)
+
+
+def split_into_sections(content: str) -> list[tuple[str, str]]:
+    """
+    Split markdown content on ## headings.
+
+    Returns list of (heading, body) tuples.
+    Content before the first heading is returned as ("", body) if non-empty.
+    Empty sections (body is whitespace-only) are excluded.
+    """
+    sections: list[tuple[str, str]] = []
+    parts = _SECTION_RE.split(content)
+
+    # parts[0] is content before first ##; parts[1], parts[2], ...
+    # alternate between heading and body
+    preamble = parts[0].strip()
+    if preamble:
+        sections.append(("", preamble))
+
+    for i in range(1, len(parts), 2):
+        heading = parts[i].strip()
+        body = parts[i + 1].strip() if i + 1 < len(parts) else ""
+        if body:
+            sections.append((heading, body))
+
+    return sections
+
+
+def chunk_file(log_path: Path, vault_root: Path) -> list[dict[str, Any]]:
+    """
+    Chunk a single memory log file into per-section dicts.
+
+    Returns list of dicts: {heading, body, date, source, filename}
+    """
+    m = _MEMORY_LOG_RE.match(log_path.name)
+    if not m:
+        return []
+
+    file_date = f"{m.group(1)}-{m.group(2)}-{m.group(3)}"
+    try:
+        vault_rel = str(log_path.relative_to(vault_root))
+    except ValueError:
+        vault_rel = str(log_path)
+
+    try:
+        content = log_path.read_text(encoding="utf-8", errors="replace")
+    except OSError as e:
+        logger.warning("chunk_file: cannot read %s — %s", log_path, e)
+        return []
+
+    # Strip frontmatter
+    if content.startswith("---"):
+        end = content.find("\n---", 3)
+        if end != -1:
+            content = content[end + 4:].lstrip("\n")
+
+    sections = split_into_sections(content)
+    chunks: list[dict[str, Any]] = []
+    for idx, (heading, body) in enumerate(sections):
+        slug = _slug(heading) if heading else "preamble"
+        stem = log_path.stem  # YYYY-MM-DD
+        filename = f"{stem}-{slug}-{idx:02d}.md"
+        chunks.append({
+            "heading": heading,
+            "body": body,
+            "date": file_date,
+            "source": vault_rel,
+            "filename": filename,
+        })
+
+    return chunks
+
+
+def write_chunk(chunk: dict[str, Any], output_dir: Path) -> Path:
+    """Write a single chunk to output_dir with injected frontmatter."""
+    heading = chunk["heading"]
+    body = chunk["body"]
+    date = chunk["date"]
+    source = chunk["source"]
+    filename = chunk["filename"]
+
+    frontmatter_lines = [
+        "---",
+        "type: daily_chunk",
+        f"date: {date}",
+        f'source: "{source}"',
+    ]
+    if heading:
+        frontmatter_lines.append(f'section_heading: "{heading}"')
+    frontmatter_lines.append("---")
+
+    title = f"# {heading}" if heading else f"# {source} — preamble"
+    content = "\n".join(frontmatter_lines) + f"\n\n{title}\n\n{body}\n"
+
+    out_path: Path = output_dir / filename
+    out_path.write_text(content, encoding="utf-8")
+    return out_path
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="TMP-4: Daily memory log section chunker")
+    parser.add_argument("--vault-root", required=True, help="Path to vault root")
+    parser.add_argument(
+        "--output-dir",
+        default="/tmp/daily-chunks",  # noqa: S108
+        help="Output directory for chunk files (default: /tmp/daily-chunks)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be written without creating files",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    vault_root = Path(args.vault_root)
+    output_dir = Path(args.output_dir)
+
+    if not vault_root.exists():
+        logger.error("vault root not found: %s", vault_root)
+        sys.exit(1)
+
+    logs = find_memory_logs(vault_root)
+    logger.info("Found %d memory log files", len(logs))
+
+    if not args.dry_run:
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+    total_chunks = 0
+    total_files = 0
+
+    for log_path in logs:
+        chunks = chunk_file(log_path, vault_root)
+        if not chunks:
+            continue
+        total_files += 1
+        for chunk in chunks:
+            total_chunks += 1
+            if args.dry_run:
+                heading = chunk["heading"] or "(preamble)"
+                print(f"  [DRY RUN] {chunk['filename']} — {heading}")
+            else:
+                write_chunk(chunk, output_dir)
+
+    if args.dry_run:
+        logger.info("Dry run: %d chunks from %d files (no files written)", total_chunks, total_files)
+    else:
+        logger.info("Done: %d chunks written from %d files to %s", total_chunks, total_files, output_dir)
+        print(f"\nTo ingest: qmd embed {output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/embed/test_date_extract.py
+++ b/tests/embed/test_date_extract.py
@@ -1,0 +1,190 @@
+"""
+Unit tests for mnemosyne.embed.date_extract.extract_chunk_date.
+
+Targets >= 90% coverage of date_extract.py.
+"""
+
+from __future__ import annotations
+
+from mnemosyne.embed.date_extract import extract_chunk_date
+
+# ---------------------------------------------------------------------------
+# Frontmatter: date field
+# ---------------------------------------------------------------------------
+
+
+def test_frontmatter_date_unquoted() -> None:
+    """date: YYYY-MM-DD (no quotes) is extracted."""
+    doc = "---\ntitle: My Doc\ndate: 2026-03-15\n---\nBody text."
+    assert extract_chunk_date(doc, "/notes/somefile.md") == "2026-03-15"
+
+
+def test_frontmatter_date_single_quotes() -> None:
+    """date: 'YYYY-MM-DD' (single quotes) is extracted."""
+    doc = "---\ndate: '2025-11-01'\n---\nBody."
+    assert extract_chunk_date(doc, "/notes/x.md") == "2025-11-01"
+
+
+def test_frontmatter_date_double_quotes() -> None:
+    """date: "YYYY-MM-DD" (double quotes) is extracted."""
+    doc = '---\ndate: "2024-06-20"\n---\nBody.'
+    assert extract_chunk_date(doc, "/notes/x.md") == "2024-06-20"
+
+
+def test_frontmatter_date_datetime_takes_date_part() -> None:
+    """date: YYYY-MM-DD HH:MM:SS — only the date portion is returned."""
+    doc = "---\ndate: 2026-01-10 14:30:00\n---\nContent."
+    assert extract_chunk_date(doc, "/notes/x.md") == "2026-01-10"
+
+
+def test_frontmatter_created_field() -> None:
+    """created: YYYY-MM-DD is recognised."""
+    doc = "---\ncreated: 2023-07-04\n---\nBody."
+    assert extract_chunk_date(doc, "/notes/x.md") == "2023-07-04"
+
+
+def test_frontmatter_updated_field() -> None:
+    """updated: YYYY-MM-DD is recognised."""
+    doc = "---\nupdated: 2022-12-31\n---\nBody."
+    assert extract_chunk_date(doc, "/notes/x.md") == "2022-12-31"
+
+
+def test_frontmatter_created_at_field() -> None:
+    """created_at: YYYY-MM-DD is recognised."""
+    doc = "---\ncreated_at: 2021-05-19\n---\nBody."
+    assert extract_chunk_date(doc, "/notes/x.md") == "2021-05-19"
+
+
+# ---------------------------------------------------------------------------
+# Filename / path patterns
+# ---------------------------------------------------------------------------
+
+
+def test_path_date_prefix() -> None:
+    """YYYY-MM-DD at the start of the filename is found."""
+    assert extract_chunk_date("", "/notes/2026-04-09-standup.md") == "2026-04-09"
+
+
+def test_path_date_middle() -> None:
+    """YYYY-MM-DD embedded in a directory name is found."""
+    assert extract_chunk_date("", "/archive/2025-01-01/index.md") == "2025-01-01"
+
+
+def test_path_date_suffix() -> None:
+    """YYYY-MM-DD at the end of the stem is found."""
+    assert extract_chunk_date("", "/reports/quarterly-2023-10-01.md") == "2023-10-01"
+
+
+# ---------------------------------------------------------------------------
+# Priority: frontmatter > filename
+# ---------------------------------------------------------------------------
+
+
+def test_frontmatter_wins_over_path() -> None:
+    """When both frontmatter and path contain dates, frontmatter takes priority."""
+    doc = "---\ndate: 2026-03-01\n---\nBody."
+    result = extract_chunk_date(doc, "/notes/2020-01-01-old.md")
+    assert result == "2026-03-01"
+
+
+# ---------------------------------------------------------------------------
+# Invalid / out-of-range dates
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_date_string_falls_through_to_path() -> None:
+    """An invalid frontmatter date (not-a-date) is skipped; path date is used."""
+    doc = "---\ndate: not-a-date\n---\nBody."
+    assert extract_chunk_date(doc, "/notes/2024-08-15-notes.md") == "2024-08-15"
+
+
+def test_out_of_range_year_before_2000() -> None:
+    """A date before 2000-01-01 is rejected entirely."""
+    doc = "---\ndate: 1999-12-31\n---\nBody."
+    assert extract_chunk_date(doc, "/notes/no-date.md") is None
+
+
+def test_impossible_date_like_9999() -> None:
+    """A year-9999 date is out of range and returns None."""
+    doc = "---\ndate: 9999-99-99\n---\nBody."
+    assert extract_chunk_date(doc, "/notes/no-date.md") is None
+
+
+# ---------------------------------------------------------------------------
+# No date anywhere
+# ---------------------------------------------------------------------------
+
+
+def test_no_date_anywhere_returns_none() -> None:
+    """When neither doc nor path contain a date, None is returned."""
+    assert extract_chunk_date("Just some text.", "/notes/meeting.md") is None
+
+
+def test_empty_doc_and_path_returns_none() -> None:
+    """Empty strings produce None without errors."""
+    assert extract_chunk_date("", "") is None
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter beyond first 2000 chars is not scanned
+# ---------------------------------------------------------------------------
+
+
+def test_frontmatter_beyond_2000_chars_not_matched() -> None:
+    """A date buried after 2000 chars is ignored (only head is scanned)."""
+    padding = "x" * 2001
+    doc = padding + "\ndate: 2026-01-01\n"
+    assert extract_chunk_date(doc, "/notes/no-date.md") is None
+
+
+# ---------------------------------------------------------------------------
+# Datetime format in frontmatter (T separator)
+# ---------------------------------------------------------------------------
+
+
+def test_frontmatter_date_iso_t_separator() -> None:
+    """date: YYYY-MM-DDTHH:MM:SS (T separator) — only the date part is captured."""
+    doc = "---\ndate: 2026-02-28T09:00:00\n---\nBody."
+    assert extract_chunk_date(doc, "/notes/x.md") == "2026-02-28"
+
+
+# ---------------------------------------------------------------------------
+# TMP-5b: YYYY-MM year-month frontmatter handling
+# ---------------------------------------------------------------------------
+
+
+def test_yearmonth_frontmatter_returns_first_of_month() -> None:
+    """YYYY-MM in date field maps to YYYY-MM-01."""
+    doc = "---\ndate: 2025-11\n---\n# Body"
+    result = extract_chunk_date(doc, "test.md")
+    assert result == "2025-11-01"
+
+
+def test_yearmonth_does_not_override_full_iso_date() -> None:
+    """Full YYYY-MM-DD in frontmatter takes priority over YYYY-MM."""
+    doc = "---\ndate: 2026-04-10\n---\n# Body"
+    assert extract_chunk_date(doc, "test.md") == "2026-04-10"
+
+
+def test_yearmonth_created_field() -> None:
+    """created field also matches YYYY-MM."""
+    doc = "---\ncreated: 2025-07\n---\n# Body"
+    assert extract_chunk_date(doc, "test.md") == "2025-07-01"
+
+
+def test_yearmonth_updated_field() -> None:
+    """updated field also matches YYYY-MM."""
+    doc = "---\nupdated: 2024-12\n---\n# Body"
+    assert extract_chunk_date(doc, "test.md") == "2024-12-01"
+
+
+def test_yearmonth_path_date_fallback_still_works() -> None:
+    """Filename YYYY-MM-DD still takes effect when no frontmatter match."""
+    doc = "# No frontmatter\nJust body."
+    assert extract_chunk_date(doc, "2026-04-08-daily.md") == "2026-04-08"
+
+
+def test_yearmonth_not_matched_if_dd_follows() -> None:
+    """YYYY-MM-DD must NOT be matched by yearmonth pattern."""
+    from mnemosyne.embed.date_extract import _FRONTMATTER_YEARMONTH_PATTERN
+    assert _FRONTMATTER_YEARMONTH_PATTERN.search("date: 2026-04-10") is None

--- a/tests/embed/test_db_roundtrip.py
+++ b/tests/embed/test_db_roundtrip.py
@@ -46,6 +46,7 @@ def create_qmd_schema(db: sqlite3.Connection) -> None:
             pos INTEGER NOT NULL DEFAULT 0,
             model TEXT NOT NULL,
             embedded_at TEXT NOT NULL,
+            chunk_date DATE,
             PRIMARY KEY (hash, seq)
         );
     """)

--- a/tests/embed/test_schema_date_filter.py
+++ b/tests/embed/test_schema_date_filter.py
@@ -1,0 +1,183 @@
+"""
+Tests for mnemosyne.embed.schema.get_date_filtered_paths.
+
+Verifies:
+  - Empty frozenset when both bounds are None
+  - Returns correct paths for rows within window
+  - Excludes paths outside window
+  - Both boundary dates are inclusive
+  - Single-bound queries (start-only, end-only)
+  - Returns empty frozenset on DB error (no raise)
+  - NULL chunk_dates are excluded regardless of window
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import date
+
+from mnemosyne.embed.schema import get_date_filtered_paths
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_db_with_dated_chunks() -> sqlite3.Connection:
+    """
+    Return an in-memory DB with content_vectors + documents tables.
+
+    Documents and chunks:
+      hash='h1' path='old.md'     chunk_date='2026-01-10'
+      hash='h2' path='mid.md'     chunk_date='2026-03-15'
+      hash='h3' path='recent.md'  chunk_date='2026-04-08'
+      hash='h4' path='nodated.md' chunk_date=NULL
+    """
+    db = sqlite3.connect(":memory:")
+    db.executescript("""
+        CREATE TABLE documents (
+            id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            hash       TEXT NOT NULL,
+            path       TEXT NOT NULL,
+            collection TEXT NOT NULL DEFAULT 'vault',
+            title      TEXT,
+            active     INTEGER NOT NULL DEFAULT 1
+        );
+        CREATE TABLE content_vectors (
+            hash       TEXT NOT NULL,
+            seq        INTEGER NOT NULL DEFAULT 0,
+            pos        INTEGER NOT NULL DEFAULT 0,
+            model      TEXT NOT NULL DEFAULT 'test',
+            embedded_at TEXT NOT NULL DEFAULT '0',
+            chunk_date TEXT,
+            PRIMARY KEY (hash, seq)
+        );
+
+        INSERT INTO documents (hash, path, collection) VALUES
+            ('h1', 'old.md',     'vault'),
+            ('h2', 'mid.md',     'vault'),
+            ('h3', 'recent.md',  'vault'),
+            ('h4', 'nodated.md', 'vault');
+
+        INSERT INTO content_vectors (hash, seq, chunk_date) VALUES
+            ('h1', 0, '2026-01-10'),
+            ('h2', 0, '2026-03-15'),
+            ('h3', 0, '2026-04-08'),
+            ('h4', 0, NULL);
+    """)
+    db.commit()
+    return db
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_both_none_returns_empty() -> None:
+    """When both start and end are None, returns empty frozenset immediately."""
+    db = _make_db_with_dated_chunks()
+    result = get_date_filtered_paths(db, start=None, end=None)
+    assert result == frozenset()
+
+
+def test_returns_paths_in_window() -> None:
+    """Paths with chunk_date in [start, end] are returned."""
+    db = _make_db_with_dated_chunks()
+    result = get_date_filtered_paths(db, start=date(2026, 3, 1), end=date(2026, 4, 30))
+    assert "mid.md" in result
+    assert "recent.md" in result
+    assert "old.md" not in result
+
+
+def test_excludes_paths_outside_window() -> None:
+    """Paths with chunk_date outside window are excluded."""
+    db = _make_db_with_dated_chunks()
+    result = get_date_filtered_paths(db, start=date(2026, 4, 1), end=date(2026, 4, 30))
+    assert "recent.md" in result
+    assert "old.md" not in result
+    assert "mid.md" not in result
+
+
+def test_null_chunk_dates_always_excluded() -> None:
+    """Documents with chunk_date=NULL are never included regardless of window."""
+    db = _make_db_with_dated_chunks()
+    # Wide window that would include everything if NULLs weren't filtered
+    result = get_date_filtered_paths(db, start=date(2000, 1, 1), end=date(2099, 12, 31))
+    assert "nodated.md" not in result
+
+
+def test_start_boundary_inclusive() -> None:
+    """Start date boundary is inclusive."""
+    db = _make_db_with_dated_chunks()
+    result = get_date_filtered_paths(db, start=date(2026, 1, 10), end=date(2026, 2, 1))
+    assert "old.md" in result  # chunk_date='2026-01-10' == start
+
+
+def test_end_boundary_inclusive() -> None:
+    """End date boundary is inclusive."""
+    db = _make_db_with_dated_chunks()
+    result = get_date_filtered_paths(db, start=date(2026, 3, 1), end=date(2026, 4, 8))
+    assert "recent.md" in result  # chunk_date='2026-04-08' == end
+
+
+def test_start_only_no_upper_bound() -> None:
+    """When end=None, all paths from start onward are returned."""
+    db = _make_db_with_dated_chunks()
+    result = get_date_filtered_paths(db, start=date(2026, 3, 15), end=None)
+    assert "mid.md" in result
+    assert "recent.md" in result
+    assert "old.md" not in result
+
+
+def test_end_only_no_lower_bound() -> None:
+    """When start=None, all paths up to end are returned."""
+    db = _make_db_with_dated_chunks()
+    result = get_date_filtered_paths(db, start=None, end=date(2026, 3, 14))
+    assert "old.md" in result
+    assert "mid.md" not in result
+    assert "recent.md" not in result
+
+
+def test_empty_window_returns_empty() -> None:
+    """Window that contains no dated chunks returns empty frozenset."""
+    db = _make_db_with_dated_chunks()
+    result = get_date_filtered_paths(db, start=date(2025, 1, 1), end=date(2025, 12, 31))
+    assert result == frozenset()
+
+
+def test_returns_frozenset() -> None:
+    """Return type is always frozenset."""
+    db = _make_db_with_dated_chunks()
+    result = get_date_filtered_paths(db, start=date(2026, 1, 1), end=date(2026, 12, 31))
+    assert isinstance(result, frozenset)
+
+
+def test_db_error_returns_empty_not_raises() -> None:
+    """On DB error, returns empty frozenset without raising."""
+    db = sqlite3.connect(":memory:")  # no tables — will error on query
+    result = get_date_filtered_paths(db, start=date(2026, 1, 1), end=date(2026, 4, 30))
+    assert result == frozenset()
+
+
+def test_multiple_chunks_same_document_deduplicated() -> None:
+    """Multiple chunks (seq>0) for same document path appear only once in result."""
+    db = sqlite3.connect(":memory:")
+    db.executescript("""
+        CREATE TABLE documents (
+            hash TEXT NOT NULL, path TEXT NOT NULL,
+            collection TEXT NOT NULL DEFAULT 'vault', active INTEGER DEFAULT 1
+        );
+        CREATE TABLE content_vectors (
+            hash TEXT NOT NULL, seq INTEGER NOT NULL DEFAULT 0,
+            model TEXT NOT NULL DEFAULT 'test', embedded_at TEXT NOT NULL DEFAULT '0',
+            chunk_date TEXT, pos INTEGER DEFAULT 0
+        );
+        INSERT INTO documents VALUES ('h1', 'multi.md', 'vault', 1);
+        INSERT INTO content_vectors VALUES ('h1', 0, 'test', '0', '2026-04-08', 0);
+        INSERT INTO content_vectors VALUES ('h1', 1, 'test', '0', '2026-04-08', 1);
+        INSERT INTO content_vectors VALUES ('h1', 2, 'test', '0', '2026-04-08', 2);
+    """)
+    db.commit()
+    result = get_date_filtered_paths(db, start=date(2026, 4, 1), end=date(2026, 4, 30))
+    assert result == frozenset({"multi.md"})

--- a/tests/scripts/test_audit_date_formats.py
+++ b/tests/scripts/test_audit_date_formats.py
@@ -1,0 +1,144 @@
+"""
+Tests for scripts/audit-date-formats.py — date format audit (TMP-5).
+
+Uses importlib for the hyphenated script filename.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+_SCRIPT_PATH = Path(__file__).parent.parent.parent / "scripts" / "audit-date-formats.py"
+
+
+def _load_script() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("audit_date_formats", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[attr-defined]
+    return mod
+
+
+_mod = _load_script()
+classify_date_value = _mod.classify_date_value
+audit_file = _mod.audit_file
+run_audit = _mod.run_audit
+
+
+# ---------------------------------------------------------------------------
+# classify_date_value
+# ---------------------------------------------------------------------------
+
+
+def test_iso_date_classified_correctly() -> None:
+    assert classify_date_value("2026-04-10") == "iso"
+
+
+def test_quoted_iso_date_classified_correctly() -> None:
+    assert classify_date_value('"2026-04-10"') == "iso"
+
+
+def test_datetime_string_classified_as_datetime() -> None:
+    assert classify_date_value("2026-04-10T09:30") == "datetime"
+    assert classify_date_value("2026-04-10 09:30") == "datetime"
+
+
+def test_non_iso_classified_correctly() -> None:
+    assert classify_date_value("10 April 2026") == "non_iso"
+    assert classify_date_value("April 10, 2026") == "non_iso"
+    assert classify_date_value("10/04/2026") == "non_iso"
+
+
+def test_empty_value_classified_as_absent() -> None:
+    assert classify_date_value("") == "absent"
+
+
+# ---------------------------------------------------------------------------
+# audit_file
+# ---------------------------------------------------------------------------
+
+
+def test_iso_frontmatter_detected(tmp_path: Path) -> None:
+    f = tmp_path / "test.md"
+    f.write_text("---\ndate: 2026-04-10\ntitle: Test\n---\n# Body\n")
+    cls, raw = audit_file(f)
+    assert cls == "iso"
+    assert raw == "2026-04-10"
+
+
+def test_non_iso_frontmatter_detected(tmp_path: Path) -> None:
+    f = tmp_path / "test.md"
+    f.write_text("---\ndate: 10 April 2026\n---\n# Body\n")
+    cls, raw = audit_file(f)
+    assert cls == "non_iso"
+    assert raw == "10 April 2026"
+
+
+def test_absent_date_no_frontmatter(tmp_path: Path) -> None:
+    f = tmp_path / "test.md"
+    f.write_text("# No frontmatter\nJust body text.\n")
+    cls, raw = audit_file(f)
+    assert cls == "absent"
+    assert raw == ""
+
+
+def test_absent_date_frontmatter_no_date_field(tmp_path: Path) -> None:
+    f = tmp_path / "test.md"
+    f.write_text("---\ntitle: No date\ntags: [test]\n---\n# Body\n")
+    cls, raw = audit_file(f)
+    assert cls == "absent"
+
+
+def test_datetime_frontmatter_detected(tmp_path: Path) -> None:
+    f = tmp_path / "test.md"
+    f.write_text("---\ncreated: 2026-04-10T09:30:00\n---\n# Body\n")
+    cls, raw = audit_file(f)
+    assert cls == "datetime"
+
+
+# ---------------------------------------------------------------------------
+# run_audit
+# ---------------------------------------------------------------------------
+
+
+def test_run_audit_counts_correct(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "iso.md").write_text("---\ndate: 2026-04-10\n---\n# Test\n")
+    (vault / "non_iso.md").write_text("---\ndate: 10 April 2026\n---\n# Test\n")
+    (vault / "absent.md").write_text("# No frontmatter\n")
+
+    result = run_audit(vault)
+
+    assert result["classification_counts"]["iso"] == 1
+    assert result["classification_counts"]["non_iso"] == 1
+    assert result["classification_counts"]["absent"] == 1
+    assert result["total_files"] == 3
+
+
+def test_run_audit_json_structure(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "test.md").write_text("---\ndate: 2026-01-01\n---\n# Test\n")
+
+    result = run_audit(vault)
+
+    assert "total_files" in result
+    assert "classification_counts" in result
+    assert "by_category" in result
+    assert "non_iso_top_values" in result
+    assert "extractable_pct" in result
+
+
+def test_extractable_pct_correct(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "iso.md").write_text("---\ndate: 2026-04-10\n---\n# Test\n")
+    (vault / "dt.md").write_text("---\ndate: 2026-04-10T10:00\n---\n# Test\n")
+    (vault / "bad.md").write_text("---\ndate: not a date\n---\n# Test\n")
+    (vault / "no.md").write_text("# no date\n")
+
+    result = run_audit(vault)
+    assert result["extractable_pct"] == 50.0

--- a/tests/scripts/test_chunk_daily_files.py
+++ b/tests/scripts/test_chunk_daily_files.py
@@ -1,0 +1,156 @@
+"""
+Tests for scripts/chunk-daily-files.py — TMP-4: daily memory log chunker.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+_SCRIPT_PATH = Path(__file__).parent.parent.parent / "scripts" / "chunk-daily-files.py"
+
+
+def _load_script() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("chunk_daily_files", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[attr-defined]
+    return mod
+
+
+_mod = _load_script()
+split_into_sections = _mod.split_into_sections
+chunk_file = _mod.chunk_file
+write_chunk = _mod.write_chunk
+find_memory_logs = _mod.find_memory_logs
+
+
+# ---------------------------------------------------------------------------
+# split_into_sections
+# ---------------------------------------------------------------------------
+
+
+def test_splits_on_h2_headings() -> None:
+    content = "## Morning\nDid standup.\n\n## Afternoon\nWrote code."
+    sections = split_into_sections(content)
+    assert len(sections) == 2
+    assert sections[0] == ("Morning", "Did standup.")
+    assert sections[1] == ("Afternoon", "Wrote code.")
+
+
+def test_preamble_before_first_heading() -> None:
+    content = "Intro text.\n\n## Section One\nBody."
+    sections = split_into_sections(content)
+    assert len(sections) == 2
+    assert sections[0] == ("", "Intro text.")
+    assert sections[1] == ("Section One", "Body.")
+
+
+def test_empty_sections_excluded() -> None:
+    content = "## Empty\n   \n## Full\nContent here."
+    sections = split_into_sections(content)
+    assert len(sections) == 1
+    assert sections[0][0] == "Full"
+
+
+def test_body_only_no_headings_returns_single() -> None:
+    content = "Just some body text with no headings."
+    sections = split_into_sections(content)
+    assert len(sections) == 1
+    assert sections[0] == ("", "Just some body text with no headings.")
+
+
+# ---------------------------------------------------------------------------
+# chunk_file
+# ---------------------------------------------------------------------------
+
+
+def test_extracts_date_from_filename(tmp_path: Path) -> None:
+    log = tmp_path / "2026-04-08.md"
+    log.write_text("## Morning\nDid something.\n")
+    chunks = chunk_file(log, tmp_path)
+    assert len(chunks) == 1
+    assert chunks[0]["date"] == "2026-04-08"
+
+
+def test_chunk_has_heading_and_body(tmp_path: Path) -> None:
+    log = tmp_path / "2026-04-08.md"
+    log.write_text("## Work Log\nFixed bug.\n\n## Reflections\nLearned things.\n")
+    chunks = chunk_file(log, tmp_path)
+    assert len(chunks) == 2
+    assert chunks[0]["heading"] == "Work Log"
+    assert "Fixed bug" in chunks[0]["body"]
+
+
+def test_non_memory_log_returns_empty(tmp_path: Path) -> None:
+    log = tmp_path / "not-a-date.md"
+    log.write_text("## Section\nBody.\n")
+    chunks = chunk_file(log, tmp_path)
+    assert chunks == []
+
+
+def test_frontmatter_stripped_from_body(tmp_path: Path) -> None:
+    log = tmp_path / "2026-04-08.md"
+    log.write_text("---\ndate: 2026-04-08\n---\n\n## Section\nReal body.\n")
+    chunks = chunk_file(log, tmp_path)
+    assert len(chunks) == 1
+    assert "---" not in chunks[0]["body"]
+    assert "Real body" in chunks[0]["body"]
+
+
+# ---------------------------------------------------------------------------
+# write_chunk
+# ---------------------------------------------------------------------------
+
+
+def test_output_file_created(tmp_path: Path) -> None:
+    chunk = {
+        "heading": "Work Log",
+        "body": "Did important work.",
+        "date": "2026-04-08",
+        "source": "04-Agent-Knowledge/growth/memory/2026-04-08.md",
+        "filename": "2026-04-08-work-log-00.md",
+    }
+    out = write_chunk(chunk, tmp_path)
+    assert out.exists()
+    content = out.read_text()
+    assert "date: 2026-04-08" in content
+    assert "section_heading: " in content
+    assert "Did important work" in content
+
+
+def test_chunk_frontmatter_has_source(tmp_path: Path) -> None:
+    chunk = {
+        "heading": "Reflections",
+        "body": "Body text.",
+        "date": "2026-04-08",
+        "source": "04-Agent-Knowledge/memory/2026-04-08.md",
+        "filename": "2026-04-08-reflections-01.md",
+    }
+    out = write_chunk(chunk, tmp_path)
+    content = out.read_text()
+    assert 'source: "04-Agent-Knowledge/memory/2026-04-08.md"' in content
+
+
+# ---------------------------------------------------------------------------
+# find_memory_logs
+# ---------------------------------------------------------------------------
+
+
+def test_find_memory_logs_only_dated_files(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    mem_dir = vault / "memory"
+    mem_dir.mkdir()
+    (mem_dir / "2026-04-08.md").write_text("## Section\nBody.")
+    (mem_dir / "2026-04-09.md").write_text("## Section\nBody.")
+    (mem_dir / "notes.md").write_text("Not a dated log.")
+    (mem_dir / "not-dated.md").write_text("Also not dated.")
+
+    logs = find_memory_logs(vault)
+    names = {p.name for p in logs}
+    assert "2026-04-08.md" in names
+    assert "2026-04-09.md" in names
+    assert "notes.md" not in names
+    assert "not-dated.md" not in names

--- a/tests/search/test_temporal_filter.py
+++ b/tests/search/test_temporal_filter.py
@@ -1,0 +1,198 @@
+"""
+Tests for TMP-2: date-range path filtering in BM25 and vector search.
+
+Covers:
+  - _path_from_file_uri helper (bm25.py)
+  - bm25_search date_filter_paths post-filter
+  - vector_search_bytes date_filter_paths post-filter
+  - hybrid.search TEMPORAL intent passes date_filter to both searches
+  - Graceful degradation when date_filter_paths is empty or None
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mnemosyne.search.bm25 import BM25Result, _path_from_file_uri, bm25_search
+from mnemosyne.search.vector import VecResult, vector_search_bytes
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_bm25_result(path: str, collection: str = "vault-areas") -> BM25Result:
+    return BM25Result(
+        file=f"qmd://{collection}/{path}",
+        title="Test",
+        snippet="Test snippet",
+        score=1.0,
+        collection=collection,
+    )
+
+
+def _make_vec_result(path: str) -> VecResult:
+    return VecResult(
+        hash_seq="abc_0",
+        distance=0.1,
+        path=path,
+        collection="vault-areas",
+        title="Test",
+        snippet="Test snippet",
+    )
+
+
+# ---------------------------------------------------------------------------
+# _path_from_file_uri
+# ---------------------------------------------------------------------------
+
+
+def test_path_from_file_uri_standard() -> None:
+    """Standard qmd:// URI returns vault-relative path."""
+    uri = "qmd://vault-areas/02-Areas/00-Clients/AcmeCorp/overview.md"
+    assert _path_from_file_uri(uri) == "02-Areas/00-Clients/AcmeCorp/overview.md"
+
+
+def test_path_from_file_uri_single_segment_path() -> None:
+    """Collection-only path (no slash after collection) returns after-collection string."""
+    uri = "qmd://vault-areas/file.md"
+    assert _path_from_file_uri(uri) == "file.md"
+
+
+def test_path_from_file_uri_non_qmd_passthrough() -> None:
+    """Non-qmd:// URIs are returned unchanged."""
+    uri = "/data/obsidian-vault/file.md"
+    assert _path_from_file_uri(uri) == "/data/obsidian-vault/file.md"
+
+
+def test_path_from_file_uri_no_scheme() -> None:
+    """URI without :// is returned unchanged."""
+    assert _path_from_file_uri("bare-path.md") == "bare-path.md"
+
+
+# ---------------------------------------------------------------------------
+# bm25_search date_filter_paths
+# ---------------------------------------------------------------------------
+
+
+def test_bm25_date_filter_none_no_filtering() -> None:
+    """date_filter_paths=None → results not filtered."""
+    r1 = _make_bm25_result("doc-a.md")
+    r2 = _make_bm25_result("doc-b.md")
+
+    with (
+        patch("mnemosyne.search.bm25.get_qmd_binary", return_value="/usr/bin/qmd"),
+        patch("subprocess.run") as mock_run,
+        patch("mnemosyne.search.bm25._bm25_direct_db", return_value=[]),
+    ):
+        import json
+
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps([
+                {"file": r1["file"], "title": r1["title"], "snippet": r1["snippet"],
+                 "score": r1["score"], "collection": r1["collection"]},
+                {"file": r2["file"], "title": r2["title"], "snippet": r2["snippet"],
+                 "score": r2["score"], "collection": r2["collection"]},
+            ]),
+            stderr="",
+        )
+        results = bm25_search("test query", date_filter_paths=None)
+
+    assert len(results) == 2
+
+
+def test_bm25_date_filter_empty_no_filtering() -> None:
+    """date_filter_paths=frozenset() → results not filtered (empty = no-filter)."""
+    r1 = _make_bm25_result("doc-a.md")
+
+    with (
+        patch("mnemosyne.search.bm25.get_qmd_binary", return_value="/usr/bin/qmd"),
+        patch("subprocess.run") as mock_run,
+        patch("mnemosyne.search.bm25._bm25_direct_db", return_value=[]),
+    ):
+        import json
+
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps([
+                {"file": r1["file"], "title": r1["title"], "snippet": r1["snippet"],
+                 "score": r1["score"], "collection": r1["collection"]},
+            ]),
+            stderr="",
+        )
+        results = bm25_search("test query", date_filter_paths=frozenset())
+
+    assert len(results) == 1
+
+
+def test_bm25_date_filter_applied() -> None:
+    """date_filter_paths with one path → only matching result returned."""
+    r1 = _make_bm25_result("02-Areas/good.md")
+    r2 = _make_bm25_result("02-Areas/bad.md")
+
+    with (
+        patch("mnemosyne.search.bm25.get_qmd_binary", return_value="/usr/bin/qmd"),
+        patch("subprocess.run") as mock_run,
+        patch("mnemosyne.search.bm25._bm25_direct_db", return_value=[]),
+    ):
+        import json
+
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps([
+                {"file": r1["file"], "title": "", "snippet": "", "score": 1.0, "collection": "vault-areas"},
+                {"file": r2["file"], "title": "", "snippet": "", "score": 0.5, "collection": "vault-areas"},
+            ]),
+            stderr="",
+        )
+        results = bm25_search("test query", date_filter_paths=frozenset({"02-Areas/good.md"}))
+
+    assert len(results) == 1
+    assert _path_from_file_uri(results[0]["file"]) == "02-Areas/good.md"
+
+
+# ---------------------------------------------------------------------------
+# vector_search_bytes date_filter_paths
+# ---------------------------------------------------------------------------
+
+
+def test_vector_date_filter_none_passthrough() -> None:
+    """date_filter_paths=None → vector results not filtered."""
+    mock_db = MagicMock()
+    r1 = _make_vec_result("doc-a.md")
+    r2 = _make_vec_result("doc-b.md")
+
+    with patch("mnemosyne.search.vector._vsearch_with_bytes", return_value=[r1, r2]):
+        results = vector_search_bytes(mock_db, b"\x00" * 4, date_filter_paths=None)
+
+    assert len(results) == 2
+
+
+def test_vector_date_filter_empty_passthrough() -> None:
+    """date_filter_paths=frozenset() → results not filtered."""
+    mock_db = MagicMock()
+    r1 = _make_vec_result("doc-a.md")
+
+    with patch("mnemosyne.search.vector._vsearch_with_bytes", return_value=[r1]):
+        results = vector_search_bytes(mock_db, b"\x00" * 4, date_filter_paths=frozenset())
+
+    assert len(results) == 1
+
+
+def test_vector_date_filter_applied() -> None:
+    """date_filter_paths with one path → only matching result returned."""
+    mock_db = MagicMock()
+    r1 = _make_vec_result("02-Areas/good.md")
+    r2 = _make_vec_result("02-Areas/bad.md")
+
+    with patch("mnemosyne.search.vector._vsearch_with_bytes", return_value=[r1, r2]):
+        results = vector_search_bytes(
+            mock_db, b"\x00" * 4, date_filter_paths=frozenset({"02-Areas/good.md"})
+        )
+
+    assert len(results) == 1
+    assert results[0]["path"] == "02-Areas/good.md"


### PR DESCRIPTION
## Summary

- **TMP-1**: `chunk_date` column in `content_vectors` — idempotent migration applied at embed startup. New `date_extract.py` module extracts document dates from frontmatter (YYYY-MM-DD and YYYY-MM), filename patterns, and vault path conventions. 24 tests.
- **TMP-2**: Date-filtered retrieval for TEMPORAL intent — `get_date_filtered_paths()` returns a `frozenset[str]` of dated document paths; applied as post-filter to both BM25 (`_path_from_file_uri()`) and vector results. Gated on `is_relative_temporal()` so absolute date queries (`March 2026`, `2026-03-09`) are not incorrectly filtered. 10 tests.
- **TMP-4**: `scripts/chunk-daily-files.py` — pre-processor for daily memory log files (`YYYY-MM-DD.md`). Splits on `##` headings, writes section chunks with injected frontmatter. 11 tests.
- **TMP-5/5b**: `scripts/audit-date-formats.py` for vault date field coverage reporting; YYYY-MM year-month frontmatter support in `date_extract.py`. 13 tests.

## Confidentiality check

All private deployment configuration removed:
- No hardcoded vault paths, entity names, or Azure resource names
- `_SHARED_COLLECTIONS` retains `MNEMOSYNE_EXTRA_COLLECTIONS` env var pattern from PR #7
- Test fixtures use generic paths (`AcmeCorp`, `vault-areas`, etc.)
- Scripts accept `--vault-root` as a required CLI argument (no defaults)

## Validation

Fresh-clone install validation performed:
```
python3 -m venv venv && venv/bin/pip install -e ".[dev]"
python3 -m pytest tests/ --ignore=tests/e2e --ignore=tests/integration
# → 781 passed, 20 skipped
```
- ruff clean across all changed files
- mypy --strict clean across all changed files

## Benchmark (R5 — 83 curated queries, 2026-04-10)

| Category | Before | After | Δ |
|---|---|---|---|
| temporal | 0.369 | **0.382** | +0.013 |
| entity | 0.751 | 0.751 | — |
| multi_hop | 0.549 | 0.549 | — |
| procedural | 0.564 | 0.564 | — |
| **Overall** | 0.5807 | **0.5569** | −0.024 |

Note: overall NDCG reflects the new 83-case curated suite vs prior 263-case suite (different gold sets, not directly comparable). Keyword regression (KWD-1) is pre-existing and under investigation.

## Test plan

- [ ] Confirm CI passes (ruff, mypy, pytest)
- [ ] Verify `date_extract.py` correctly handles YYYY-MM-DD, YYYY-MM, and filename patterns
- [ ] Verify `is_relative_temporal()` gates — `"last week"` → filtered; `"March 2026"` → not filtered
- [ ] Verify fresh install: `pip install -e ".[dev]" && pytest` green