### PR TITLE
feat(curator): kairix curator health CLI (CA-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **CA-1**: `kairix curator health` — Curator agent health check CLI. Checks entities.db for synthesis failures (no summary), missing vault paths, and stale entities (configurable threshold, default 90 days). Reports Neo4j node counts when available. Output: vault-ready Markdown or JSON. Part of the Curator agent (ADR-003: plain Python, no framework dependency).
 - **P1-2**: `mnemosyne/llm/` — `LLMBackend` protocol with `chat()`, `embed()`, `embed_as_bytes()` methods. `AzureOpenAIBackend` and `AnthropicBackend` (stub) implementations. `get_default_backend()` returns `AzureOpenAIBackend`. All product code now receives `LLMBackend` via dependency injection rather than importing backends directly.
 - **P1-3**: Repo boundary — all direct `mnemosyne._azure` imports removed from product code. `hybrid.py` acquires embed via `_get_llm().embed_as_bytes()`. `search/planner.py` acquires chat via `_get_llm().chat()`. No module-level `mnemosyne._azure` imports remain outside `mnemosyne/llm/backends.py`.
 

--- a/kairix/cli.py
+++ b/kairix/cli.py
@@ -5,6 +5,7 @@ Subcommands:
   embed      Embed vault documents into QMD sqlite-vec (text-embedding-3-large)
   search     Hybrid search: BM25 + vector via RRF (Phase 1)
   entity     Entity graph: lookup, write, extract (Phase 1)
+  curator    Curator agent: entity health monitoring and enrichment (CA-1)
   timeline   Temporal query rewriting + date-aware retrieval (Phase 2)
   summarise  L0/L1 tiered context generation (Phase 2)
   classify   Auto-classify memory writes (Phase 3)
@@ -34,6 +35,11 @@ def main() -> None:
         from kairix.entities.cli import main as entity_main
 
         entity_main(sys.argv[2:])
+
+    elif cmd == "curator":
+        from kairix.curator.cli import main as curator_main
+
+        curator_main(sys.argv[2:])
 
     elif cmd == "search":
         from kairix.search.cli import main as search_main

--- a/kairix/curator/__init__.py
+++ b/kairix/curator/__init__.py
@@ -1,0 +1,17 @@
+"""
+kairix.curator — Curator agent: entity graph health monitoring and enrichment.
+
+The Curator is a plain Python module (ADR-003) — no agent framework dependency.
+It monitors the entity graph for quality issues and surfaces them for human review.
+
+Provides:
+  health  — run_health_check(), HealthReport, HealthIssue
+"""
+
+from kairix.curator.health import HealthIssue, HealthReport, run_health_check
+
+__all__ = [
+    "HealthIssue",
+    "HealthReport",
+    "run_health_check",
+]

--- a/kairix/curator/cli.py
+++ b/kairix/curator/cli.py
@@ -1,0 +1,101 @@
+"""
+Curator agent CLI for Kairix.
+
+Usage:
+  kairix curator health [--format text|json] [--output FILE]
+                        [--staleness-days N] [--no-neo4j]
+
+Exit code is always 0 — health issues are surfaced via the report, not the
+exit code, so callers (cron, OpenClaw, CI) do not see spurious failures.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def _health_cmd(args: argparse.Namespace) -> None:
+    from kairix.curator.health import (
+        format_report_json,
+        format_report_text,
+        run_health_check,
+    )
+    from kairix.entities.schema import open_entities_db
+
+    db = open_entities_db()
+
+    neo4j_client = None
+    if not args.no_neo4j:
+        try:
+            from kairix.graph.client import get_client
+
+            client = get_client()
+            if client.available:
+                neo4j_client = client
+        except Exception:
+            pass  # Neo4j unavailable — health check proceeds without graph counts
+
+    report = run_health_check(db, neo4j_client=neo4j_client, staleness_days=args.staleness_days)
+    db.close()
+
+    output = format_report_json(report) if args.format == "json" else format_report_text(report)
+
+    if args.output:
+        Path(args.output).write_text(output, encoding="utf-8")
+        print(f"Health report written to {args.output}")
+    else:
+        print(output, end="")
+
+    sys.exit(0)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point for `kairix curator` subcommand."""
+    parser = argparse.ArgumentParser(
+        prog="kairix curator",
+        description="Curator agent: entity graph health monitoring and enrichment.",
+    )
+    subparsers = parser.add_subparsers(dest="subcommand", required=True)
+
+    # --- health ---
+    health_parser = subparsers.add_parser(
+        "health",
+        help="Run entity graph health check (CA-1)",
+    )
+    health_parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format: text (vault-ready Markdown) or json (default: text)",
+    )
+    health_parser.add_argument(
+        "--output",
+        default=None,
+        metavar="FILE",
+        help="Write report to FILE instead of stdout",
+    )
+    health_parser.add_argument(
+        "--staleness-days",
+        type=int,
+        default=90,
+        dest="staleness_days",
+        metavar="N",
+        help="Flag entities with no activity for N days as stale (default: 90)",
+    )
+    health_parser.add_argument(
+        "--no-neo4j",
+        action="store_true",
+        default=False,
+        dest="no_neo4j",
+        help="Skip Neo4j availability check",
+    )
+    health_parser.set_defaults(func=_health_cmd)
+
+    parsed = parser.parse_args(argv)
+    parsed.func(parsed)
+
+
+if __name__ == "__main__":
+    main()

--- a/kairix/curator/health.py
+++ b/kairix/curator/health.py
@@ -1,0 +1,265 @@
+"""
+kairix.curator.health — Entity graph health check (CA-1).
+
+Checks entities.db for quality and coverage issues:
+  - Entity count by type
+  - Synthesis failures (entities with no summary)
+  - Missing vault_path (entities not linked to canonical vault note)
+  - Staleness (entities with no activity for > N days)
+
+Optionally queries Neo4j for node counts when a client is provided.
+Never raises — returns a HealthReport reflecting available data.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import logging
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+STALENESS_THRESHOLD_DAYS = 90
+
+
+@dataclass
+class HealthIssue:
+    """A single entity-level health issue."""
+
+    entity_id: str
+    name: str
+    entity_type: str
+    detail: str
+
+
+@dataclass
+class HealthReport:
+    """
+    Result of a single Curator health check run.
+
+    All list fields are empty when no issues are found.
+    Use report.ok to test overall health at a glance.
+    """
+
+    generated_at: str  # ISO UTC timestamp
+    total_entities: int
+    entities_by_type: dict[str, int]
+    synthesis_failures: list[HealthIssue] = field(default_factory=list)
+    stale_entities: list[HealthIssue] = field(default_factory=list)
+    missing_vault_path: list[HealthIssue] = field(default_factory=list)
+    neo4j_available: bool = False
+    neo4j_node_counts: dict[str, int] = field(default_factory=dict)
+    staleness_threshold_days: int = STALENESS_THRESHOLD_DAYS
+
+    @property
+    def issue_count(self) -> int:
+        """Total number of entity-level issues found."""
+        return len(self.synthesis_failures) + len(self.stale_entities) + len(self.missing_vault_path)
+
+    @property
+    def ok(self) -> bool:
+        """True when no issues were found."""
+        return self.issue_count == 0
+
+
+def run_health_check(
+    db: sqlite3.Connection,
+    neo4j_client: Any = None,
+    staleness_days: int = STALENESS_THRESHOLD_DAYS,
+) -> HealthReport:
+    """
+    Run a full entity graph health check against entities.db.
+
+    Args:
+        db: Open connection to entities.db (schema v2 required).
+        neo4j_client: Optional Neo4jClient instance. When provided and its
+            ``available`` flag is True, Neo4j node counts are included in the
+            report. Pass None to skip Neo4j checks entirely.
+        staleness_days: Entities with no activity for this many days are flagged
+            as stale. Defaults to STALENESS_THRESHOLD_DAYS (90).
+
+    Returns:
+        HealthReport describing the current state of the entity graph.
+    """
+    generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    threshold_str = (datetime.now(timezone.utc) - timedelta(days=staleness_days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # ── Entity counts ─────────────────────────────────────────────────────────
+    total_entities = 0
+    entities_by_type: dict[str, int] = {}
+    for row in db.execute("SELECT type, COUNT(*) AS cnt FROM entities WHERE status = 'active' GROUP BY type"):
+        entities_by_type[row[0]] = row[1]
+        total_entities += row[1]
+
+    # ── Synthesis failures ────────────────────────────────────────────────────
+    synthesis_failures: list[HealthIssue] = [
+        HealthIssue(
+            entity_id=row[0],
+            name=row[1],
+            entity_type=row[2],
+            detail="no summary",
+        )
+        for row in db.execute(
+            "SELECT id, name, type FROM entities"
+            " WHERE (summary IS NULL OR trim(summary) = '') AND status = 'active'"
+            " ORDER BY type, name"
+        )
+    ]
+
+    # ── Missing vault_path ────────────────────────────────────────────────────
+    missing_vault_path: list[HealthIssue] = [
+        HealthIssue(
+            entity_id=row[0],
+            name=row[1],
+            entity_type=row[2],
+            detail="vault_path not set",
+        )
+        for row in db.execute(
+            "SELECT id, name, type FROM entities"
+            " WHERE (vault_path IS NULL OR trim(vault_path) = '') AND status = 'active'"
+            " ORDER BY type, name"
+        )
+    ]
+
+    # ── Stale entities ────────────────────────────────────────────────────────
+    # An entity is stale when both last_seen AND updated_at predate the threshold,
+    # OR when last_seen is NULL (entity has never appeared in search results) and
+    # updated_at predates the threshold.
+    # Threshold is computed in Python and passed as a bound parameter — not
+    # interpolated into SQL — so no injection risk exists here.
+    stale_entities: list[HealthIssue] = [
+        HealthIssue(
+            entity_id=row[0],
+            name=row[1],
+            entity_type=row[2],
+            detail=f"last seen: {row[3] or 'never'}, last updated: {row[4]}",
+        )
+        for row in db.execute(
+            "SELECT id, name, type, last_seen, updated_at FROM entities"
+            " WHERE status = 'active'"
+            " AND (last_seen IS NULL OR last_seen < ?)"
+            " AND updated_at < ?"
+            " ORDER BY type, name",
+            (threshold_str, threshold_str),
+        )
+    ]
+
+    # ── Neo4j node counts ─────────────────────────────────────────────────────
+    neo4j_available = False
+    neo4j_node_counts: dict[str, int] = {}
+    if neo4j_client is not None:
+        try:
+            if neo4j_client.available:
+                rows = neo4j_client.cypher("MATCH (n) RETURN labels(n)[0] AS label, COUNT(*) AS cnt")
+                for r in rows:
+                    label = r.get("label")
+                    cnt = r.get("cnt")
+                    if label is not None and cnt is not None:
+                        neo4j_node_counts[str(label)] = int(cnt)
+                neo4j_available = True
+        except Exception as exc:
+            logger.debug("Neo4j health check failed: %s", exc)
+
+    return HealthReport(
+        generated_at=generated_at,
+        total_entities=total_entities,
+        entities_by_type=entities_by_type,
+        synthesis_failures=synthesis_failures,
+        stale_entities=stale_entities,
+        missing_vault_path=missing_vault_path,
+        neo4j_available=neo4j_available,
+        neo4j_node_counts=neo4j_node_counts,
+        staleness_threshold_days=staleness_days,
+    )
+
+
+def format_report_text(report: HealthReport) -> str:
+    """Format a HealthReport as vault-ready Markdown."""
+    lines: list[str] = [
+        "# Kairix — Entity Health Report",
+        f"_Generated: {report.generated_at}_",
+        "",
+        f"## Entity Counts (active: {report.total_entities})",
+        "",
+    ]
+
+    if report.entities_by_type:
+        lines += [
+            "| Type | Count |",
+            "|------|-------|",
+        ]
+        for etype, cnt in sorted(report.entities_by_type.items()):
+            lines.append(f"| {etype} | {cnt} |")
+    else:
+        lines.append("_No active entities._")
+
+    lines += [
+        "",
+        f"## Synthesis Failures ({len(report.synthesis_failures)})",
+        "",
+    ]
+    if report.synthesis_failures:
+        for issue in report.synthesis_failures:
+            lines.append(f"- ⚠ `{issue.entity_id}` ({issue.entity_type}) — {issue.detail}")
+    else:
+        lines.append("✅ None.")
+
+    lines += [
+        "",
+        f"## Stale Entities ({len(report.stale_entities)}, threshold: {report.staleness_threshold_days} days)",
+        "",
+    ]
+    if report.stale_entities:
+        for issue in report.stale_entities:
+            lines.append(f"- ⚠ `{issue.entity_id}` ({issue.entity_type}) — {issue.detail}")
+    else:
+        lines.append("✅ None.")
+
+    lines += [
+        "",
+        f"## Missing Vault Path ({len(report.missing_vault_path)})",
+        "",
+    ]
+    if report.missing_vault_path:
+        for issue in report.missing_vault_path:
+            lines.append(f"- ⚠ `{issue.entity_id}` ({issue.entity_type}) — {issue.detail}")
+    else:
+        lines.append("✅ None.")
+
+    lines += [
+        "",
+        "## Graph (Neo4j)",
+        "",
+    ]
+    if report.neo4j_available:
+        if report.neo4j_node_counts:
+            node_summary = ", ".join(f"{cnt} {label}" for label, cnt in sorted(report.neo4j_node_counts.items()))
+            lines.append(f"✅ Connected — {node_summary}")
+        else:
+            lines.append("✅ Connected — no nodes found")
+    else:
+        lines.append("⚠ Unavailable or not checked.")
+
+    lines += ["", "---"]
+    if report.ok:
+        lines.append("**Status: ✅ HEALTHY** — no issues found")
+    else:
+        parts = []
+        if report.synthesis_failures:
+            parts.append(f"{len(report.synthesis_failures)} synthesis failure(s)")
+        if report.stale_entities:
+            parts.append(f"{len(report.stale_entities)} stale")
+        if report.missing_vault_path:
+            parts.append(f"{len(report.missing_vault_path)} missing vault path")
+        lines.append(f"**Status: ⚠ ISSUES FOUND** — {', '.join(parts)}")
+
+    return "\n".join(lines) + "\n"
+
+
+def format_report_json(report: HealthReport) -> str:
+    """Format a HealthReport as indented JSON."""
+    return json.dumps(dataclasses.asdict(report), indent=2)

--- a/tests/curator/test_health.py
+++ b/tests/curator/test_health.py
@@ -1,0 +1,350 @@
+"""
+Tests for kairix.curator.health — entity graph health check (CA-1).
+
+All tests use an in-memory entities.db (schema v2) via KAIRIX_TEST_DB env var.
+No external services required.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+
+from kairix.curator.health import (
+    format_report_json,
+    format_report_text,
+    run_health_check,
+)
+from kairix.entities.schema import open_entities_db
+
+
+@pytest.fixture()
+def health_db(tmp_path: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch) -> sqlite3.Connection:
+    """Fresh entities DB (schema v2) isolated per test via KAIRIX_TEST_DB."""
+    db_path = str(tmp_path / "health_test.db")
+    monkeypatch.setenv("KAIRIX_TEST_DB", db_path)
+    db = open_entities_db()
+    yield db  # type: ignore[misc]
+    db.close()
+
+
+def _insert(
+    db: sqlite3.Connection,
+    entity_id: str,
+    entity_type: str = "person",
+    name: str = "Test Entity",
+    summary: str | None = "A summary.",
+    vault_path: str | None = "/vault/path",
+    status: str = "active",
+    last_seen: str | None = "2026-04-10T00:00:00Z",
+    updated_at: str = "2026-04-10T00:00:00Z",
+    created_at: str = "2026-01-01T00:00:00Z",
+) -> None:
+    """Insert a minimal entity row for testing."""
+    db.execute(
+        "INSERT INTO entities"
+        " (id, type, name, markdown_path, summary, vault_path, status,"
+        "  last_seen, created_at, updated_at)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            entity_id,
+            entity_type,
+            name,
+            f"{entity_id}.md",
+            summary,
+            vault_path,
+            status,
+            last_seen,
+            created_at,
+            updated_at,
+        ),
+    )
+    db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Entity counts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_empty_db_zero_counts(health_db: sqlite3.Connection) -> None:
+    report = run_health_check(health_db)
+    assert report.total_entities == 0
+    assert report.entities_by_type == {}
+    assert report.ok is True
+
+
+@pytest.mark.unit
+def test_counts_entities_by_type(health_db: sqlite3.Connection) -> None:
+    _insert(health_db, "p1", entity_type="person", name="Alice")
+    _insert(health_db, "p2", entity_type="person", name="Bob")
+    _insert(health_db, "o1", entity_type="organisation", name="Acme")
+    report = run_health_check(health_db)
+    assert report.total_entities == 3
+    assert report.entities_by_type == {"person": 2, "organisation": 1}
+
+
+# ---------------------------------------------------------------------------
+# Synthesis failures
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_synthesis_failure_null_summary(health_db: sqlite3.Connection) -> None:
+    _insert(health_db, "no-summary", summary=None)
+    report = run_health_check(health_db)
+    assert any(i.entity_id == "no-summary" for i in report.synthesis_failures)
+
+
+@pytest.mark.unit
+def test_synthesis_failure_whitespace_only_summary(health_db: sqlite3.Connection) -> None:
+    # SQLite trim("   ") = "" — should be treated as missing
+    _insert(health_db, "ws-summary", summary="   ")
+    report = run_health_check(health_db)
+    assert any(i.entity_id == "ws-summary" for i in report.synthesis_failures)
+
+
+@pytest.mark.unit
+def test_healthy_entity_not_in_synthesis_failures(health_db: sqlite3.Connection) -> None:
+    _insert(health_db, "good", summary="Has a real summary.")
+    report = run_health_check(health_db)
+    assert not any(i.entity_id == "good" for i in report.synthesis_failures)
+
+
+# ---------------------------------------------------------------------------
+# Missing vault path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_missing_vault_path_detected(health_db: sqlite3.Connection) -> None:
+    _insert(health_db, "no-path", vault_path=None)
+    report = run_health_check(health_db)
+    assert any(i.entity_id == "no-path" for i in report.missing_vault_path)
+
+
+@pytest.mark.unit
+def test_vault_path_set_not_flagged(health_db: sqlite3.Connection) -> None:
+    _insert(health_db, "has-path", vault_path="Network/People-Notes/test.md")
+    report = run_health_check(health_db)
+    assert not any(i.entity_id == "has-path" for i in report.missing_vault_path)
+
+
+# ---------------------------------------------------------------------------
+# Staleness
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_stale_entity_detected(health_db: sqlite3.Connection) -> None:
+    # Last seen and updated >200 days before test date — stale under 90-day threshold
+    _insert(
+        health_db,
+        "stale",
+        last_seen="2025-09-01T00:00:00Z",
+        updated_at="2025-09-01T00:00:00Z",
+    )
+    report = run_health_check(health_db, staleness_days=90)
+    assert any(i.entity_id == "stale" for i in report.stale_entities)
+
+
+@pytest.mark.unit
+def test_recent_entity_not_stale(health_db: sqlite3.Connection) -> None:
+    # Last seen 2 days ago — well within any reasonable staleness window
+    _insert(
+        health_db,
+        "fresh",
+        last_seen="2026-04-10T00:00:00Z",
+        updated_at="2026-04-10T00:00:00Z",
+    )
+    report = run_health_check(health_db, staleness_days=90)
+    assert not any(i.entity_id == "fresh" for i in report.stale_entities)
+
+
+@pytest.mark.unit
+def test_staleness_days_param_respected(health_db: sqlite3.Connection) -> None:
+    # Entity updated ~30 days before 2026-04-12: stale under 10-day threshold, not under 60-day
+    _insert(
+        health_db,
+        "mid",
+        last_seen="2026-03-13T00:00:00Z",
+        updated_at="2026-03-13T00:00:00Z",
+    )
+    stale_10 = [i.entity_id for i in run_health_check(health_db, staleness_days=10).stale_entities]
+    stale_60 = [i.entity_id for i in run_health_check(health_db, staleness_days=60).stale_entities]
+    assert "mid" in stale_10
+    assert "mid" not in stale_60
+
+
+@pytest.mark.unit
+def test_null_last_seen_counts_as_stale(health_db: sqlite3.Connection) -> None:
+    # An entity never seen in search (last_seen=NULL) and not updated recently is stale
+    _insert(
+        health_db,
+        "never-seen",
+        last_seen=None,
+        updated_at="2025-09-01T00:00:00Z",
+    )
+    report = run_health_check(health_db, staleness_days=90)
+    assert any(i.entity_id == "never-seen" for i in report.stale_entities)
+
+
+# ---------------------------------------------------------------------------
+# Archived entities excluded from all checks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_archived_entity_excluded_from_all_checks(health_db: sqlite3.Connection) -> None:
+    _insert(
+        health_db,
+        "archived",
+        summary=None,
+        vault_path=None,
+        status="archived",
+        last_seen="2020-01-01T00:00:00Z",
+        updated_at="2020-01-01T00:00:00Z",
+    )
+    report = run_health_check(health_db)
+    all_issue_ids = (
+        [i.entity_id for i in report.synthesis_failures]
+        + [i.entity_id for i in report.missing_vault_path]
+        + [i.entity_id for i in report.stale_entities]
+    )
+    assert "archived" not in all_issue_ids
+    assert report.total_entities == 0
+
+
+# ---------------------------------------------------------------------------
+# Neo4j graceful degradation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_neo4j_none_returns_unavailable(health_db: sqlite3.Connection) -> None:
+    report = run_health_check(health_db, neo4j_client=None)
+    assert report.neo4j_available is False
+    assert report.neo4j_node_counts == {}
+
+
+@pytest.mark.unit
+def test_neo4j_unavailable_client_graceful(health_db: sqlite3.Connection) -> None:
+    class _UnavailableClient:
+        available = False
+
+    report = run_health_check(health_db, neo4j_client=_UnavailableClient())
+    assert report.neo4j_available is False
+    assert report.neo4j_node_counts == {}
+
+
+# ---------------------------------------------------------------------------
+# ok property
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_ok_false_when_synthesis_failures(health_db: sqlite3.Connection) -> None:
+    _insert(health_db, "bad", summary=None)
+    assert run_health_check(health_db).ok is False
+
+
+@pytest.mark.unit
+def test_ok_true_when_all_healthy(health_db: sqlite3.Connection) -> None:
+    # Entity with summary + vault_path + recent activity — no issues expected
+    _insert(
+        health_db,
+        "healthy",
+        summary="Complete summary.",
+        vault_path="Network/People-Notes/healthy.md",
+        last_seen="2026-04-10T00:00:00Z",
+        updated_at="2026-04-10T00:00:00Z",
+    )
+    report = run_health_check(health_db, staleness_days=90)
+    assert report.ok is True
+
+
+# ---------------------------------------------------------------------------
+# JSON serialisability (contract test)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.contract
+def test_report_json_serialisable(health_db: sqlite3.Connection) -> None:
+    """HealthReport must serialise cleanly via format_report_json."""
+    _insert(health_db, "e1", summary=None, vault_path=None)
+    report = run_health_check(health_db)
+    raw = format_report_json(report)
+    decoded = json.loads(raw)
+    assert decoded["total_entities"] == 1
+    assert len(decoded["synthesis_failures"]) == 1
+    assert decoded["synthesis_failures"][0]["entity_id"] == "e1"
+    assert decoded["neo4j_available"] is False
+
+
+@pytest.mark.unit
+def test_format_report_text_contains_key_sections(health_db: sqlite3.Connection) -> None:
+    """Text report must include all section headings."""
+    report = run_health_check(health_db)
+    text = format_report_text(report)
+    assert "# Kairix — Entity Health Report" in text
+    assert "## Synthesis Failures" in text
+    assert "## Stale Entities" in text
+    assert "## Missing Vault Path" in text
+    assert "## Graph (Neo4j)" in text
+    assert "**Status:" in text
+
+
+@pytest.mark.unit
+def test_format_report_text_renders_issues(health_db: sqlite3.Connection) -> None:
+    """Text report renders issue lines and ISSUES FOUND status when problems exist."""
+    # Entity with all three issue types
+    _insert(
+        health_db,
+        "bad-entity",
+        summary=None,
+        vault_path=None,
+        last_seen="2025-01-01T00:00:00Z",
+        updated_at="2025-01-01T00:00:00Z",
+    )
+    report = run_health_check(health_db, staleness_days=90)
+    text = format_report_text(report)
+    # Issue lines rendered for synthesis failures, missing vault path, and stale
+    assert "bad-entity" in text
+    assert "ISSUES FOUND" in text
+
+
+@pytest.mark.unit
+def test_format_report_text_neo4j_connected_with_nodes(health_db: sqlite3.Connection) -> None:
+    """Text report renders 'Connected' with node counts when Neo4j is available."""
+    from kairix.curator.health import HealthReport
+
+    report = HealthReport(
+        generated_at="2026-04-12T00:00:00Z",
+        total_entities=0,
+        entities_by_type={},
+        neo4j_available=True,
+        neo4j_node_counts={"Person": 5, "Organisation": 2},
+    )
+    text = format_report_text(report)
+    assert "Connected" in text
+    assert "Person" in text
+
+
+@pytest.mark.unit
+def test_format_report_text_neo4j_connected_no_nodes(health_db: sqlite3.Connection) -> None:
+    """Text report renders 'Connected — no nodes found' when Neo4j is available but empty."""
+    from kairix.curator.health import HealthReport
+
+    report = HealthReport(
+        generated_at="2026-04-12T00:00:00Z",
+        total_entities=0,
+        entities_by_type={},
+        neo4j_available=True,
+        neo4j_node_counts={},
+    )
+    text = format_report_text(report)
+    assert "Connected" in text
+    assert "no nodes found" in text


### PR DESCRIPTION
## Summary

- Adds `kairix curator health` subcommand (CA-1 milestone)
- `health.py`: `run_health_check()` queries entities.db for synthesis failures (no summary), missing vault paths, and stale entities; optionally queries Neo4j for node counts
- `cli.py`: argparse wrapper with `--format text|json`, `--output FILE`, `--staleness-days N`, `--no-neo4j`; always exits 0 (health issues reported, not errors — prevents false cron failures)
- `format_report_text()` produces vault-ready Markdown; `format_report_json()` wraps `dataclasses.asdict()`
- 21 tests (unit + contract); total coverage 80.39% (gate: 80%)

## Test plan

- [x] `pytest tests/curator/ -v` — 21/21 pass
- [x] `pytest tests/ -m "not integration and not e2e" --cov=kairix --cov-fail-under=80` — 80.39%
- [x] `ruff check kairix/curator/ tests/curator/` — all checks passed
- [x] `mypy kairix/curator/` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)