### PR TITLE
docs: standardise on kairix — README, OPERATIONS, CONTRIBUTING, env.example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 ```bash
 git clone https://github.com/quanyeomans/agentic-context-mesh
-cd qmd-azure-embed
+cd agentic-context-mesh
 pip install -e ".[dev]"
 ```
 
@@ -15,7 +15,7 @@ pip install -e ".[dev]"
 pytest tests/unit/ tests/integration/ -v
 
 # E2E (requires real QMD index + Azure credentials)
-QMD_E2E=1 pytest tests/e2e/ -v -s
+KAIRIX_E2E=1 pytest tests/e2e/ -v -s
 ```
 
 ### About skipped tests
@@ -34,14 +34,35 @@ LD_PRELOAD=$(find ~/.local -name "vec0.so" 2>/dev/null | head -1) pytest tests/i
 ## Architecture
 
 ```
-qmd_azure_embed/
-  schema.py       — QMD DB path resolution, schema validation, pending chunk queries
-  embed.py        — Azure API client, chunking, vector encoding, DB writes
-  recall_check.py — Post-embed quality gate (vsearch queries against known docs)
-  cli.py          — argparse entrypoint, lockfile acquisition, run logging
+kairix/
+  cli.py              — top-level dispatcher (kairix <subcommand>)
+  embed/              — Azure OpenAI embedding pipeline → sqlite-vec
+    schema.py         — QMD DB path resolution, schema validation, pending chunk queries
+    embed.py          — Azure API client, chunking, vector encoding, DB writes
+    recall_check.py   — Post-embed quality gate
+    cli.py            — argparse entrypoint, lockfile, run logging
+  search/             — Hybrid BM25 + vector retrieval
+    hybrid.py         — Full pipeline: intent → BM25+vec → RRF → entity boost → budget
+    intent.py         — Query intent classification (6 intents)
+    bm25.py           — QMD FTS wrapper
+    vector.py         — sqlite-vec wrapper
+    rrf.py            — Reciprocal Rank Fusion + entity/procedural boosts
+    budget.py         — Token budget management (L0/L1/L2 tiering)
+  entities/           — Entity graph (entities.db, alias resolution, multi-hop)
+  graph/              — Neo4j client + graph models (OrganisationNode, PersonNode, etc.)
+  vault/              — Vault crawler → Neo4j; vault health check
+  temporal/           — Date-aware query rewriting + chunking
+  summaries/          — L0/L1 tiered summary generation
+  wikilinks/          — Wikilink injection + entity resolver
+  briefing/           — Session briefing synthesis
+  classify/           — Memory write auto-classification
+  contradict/         — Contradiction detection on new knowledge writes
+  curator/            — Entity health monitoring (CA-1)
+  mcp/                — MCP server (search/entity/prep/timeline tools)
+  benchmark/          — YAML-driven benchmark runner (NDCG@10/Hit@5/MRR@10)
 ```
 
-**Key invariant:** `schema.py` is the only place that knows about QMD's table structure.
+**Key invariant:** `kairix/embed/schema.py` is the only place that knows about QMD's table structure.
 `embed.py` calls `schema.py` functions — it does not contain raw SQL against QMD's tables.
 If QMD's schema changes, `schema.py` is the single file to update.
 
@@ -52,14 +73,14 @@ for the update procedure. The schema validation on startup will tell you exactly
 
 ## Adding support for other OpenAI-compatible endpoints
 
-The embedding logic in `embed.py` uses the Azure OpenAI REST API format
+The embedding logic in `kairix/embed/embed.py` uses the Azure OpenAI REST API format
 (`/openai/deployments/{deployment}/embeddings`). To support standard OpenAI or other
-compatible endpoints, the URL construction in `embed_batch()` and `preflight_check()` 
+compatible endpoints, the URL construction in `embed_batch()` and `preflight_check()`
 would need a flag to switch between Azure and OpenAI endpoint formats.
 PRs welcome.
 
 ## Cutting a release
 
-1. Bump `version` in `pyproject.toml` and `__init__.py`
+1. Bump `version` in `pyproject.toml`
 2. Update [QMD_COMPAT.md](QMD_COMPAT.md) with any new tested QMD versions
 3. Tag: `git tag vX.Y.Z && git push origin vX.Y.Z`

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -1,6 +1,6 @@
 # Operations Guide
 
-Step-by-step deployment and operations guide for Mnemosyne on an a server. This document is the single source of truth for getting a new deployment running and keeping it healthy.
+Step-by-step deployment and operations guide for Kairix on a server. This document is the single source of truth for getting a new deployment running and keeping it healthy.
 
 For design rationale see [PRD.md](PRD.md). For benchmark methodology see [EVALUATION.md](EVALUATION.md). For QMD schema compatibility see [QMD_COMPAT.md](QMD_COMPAT.md).
 
@@ -14,13 +14,13 @@ All infrastructure-specific values (vault name, paths, credentials) are passed v
 
 ```bash
 # On your deployment VM
-cp env.example /opt/mnemosyne/service.env
-chmod 600 /opt/mnemosyne/service.env
+cp env.example /opt/kairix/service.env
+chmod 600 /opt/kairix/service.env
 # Edit with your values (Key Vault name, vault path, data dir, etc.)
-nano /opt/mnemosyne/service.env
+nano /opt/kairix/service.env
 
 # Source it in each cron job (see Cron Scheduling below)
-source /opt/mnemosyne/service.env
+source /opt/kairix/service.env
 ```
 
 **For local dev/testing:**
@@ -28,7 +28,7 @@ source /opt/mnemosyne/service.env
 ```bash
 cp env.example .env    # .env is gitignored
 # Edit with your values, then:
-source .env && mnemosyne search "test query" --agent builder
+source .env && kairix search "test query" --agent builder
 ```
 
 **For GitHub Actions:** add each variable as a repository secret (Settings → Secrets and variables → Actions). The CI workflows that need Azure credentials read them as `${{ secrets.AZURE_OPENAI_API_KEY }}` etc.
@@ -37,9 +37,9 @@ source .env && mnemosyne search "test query" --agent builder
 
 | Variable | What it is |
 |---|---|
-| `MNEMOSYNE_KV_NAME` | Your Azure Key Vault name |
-| `MNEMOSYNE_VAULT_ROOT` | Path to your Obsidian vault |
-| `MNEMOSYNE_DATA_DIR` | Where entities.db and logs go |
+| `KAIRIX_KV_NAME` | Your Azure Key Vault name |
+| `KAIRIX_VAULT_ROOT` | Path to your Obsidian vault |
+| `KAIRIX_DATA_DIR` | Where entities.db and logs go |
 | `LOG_DIR` | Where deploy.sh and cron wrappers write logs |
 
 See `env.example` for the complete variable reference.
@@ -82,7 +82,7 @@ az keyvault secret set --vault-name ${KV_NAME} --name azure-openai-gpt4o-mini-de
 
 ### 2. Azure Authentication on the VM
 
-The VM running Mnemosyne must be able to authenticate to Azure Key Vault. Two options:
+The VM running Kairix must be able to authenticate to Azure Key Vault. Two options:
 
 **Option A: Azure Managed Identity (recommended for production)**
 - Assign a system-assigned or user-assigned managed identity to the VM
@@ -101,7 +101,7 @@ az keyvault secret show --vault-name ${KV_NAME} --name azure-openai-endpoint --q
 
 ### 3. QMD Installed and Running
 
-Mnemosyne writes into QMD's SQLite index. QMD must be installed and have indexed your vault before running `mnemosyne embed`.
+Kairix writes into QMD's SQLite index. QMD must be installed and have indexed your vault before running `kairix embed`.
 
 ```bash
 # Verify QMD is installed
@@ -115,7 +115,7 @@ qmd status
 # Expected: N files, N vectors, last updated <date>
 ```
 
-**sqlite-vec:** Mnemosyne uses the sqlite-vec extension bundled with QMD. No separate installation needed — the extension is discovered automatically from QMD's `node_modules` directory. If the discovery fails at startup, set:
+**sqlite-vec:** Kairix uses the sqlite-vec extension bundled with QMD. No separate installation needed — the extension is discovered automatically from QMD's `node_modules` directory. If the discovery fails at startup, set:
 ```bash
 export SQLITE_VEC_PATH="/path/to/vec0.so"
 ```
@@ -127,16 +127,16 @@ See [QMD_COMPAT.md](QMD_COMPAT.md) for compatible QMD versions and schema detail
 Create the required directories on the VM before first run:
 
 ```bash
-sudo mkdir -p /data/mnemosyne/briefing
-sudo mkdir -p /data/mnemosyne/logs
-sudo chown -R <service-user>:<service-user> /data/mnemosyne
+sudo mkdir -p /data/kairix/briefing
+sudo mkdir -p /data/kairix/logs
+sudo chown -R <service-user>:<service-user> /data/kairix
 ```
 
-Mnemosyne expects:
+Kairix expects:
 - `/data/obsidian-vault/` — vault root (QMD indexes this; set your actual vault path via `VAULT_ROOT` if different)
-- `/data/mnemosyne/entities.db` — entity graph (created automatically on first run)
-- `/data/mnemosyne/briefing/` — session briefings output directory
-- `/data/mnemosyne/logs/` — optional query logs (`MNEMOSYNE_LOG_QUERIES=1`)
+- `/data/kairix/entities.db` — entity graph (created automatically on first run)
+- `/data/kairix/briefing/` — session briefings output directory
+- `/data/kairix/logs/` — optional query logs (`KAIRIX_LOG_QUERIES=1`)
 - `/data/workspaces/<agent>/memory/` — agent memory logs (required for briefing pipeline)
 
 ---
@@ -153,7 +153,7 @@ python3 -m venv .venv
 .venv/bin/pip install -e .
 
 # Verify
-.venv/bin/mnemosyne --help
+.venv/bin/kairix --help
 ```
 
 ---
@@ -185,7 +185,7 @@ cd /data/tools/qmd-azure-embed
 
 AZURE_OPENAI_ENDPOINT="$ENDPOINT" \
 AZURE_OPENAI_API_KEY="$APIKEY" \
-.venv/bin/mnemosyne embed --limit 20
+.venv/bin/kairix embed --limit 20
 ```
 
 Expected output:
@@ -204,13 +204,13 @@ If you see `SchemaVersionError` or `sqlite-vec extension load failed`, see [Trou
 ```bash
 AZURE_OPENAI_ENDPOINT="$ENDPOINT" \
 AZURE_OPENAI_API_KEY="$APIKEY" \
-nohup .venv/bin/mnemosyne embed >> /data/mnemosyne/logs/embed.log 2>&1 &
+nohup .venv/bin/kairix embed >> /data/kairix/logs/embed.log 2>&1 &
 echo "PID: $!"
 ```
 
 For a ~2,800 file vault this takes 15–20 minutes and costs ~$0.30–0.40 at 1536-dim. Monitor with:
 ```bash
-tail -f /data/mnemosyne/logs/embed.log
+tail -f /data/kairix/logs/embed.log
 ```
 
 Done when you see: `Done — embedded=N failed=0`
@@ -218,7 +218,7 @@ Done when you see: `Done — embedded=N failed=0`
 ### Step 4: Verify search works
 
 ```bash
-.venv/bin/mnemosyne search "what are our engineering standards" --agent builder
+.venv/bin/kairix search "what are our engineering standards" --agent builder
 ```
 
 Expected: 3–5 results with file paths and relevance snippets. If you get 0 results, the embed didn't complete or the QMD index path is wrong.
@@ -226,8 +226,8 @@ Expected: 3–5 results with file paths and relevance snippets. If you get 0 res
 ### Step 5: Seed the entity graph
 
 ```bash
-.venv/bin/mnemosyne entity extract --changed
-.venv/bin/mnemosyne entity list   # should report entity count
+.venv/bin/kairix entity extract --changed
+.venv/bin/kairix entity list   # should report entity count
 ```
 
 Expected: entity count ≥ 100 for a typical vault. The entity extraction runs LLM calls for named entity recognition — requires Azure credentials.
@@ -237,10 +237,10 @@ Expected: entity count ≥ 100 for a typical vault. The entity extraction runs L
 ```bash
 AZURE_OPENAI_ENDPOINT="$ENDPOINT" \
 AZURE_OPENAI_API_KEY="$APIKEY" \
-.venv/bin/mnemosyne brief builder
+.venv/bin/kairix brief builder
 ```
 
-Output written to `/data/mnemosyne/briefing/builder-latest.md`. Verify it's non-empty and coherent.
+Output written to `/data/kairix/briefing/builder-latest.md`. Verify it's non-empty and coherent.
 
 ### Step 7: Register cron jobs
 
@@ -254,14 +254,14 @@ Two recurring jobs are required for a production deployment.
 
 ### Hourly embed (new vault files)
 
-Runs mnemosyne embed incrementally — only embeds files modified since the last run. Exits quickly (embedded=0) when nothing has changed.
+Runs kairix embed incrementally — only embeds files modified since the last run. Exits quickly (embedded=0) when nothing has changed.
 
 ```cron
 15 * * * * source /opt/<service-user>/env/service.env \
   && export AZURE_OPENAI_ENDPOINT=$(az keyvault secret show --vault-name ${KV_NAME} --name azure-openai-endpoint --query value -o tsv 2>/dev/null) \
   && export AZURE_OPENAI_API_KEY=$(az keyvault secret show --vault-name ${KV_NAME} --name azure-openai-api-key --query value -o tsv 2>/dev/null) \
   && cd /data/tools/qmd-azure-embed \
-  && .venv/bin/mnemosyne embed >> /data/mnemosyne/logs/embed.log 2>&1
+  && .venv/bin/kairix embed >> /data/kairix/logs/embed.log 2>&1
 ```
 
 ### Nightly entity + relationship seed (03:00 AEST / 17:00 UTC)
@@ -269,11 +269,11 @@ Runs mnemosyne embed incrementally — only embeds files modified since the last
 Runs incremental entity extraction and relationship seeding. Uses GPT-4o-mini for relationship classification.
 
 ```cron
-0 17 * * * /opt/mnemosyne/cron-scripts/entity-relation-seed.sh >> /data/mnemosyne/logs/entity-relation-seed.log 2>&1
+0 17 * * * /opt/kairix/cron-scripts/entity-relation-seed.sh >> /data/kairix/logs/entity-relation-seed.log 2>&1
 ```
 
 The shell script (`entity-relation-seed.sh`) handles Key Vault credential fetching and runs:
-1. `mnemosyne entity extract --changed`
+1. `kairix entity extract --changed`
 2. `python scripts/seed-entity-relations.py`
 
 Add both crons with `crontab -e` as the `<service-user>` service user.
@@ -289,10 +289,10 @@ crontab -l
 
 ```bash
 # Check embed log (should show runs at :15 of each hour)
-grep "Done —" /data/mnemosyne/logs/embed.log | tail -5
+grep "Done —" /data/kairix/logs/embed.log | tail -5
 
 # Check entity log (should show a run at 03:00 AEST)
-tail -20 /data/mnemosyne/logs/entity-relation-seed.log
+tail -20 /data/kairix/logs/entity-relation-seed.log
 ```
 
 ---
@@ -307,7 +307,7 @@ All credentials are fetched from Azure Key Vault at runtime. You can override an
 | `AZURE_OPENAI_ENDPOINT` | Azure OpenAI endpoint URL | From Key Vault `azure-openai-endpoint` |
 | `AZURE_OPENAI_EMBED_DEPLOYMENT` | Embedding deployment name | From Key Vault `azure-openai-embedding-deployment` |
 | `VAULT_ROOT` | Path to Obsidian vault | `/data/obsidian-vault` |
-| `MNEMOSYNE_LOG_QUERIES` | Set to `1` to log all search queries to `queries.jsonl` | Off |
+| `KAIRIX_LOG_QUERIES` | Set to `1` to log all search queries to `queries.jsonl` | Off |
 | `SQLITE_VEC_PATH` | Override sqlite-vec `.so` path | Auto-discovered from QMD node_modules |
 
 ---
@@ -324,7 +324,7 @@ cd /data/tools/qmd-azure-embed
   --suite suites/v2-real-world.yaml
 
 # View latest results
-tail -30 /data/mnemosyne/logs/benchmark.log
+tail -30 /data/kairix/logs/benchmark.log
 ```
 
 **Current scores (R1, 2026-04-07):**
@@ -343,7 +343,7 @@ To rebuild gold paths after a large vault restructure:
 ```bash
 AZURE_OPENAI_ENDPOINT="$ENDPOINT" AZURE_OPENAI_API_KEY="$APIKEY" \
 PYTHONUNBUFFERED=1 .venv/bin/python -u scripts/build-eval-gold.py \
-  > /data/mnemosyne/logs/build-eval-gold.log 2>&1 &
+  > /data/kairix/logs/build-eval-gold.log 2>&1 &
 ```
 This takes ~80 minutes and costs ~$0.27 for 388 queries.
 
@@ -355,13 +355,13 @@ This takes ~80 minutes and costs ~$0.27 for 388 queries.
 
 ```bash
 # Embed ran and found/embedded the right number of files
-grep "Done —" /data/mnemosyne/logs/embed.log | tail -3
+grep "Done —" /data/kairix/logs/embed.log | tail -3
 
 # No dimension mismatch errors (would indicate QMD cron conflict)
-grep -i "dimension mismatch" /data/mnemosyne/logs/embed.log | tail -5
+grep -i "dimension mismatch" /data/kairix/logs/embed.log | tail -5
 
 # Entity extraction ran cleanly
-tail -5 /data/mnemosyne/logs/entity-relation-seed.log
+tail -5 /data/kairix/logs/entity-relation-seed.log
 
 # Vector count is stable or growing
 qmd status
@@ -370,15 +370,15 @@ qmd status
 ### Key metrics to track
 
 - **Vector count:** Should grow as vault grows. Sudden drop indicates QMD reindex issue.
-- **Entity count:** Grows as new entity stubs are written. Check with `mnemosyne entity list`.
-- **Relationship count:** Grows as nightly seed runs. Check with sqlite CLI: `sqlite3 /data/mnemosyne/entities.db "SELECT COUNT(*) FROM entity_relationships;"`
-- **Recall gate:** Post-embed recall check in embed log — should be ≥ 4/5. If < 4/5, run `mnemosyne embed --force`.
+- **Entity count:** Grows as new entity stubs are written. Check with `kairix entity list`.
+- **Relationship count:** Grows as nightly seed runs. Check with sqlite CLI: `sqlite3 /data/kairix/entities.db "SELECT COUNT(*) FROM entity_relationships;"`
+- **Recall gate:** Post-embed recall check in embed log — should be ≥ 4/5. If < 4/5, run `kairix embed --force`.
 
 ### Enabling query logging
 
 ```bash
-export MNEMOSYNE_LOG_QUERIES=1
-# Queries logged to /data/mnemosyne/logs/queries.jsonl
+export KAIRIX_LOG_QUERIES=1
+# Queries logged to /data/kairix/logs/queries.jsonl
 # Analyse with:
 .venv/bin/python scripts/analyze_queries.py
 ```
@@ -410,7 +410,7 @@ find $(dirname $(which qmd))/../ -name "vec0.so" 2>/dev/null
 
 # Override manually
 export SQLITE_VEC_PATH="/path/to/vec0.so"
-mnemosyne embed --limit 5
+kairix embed --limit 5
 ```
 
 ### `SchemaVersionError: missing columns`
@@ -443,7 +443,7 @@ sqlite3 ~/.cache/qmd/index.sqlite \
 
 # If 0 vectors: run full re-embed
 AZURE_OPENAI_ENDPOINT="$ENDPOINT" AZURE_OPENAI_API_KEY="$APIKEY" \
-mnemosyne embed --force
+kairix embed --force
 ```
 
 ### `Dimension mismatch` errors in embed log
@@ -464,10 +464,10 @@ crontab -l | grep qmd
 crontab -l
 
 # Check log for last run
-tail -20 /data/mnemosyne/logs/entity-relation-seed.log
+tail -20 /data/kairix/logs/entity-relation-seed.log
 
 # Run manually to debug
-/opt/mnemosyne/cron-scripts/entity-relation-seed.sh
+/opt/kairix/cron-scripts/entity-relation-seed.sh
 ```
 
 ### Briefing output is empty or incoherent
@@ -477,10 +477,10 @@ tail -20 /data/mnemosyne/logs/entity-relation-seed.log
 ls /data/workspaces/<agent>/memory/ | tail -5
 
 # Check entity graph has content
-mnemosyne entity list
+kairix entity list
 
 # Run briefing with debug output
-MNEMOSYNE_LOG_QUERIES=1 mnemosyne brief <agent> --budget 5000
+KAIRIX_LOG_QUERIES=1 kairix brief <agent> --budget 5000
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Agentic Context Mesh
+# Kairix — Agentic Context Mesh
 
 Private, on-infrastructure contextual retrieval for human-agent teams. Your knowledge stays on your servers. Your agents and teammates query the same indexed knowledge base.
 
-**NDCG@10 0.5569** on an 83-case curated real-world benchmark (strict NDCG@10, graded relevance) · **Hit@5 0.84**. Temporal date-filtered retrieval (Sprint 3) raised temporal NDCG from 0.37 to 0.38; procedural path boost raised how-to/runbook NDCG from 0.39 to 0.56.
+**NDCG@10 0.5686** on an 83-case curated real-world benchmark (strict NDCG@10, graded relevance) · **Hit@5 0.874** · **MRR@10 0.673**.
 
 ---
 
@@ -16,13 +16,13 @@ Most AI memory solutions compound this by sending your knowledge to a third-part
 2. **Retrieval quality** — generic RAG without entity awareness, temporal reasoning, or domain-specific patterns produces mediocre results on knowledge that matters
 3. **Team coherence** — when agents and humans draw from different sources, shared context breaks down
 
-Agentic Context Mesh is the alternative: a private, on-infrastructure retrieval layer that both human team members and AI agents query against the same indexed knowledge base. Every query compounds the shared understanding. **Your data never leaves your servers.**
+Kairix is the alternative: a private, on-infrastructure retrieval layer that both human team members and AI agents query against the same indexed knowledge base. Every query compounds the shared understanding. **Your data never leaves your servers.**
 
 ---
 
 ## How it works
 
-A skilled professional should be able to walk onto any job already knowing it — the history, the plan, the outstanding items. Agentic Context Mesh is the infrastructure for that: a structured knowledge base that agents can query before every session to arrive ready to work.
+A skilled professional should be able to walk onto any job already knowing it — the history, the plan, the outstanding items. Kairix is the infrastructure for that: a structured knowledge base that agents can query before every session to arrive ready to work.
 
 The design mirrors how experienced professionals think about knowledge:
 
@@ -34,16 +34,16 @@ The design mirrors how experienced professionals think about knowledge:
 
 ## How it differs from alternatives
 
-| | Agentic Context Mesh | Notion AI / Confluence AI | Mem.ai / Rewind | Raw LLM context |
+| | Kairix | Notion AI / Confluence AI | Mem.ai / Rewind | Raw LLM context |
 |---|---|---|---|---|
 | **Data residency** | Your infrastructure | Vendor cloud | Vendor cloud | API provider |
 | **Search approach** | Hybrid BM25 + vector + entity | Full-text only | Vector only | None — full dump |
 | **Entity awareness** | Graph with alias resolution | No | No | No |
 | **Token efficiency** | Budget-managed retrieval | Unranked export | Unranked export | Unbounded |
 | **Temporal reasoning** | Date-aware chunking + routing | No | Limited | No |
-| **NDCG@10** | 0.58 curated / 0.94 session | Not published | Not published | N/A |
+| **NDCG@10** | 0.5686 curated real-world | Not published | Not published | N/A |
 
-**On token efficiency:** commercial alternatives typically export full page content and rely on the LLM to filter relevance — you pay for every token regardless of utility. Agentic Context Mesh runs ranked retrieval with a configurable token budget (`--budget`), returning only the highest-relevance chunks within that budget. L0/L1 tiered loading (summary-first, full text on demand) further reduces context consumption.
+**On token efficiency:** commercial alternatives typically export full page content and rely on the LLM to filter relevance — you pay for every token regardless of utility. Kairix runs ranked retrieval with a configurable token budget (`--budget`), returning only the highest-relevance chunks within that budget. L0/L1 tiered loading (summary-first, full text on demand) further reduces context consumption.
 
 ---
 
@@ -61,20 +61,20 @@ The retrieval design draws on several well-validated approaches:
 ## Architecture
 
 ```
-mnemosyne search "query" --agent <name>
+kairix search "query" --agent <name>
        │
        ├─ BM25 search (QMD FTS)        ─┐
        ├─ Vector search (sqlite-vec)    ─┤ concurrent
        │                                │
        └─ RRF fusion ◄──────────────────┘
               │
-              ├─ Entity boost (entities.db)
+              ├─ Entity boost (Neo4j / entities.db)
               ├─ Token budget cap
               └─ SearchResult → agent context
 ```
 
 ```
-mnemosyne brief <agent>
+kairix brief <agent>
        │
        ├─ Memory logs (last 7 days)
        ├─ Entity stubs (entity collection)
@@ -82,13 +82,20 @@ mnemosyne brief <agent>
        ├─ Hybrid search (top queries)
        └─ GPT-4o-mini synthesis → briefing.md
 
-mnemosyne classify "<content>"
+kairix classify "<content>"
        │
        ├─ Rule-based classifier (≥90% coverage)
        └─ GPT-4o-mini fallback → vault destination
+
+kairix vault crawl --vault-root /path/to/vault
+       │
+       ├─ Scans PARA structure → OrganisationNode, PersonNode, OutcomeNode
+       ├─ Extracts WORKS_AT edges from frontmatter
+       ├─ Extracts MENTIONS edges from [[wikilinks]]
+       └─ Upserts into Neo4j (idempotent)
 ```
 
-All search and entity data is stored in SQLite — no separate vector database, no external services beyond Azure OpenAI for embedding and synthesis calls.
+All search and entity data is stored in SQLite — no separate vector database. Neo4j Community Edition is used for the entity graph (optional; degrades gracefully when unavailable).
 
 ---
 
@@ -96,16 +103,19 @@ All search and entity data is stored in SQLite — no separate vector database, 
 
 | Module | Status | What it delivers |
 |---|---|---|
-| `mnemosyne embed` | ✅ Shipped | Azure OpenAI `text-embedding-3-large` → sqlite-vec (1536-dim) |
-| `mnemosyne search` | ✅ Shipped | Hybrid BM25 + vector via RRF, token budget management |
-| `mnemosyne entity` | ✅ Shipped | Entity graph, alias resolution, entity boost, multi-hop query planning |
-| `mnemosyne temporal` | ✅ Shipped | Temporal query rewriting + date-filtered retrieval (TMP-2); `chunk_date` extraction at embed time (TMP-1/5b) |
-| `mnemosyne summarise` | ✅ Shipped | L0/L1 tiered context loading |
-| `mnemosyne wikilinks` | ✅ Shipped | Wikilink injection + entity resolver |
-| `mnemosyne brief` | ✅ Shipped | Session briefing synthesis via GPT-4o-mini |
-| `mnemosyne classify` | ✅ Shipped | Auto-classification of memory writes to vault destinations |
-| `mnemosyne benchmark` | ✅ Shipped | YAML-driven benchmark runner, NDCG@10 scoring, phase gates |
-| `mnemosyne contradict` | 🔲 Planned | Contradiction detection on new knowledge writes |
+| `kairix embed` | ✅ Shipped | Azure OpenAI `text-embedding-3-large` → sqlite-vec (1536-dim) |
+| `kairix search` | ✅ Shipped | Hybrid BM25 + vector via RRF, token budget management |
+| `kairix entity` | ✅ Shipped | Entity graph, alias resolution, entity boost, multi-hop query planning |
+| `kairix temporal` | ✅ Shipped | Temporal query rewriting + date-filtered retrieval (TMP-2); `chunk_date` extraction at embed time (TMP-1/5b) |
+| `kairix summarise` | ✅ Shipped | L0/L1 tiered context loading |
+| `kairix wikilinks` | ✅ Shipped | Wikilink injection + entity resolver |
+| `kairix brief` | ✅ Shipped | Session briefing synthesis via GPT-4o-mini |
+| `kairix classify` | ✅ Shipped | Auto-classification of memory writes to vault destinations |
+| `kairix benchmark` | ✅ Shipped | YAML-driven benchmark runner, NDCG@10/Hit@5/MRR@10 scoring |
+| `kairix contradict` | ✅ Shipped | Contradiction detection on new knowledge writes |
+| `kairix vault` | ✅ Shipped | Vault crawler → Neo4j entity graph; vault health check |
+| `kairix mcp` | ✅ Shipped | MCP server exposing search/entity/prep/timeline to any MCP-compatible agent |
+| `kairix curator` | ✅ Shipped | Entity health monitoring and enrichment (CA-1) |
 
 See [ROADMAP.md](ROADMAP.md) for priorities and [ENGINEERING.md](ENGINEERING.md) for design detail.
 
@@ -115,7 +125,7 @@ See [ROADMAP.md](ROADMAP.md) for priorities and [ENGINEERING.md](ENGINEERING.md)
 
 **Suite:** 83 curated queries across 6 categories (entity, keyword, multi_hop, procedural, semantic, temporal), scored with strict NDCG@10 using graded gold relevance. Evaluated on a real-world personal knowledge base of ~3,200 documents.
 
-### Current results (R5 — 2026-04-10)
+### Current results (R10 — 2026-04-10)
 
 | Category | NDCG@10 | Cases | Notes |
 |---|---|---|---|
@@ -123,9 +133,9 @@ See [ROADMAP.md](ROADMAP.md) for priorities and [ENGINEERING.md](ENGINEERING.md)
 | multi_hop | 0.549 | 10 | QueryPlanner, entity-aware sub-query decomposition |
 | procedural | 0.564 | 30 | Path boost for how-to/runbook queries |
 | semantic | 0.519 | 13 | Vector search carrying semantic load |
-| temporal | 0.382 | 8 | Date-filtered retrieval (TMP-2) |
-| keyword | 0.439 | 8 | BM25 baseline; keyword regression under investigation |
-| **Overall** | **0.5569** | **83** | |
+| temporal | 0.535 | 8 | Date-filtered retrieval (TMP-2) |
+| keyword | 0.439 | 8 | BM25 baseline |
+| **Overall** | **0.5686** | **83** | Hit@5 0.874, MRR@10 0.673 |
 
 Production RAG systems on heterogeneous personal knowledge typically score 0.45–0.65 on strict curated suites.
 
@@ -136,11 +146,10 @@ Production RAG systems on heterogeneous personal knowledge typically score 0.45�
 | BM25 baseline | 0.389 | 43 | Pre-vector baseline; synthetic suite |
 | Hybrid Phase 4 | 0.6658 | 43 | First hybrid; synthetic suite |
 | Phase 5 real-world | 0.3203 | 134 | First real-world suite; instrument issues |
-| Phase 7-A recalibrated | 0.7690 | 252 | After 768→1536 dim correction |
-| Phase 7-B 1536-dim | 0.7545 | 252 | Confirmed 1536-dim; keyword +0.114 |
-| O-1 entity-graph-planner | 0.7541 | 245 | multi_hop +0.035 from QueryPlanner |
+| Phase 7-B 1536-dim | 0.7545 | 252 | Confirmed 1536-dim |
 | R1 post-refactor | 0.7756 | 263 | Full gold rebuild |
-| **Phase 8-A procedural boost** | **0.554 procedural** | — | Path-weighted re-rank; target ≥ 0.55 met |
+| R9 procedural boost | 0.5449 | 83 | Real-world curated suite |
+| **R10** | **0.5686** | **83** | NDCG/Hit@5/MRR alignment; temporal +0.015 |
 
 ---
 
@@ -153,16 +162,20 @@ Production RAG systems on heterogeneous personal knowledge typically score 0.45�
   - `text-embedding-3-large` deployment (1536-dim)
   - `gpt-4o-mini` deployment (briefing, classify, benchmark judging)
 - **Azure Key Vault** (recommended) — or export secrets as environment variables directly
+- **Neo4j Community Edition** (optional) — for entity graph; kairix degrades gracefully when unavailable
 
 See [OPERATIONS.md](OPERATIONS.md) for full infrastructure setup, cron configuration, and first-run sequence.
 
 ## Install
 
 ```bash
-git clone https://github.com/quanyeomans/agentic-context-mesh /opt/mnemosyne
-cd /opt/mnemosyne
+git clone https://github.com/quanyeomans/agentic-context-mesh /opt/kairix
+cd /opt/kairix
 python3 -m venv .venv
 .venv/bin/pip install -e .
+
+# Optional: MCP server support
+.venv/bin/pip install -e '.[agents]'
 ```
 
 Copy and fill in your environment configuration:
@@ -182,64 +195,95 @@ Then follow the [OPERATIONS.md first-run sequence](OPERATIONS.md#first-run-seque
 ### Embed
 
 ```bash
-mnemosyne embed                  # incremental — pending docs only
-mnemosyne embed --force          # full re-embed
-mnemosyne embed --limit 50       # test with first 50 chunks
-mnemosyne embed --changed        # re-embed recently modified files
+kairix embed                  # incremental — pending docs only
+kairix embed --force          # full re-embed
+kairix embed --limit 50       # test with first 50 chunks
+kairix embed --changed        # re-embed recently modified files
 ```
 
 ### Search
 
 ```bash
-mnemosyne search "what are our engineering patterns" --agent builder
-mnemosyne search "decisions made last week" --agent shape --budget 3000
+kairix search "what are our engineering patterns" --agent builder
+kairix search "decisions made last week" --agent shape --budget 3000
 ```
 
 ### Entity graph
 
 ```bash
-mnemosyne entity list
-mnemosyne entity lookup "alice chen"
-mnemosyne entity write --name "Alice Chen" --type person
-mnemosyne entity extract --collection <your-entities-collection>
+kairix entity list
+kairix entity lookup "alice chen"
+kairix entity write --name "Alice Chen" --type person
+kairix entity extract --collection <your-entities-collection>
+```
+
+### Vault crawler (Neo4j)
+
+```bash
+kairix vault crawl --vault-root /path/to/vault        # populate Neo4j from PARA structure
+kairix vault crawl --vault-root /path/to/vault --dry-run  # preview without writing
+kairix vault health                                    # entity graph health check
+kairix vault health --json                             # machine-readable output
 ```
 
 ### Session briefing
 
 ```bash
-mnemosyne brief builder           # synthesise briefing for builder agent
-mnemosyne brief shape --budget 5000
+kairix brief builder           # synthesise briefing for builder agent
+kairix brief shape --budget 5000
 ```
 
 ### Auto-classification
 
 ```bash
-mnemosyne classify "We decided to use PostgreSQL for the jobs table"
+kairix classify "We decided to use PostgreSQL for the jobs table"
 # → type: decision, destination: <vault-root>/agent-knowledge/builder/decisions.md, confidence: 0.95
 
-mnemosyne classify "Use monkeypatching for Azure API calls in unit tests"
+kairix classify "Use monkeypatching for Azure API calls in unit tests"
 # → type: pattern, destination: <vault-root>/agent-knowledge/builder/patterns.md, confidence: 0.92
 ```
 
 ### Temporal
 
 ```bash
-mnemosyne temporal index          # index date-tagged chunks
-mnemosyne temporal query "decisions last week"
+kairix temporal index          # index date-tagged chunks
+kairix temporal query "decisions last week"
 ```
 
 ### Wikilinks
 
 ```bash
-mnemosyne wikilinks inject --vault /path/to/vault
-mnemosyne wikilinks audit
+kairix wikilinks inject --vault /path/to/vault
+kairix wikilinks audit
+```
+
+### Contradiction detection
+
+```bash
+kairix contradict check "We use PostgreSQL for all persistence" --top-k 5
+kairix contradict check "$(cat new-decision.md)" --threshold 0.7 --format json
+```
+
+### Curator health
+
+```bash
+kairix curator health          # entity graph health (Neo4j primary, entities.db fallback)
+kairix curator health --json
+```
+
+### MCP server
+
+```bash
+# Requires: pip install 'kairix[agents]'
+kairix mcp serve                            # stdio transport (Claude Desktop)
+kairix mcp serve --transport sse --port 8080  # SSE transport (HTTP)
 ```
 
 ### Benchmark
 
 ```bash
-mnemosyne benchmark run --suite suites/example.yaml --system hybrid --agent shape
-mnemosyne benchmark compare benchmark-results/run-2026-04-07.json
+kairix benchmark run --suite suites/example.yaml --system hybrid --agent shape
+kairix benchmark compare benchmark-results/run-2026-04-07.json
 ```
 
 ---
@@ -260,10 +304,10 @@ Tested against qmd@1.1.2. The embed module validates schema before writing. See 
 ```bash
 .venv/bin/pytest tests/           # unit + integration suite
 .venv/bin/pytest tests/embed/     # embed module only
-.venv/bin/python -m ruff check mnemosyne/ tests/
+.venv/bin/ruff check kairix/ tests/
 ```
 
-Coverage: 80% (unit + integration). See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, architecture, and PR process.
+Coverage: 82% (unit + integration). See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, architecture, and PR process.
 
 ---
 
@@ -275,7 +319,7 @@ See [PRIOR_ART.md](PRIOR_ART.md). Key inspirations: [QMD](https://github.com/tob
 
 ## Data Residency
 
-Vault content is sent to Azure OpenAI for embedding and synthesis only. No data is stored externally. All vectors and entity data live in SQLite on your own infrastructure. See [EVALUATION.md](EVALUATION.md) and [SECURITY.md](SECURITY.md) for detail.
+Vault content is sent to Azure OpenAI for embedding and synthesis only. No data is stored externally. All vectors and entity data live in SQLite and Neo4j on your own infrastructure. See [EVALUATION.md](EVALUATION.md) and [SECURITY.md](SECURITY.md) for detail.
 
 ---
 

--- a/env.example
+++ b/env.example
@@ -1,28 +1,28 @@
-# Mnemosyne environment configuration
+# Kairix environment configuration
 #
 # Usage:
-#   VM deployment:  cp env.example /opt/mnemosyne/service.env
-#                   # Edit values, then source in cron: source /opt/mnemosyne/service.env
+#   VM deployment:  cp env.example /opt/kairix/service.env
+#                   # Edit values, then source in cron: source /opt/kairix/service.env
 #
 #   Local testing:  cp env.example .env
 #                   # Edit values. .env is gitignored.
 #
 #   GitHub Actions: Set these as repository secrets in Settings → Secrets and variables → Actions
 #
-# Auth strategy: either set MNEMOSYNE_KV_NAME (fetch from Key Vault via managed identity)
+# Auth strategy: either set KAIRIX_KV_NAME (fetch from Key Vault via managed identity)
 # OR set AZURE_OPENAI_API_KEY + AZURE_OPENAI_ENDPOINT directly. Key Vault is recommended
 # for production; direct env vars are convenient for local dev and CI.
 
 # ── Key Vault (recommended for production) ───────────────────────────────────
 # Your Azure Key Vault name. Used by deploy.sh, the embed runner, and the
 # benchmark LLM judge to fetch Azure credentials at runtime.
-# Both KV_NAME (scripts) and MNEMOSYNE_KV_NAME (Python modules) are supported;
+# Both KV_NAME (scripts) and KAIRIX_KV_NAME (Python modules) are supported;
 # set both to the same value.
-MNEMOSYNE_KV_NAME=your-key-vault-name
+KAIRIX_KV_NAME=your-key-vault-name
 KV_NAME=your-key-vault-name
 
 # ── Azure OpenAI credentials (direct — bypasses Key Vault) ───────────────────
-# Set these instead of (or in addition to) MNEMOSYNE_KV_NAME.
+# Set these instead of (or in addition to) KAIRIX_KV_NAME.
 # When set, these take precedence over Key Vault secrets.
 # Useful for local dev and CI where managed identity is unavailable.
 AZURE_OPENAI_API_KEY=
@@ -34,22 +34,22 @@ AZURE_OPENAI_GPT4O_MINI_DEPLOYMENT=gpt-4o-mini
 
 # ── Paths ─────────────────────────────────────────────────────────────────────
 # Root of your Obsidian vault (QMD indexes this directory)
-MNEMOSYNE_VAULT_ROOT=/path/to/your/obsidian-vault
+KAIRIX_VAULT_ROOT=/path/to/your/obsidian-vault
 
 # Root of your agent workspace directories (one subdir per agent)
-# Structure: $MNEMOSYNE_WORKSPACE_ROOT/<agent>/memory/
-MNEMOSYNE_WORKSPACE_ROOT=/path/to/your/workspaces
+# Structure: $KAIRIX_WORKSPACE_ROOT/<agent>/memory/
+KAIRIX_WORKSPACE_ROOT=/path/to/your/workspaces
 
 # Top-level data directory — entities.db and logs go here by default
-MNEMOSYNE_DATA_DIR=/path/to/mnemosyne-data
+KAIRIX_DATA_DIR=/path/to/kairix-data
 
-# Override individual paths if you want them somewhere other than $MNEMOSYNE_DATA_DIR
-# MNEMOSYNE_ENTITIES_DB=/path/to/mnemosyne-data/entities.db
-# MNEMOSYNE_BRIEFING_DIR=/path/to/mnemosyne-data/briefing
-# MNEMOSYNE_SEARCH_LOG=/path/to/mnemosyne-data/logs/search.jsonl
+# Override individual paths if you want them somewhere other than $KAIRIX_DATA_DIR
+# KAIRIX_ENTITIES_DB=/path/to/kairix-data/entities.db
+# KAIRIX_BRIEFING_DIR=/path/to/kairix-data/briefing
+# KAIRIX_SEARCH_LOG=/path/to/kairix-data/logs/search.jsonl
 
 # Log directory used by deploy.sh and cron wrappers
-LOG_DIR=/path/to/mnemosyne-data/logs
+LOG_DIR=/path/to/kairix-data/logs
 
 # QMD cache directory (where index.sqlite lives)
 # Default: ~/.cache/qmd  — only set this if QMD was configured with a custom cache path
@@ -60,12 +60,12 @@ LOG_DIR=/path/to/mnemosyne-data/logs
 # SQLITE_VEC_PATH=/usr/local/lib/vec0.so
 
 # ── Optional toggles ──────────────────────────────────────────────────────────
-# Set to 1 to write raw search queries to $MNEMOSYNE_SEARCH_LOG (for analysis)
-# MNEMOSYNE_LOG_QUERIES=0
+# Set to 1 to write raw search queries to $KAIRIX_SEARCH_LOG (for analysis)
+# KAIRIX_LOG_QUERIES=0
 
 # Set to 1 to enable E2E tests against live Azure API (requires credentials above)
-# MNEMOSYNE_E2E=0
+# KAIRIX_E2E=0
 
 # ── Test overrides ────────────────────────────────────────────────────────────
 # Override entities.db path during testing (avoids touching production data)
-# MNEMOSYNE_TEST_DB=/tmp/mnemosyne-test.db
+# KAIRIX_TEST_DB=/tmp/kairix-test.db


### PR DESCRIPTION
## Summary

Comprehensive documentation pass to complete the mnemosyne → kairix rename. All user-facing docs now match the binary name and env var prefix.

## Changes

**README.md** — major update:
- All CLI examples updated (`kairix search`, `kairix embed`, `kairix vault crawl`, etc.)
- Architecture diagram: adds vault crawl pipeline, references Neo4j entity graph
- Capabilities table: adds `vault`, `mcp`, `curator`; marks `contradict` as shipped
- Benchmark numbers updated to R10: NDCG@10 0.5686, Hit@5 0.874, MRR@10 0.673
- Score trajectory: adds R9 and R10 rows
- Install path: `/opt/kairix` (was `/opt/mnemosyne`)
- Dev commands: `ruff check kairix/` (was `mnemosyne/`); coverage 82% (was 80%)
- Prerequisites: adds Neo4j Community Edition as optional

**OPERATIONS.md** — complete rename pass:
- All `.venv/bin/mnemosyne` → `.venv/bin/kairix`
- All `/data/mnemosyne/` → `/data/kairix/`
- All `/opt/mnemosyne/` → `/opt/kairix/`
- `MNEMOSYNE_*` env vars → `KAIRIX_*` throughout

**CONTRIBUTING.md** — architecture section rewritten:
- Full `kairix/` module layout with all current modules documented
- `KAIRIX_E2E` (was `QMD_E2E`)

**env.example** — all `MNEMOSYNE_*` → `KAIRIX_*`:
- `KAIRIX_KV_NAME`, `KAIRIX_VAULT_ROOT`, `KAIRIX_DATA_DIR`, etc.
- `/path/to/kairix-data` install path

## Test plan
- [x] No remaining `mnemosyne` references in README, OPERATIONS, CONTRIBUTING, env.example
- [x] All benchmark numbers verified against R10 results

🤖 Generated with [Claude Code](https://claude.com/claude-code)