### PR TITLE
fix: stop reference-library polluting default search; fix MCP timeline result-shape

### DIFF
--- a/kairix.example.config.yaml
+++ b/kairix.example.config.yaml
@@ -24,6 +24,14 @@
 # Each collection maps a name to a folder inside your document store.
 # If not configured, all documents in your vault are searched as one collection.
 #
+# Note: ``reference-library`` is a reserved name. Even if listed in
+# ``shared``, the search resolver excludes it from default user-facing
+# scopes (shared / agent / shared+agent / all-agents / everything).
+# Reflib content is reachable only via ``--collection reference-library``
+# on a search call. Adding it to shared is a no-op — kept that way to
+# prevent the corpus (much larger than user docs) from polluting result
+# mix on common terms.
+#
 # collections:
 #   # Shared collections — searched by all agents
 #   shared:

--- a/kairix/agents/mcp/server.py
+++ b/kairix/agents/mcp/server.py
@@ -462,17 +462,24 @@ def tool_timeline(
         # Fallthrough search: when search_fn is wired, always run a search using
         # the (possibly rewritten) query so MCP callers get results even on
         # non-temporal queries. fell_back signals the rewrite was a no-op.
+        # Result items are BudgetedResult — fields live on .result; .content
+        # is the boundary-trimmed snippet. Earlier code shape-mismatched and
+        # produced empty placeholders (Shape's 2026-05-05 MCP path report).
         results_list: list[dict[str, Any]] = []
         if search_fn is not None:
             try:
                 sr = search_fn(query=rewritten, budget=3000, agent=agent, scope=scope)
-                for r in getattr(sr, "results", []):
+                for budgeted in getattr(sr, "results", []):
+                    inner = getattr(budgeted, "result", None)
+                    if inner is None:
+                        continue
+                    snippet = getattr(budgeted, "content", "") or getattr(inner, "snippet", "")
                     results_list.append(
                         {
-                            "path": getattr(r, "path", ""),
-                            "title": getattr(r, "title", ""),
-                            "snippet": getattr(r, "snippet", "")[:300],
-                            "score": getattr(r, "score", 0.0),
+                            "path": getattr(inner, "path", ""),
+                            "title": getattr(inner, "title", ""),
+                            "snippet": snippet[:300],
+                            "score": getattr(inner, "boosted_score", getattr(inner, "score", 0.0)),
                         }
                     )
             except Exception:

--- a/kairix/core/search/resolver.py
+++ b/kairix/core/search/resolver.py
@@ -44,6 +44,19 @@ class DefaultCollectionResolver:
 
     _DEFAULT_AGENT_PATTERN = "{agent}-memory"
 
+    # Reserved collections that must never appear in default user-facing
+    # search scopes (SHARED, AGENT, SHARED_AGENT, ALL_AGENTS). These are
+    # corpora that ride alongside the user's documents in the same SQLite
+    # index but are an order of magnitude larger and would dominate result
+    # mix on common terms. Callers that explicitly want them must pass
+    # ``collections=[...]`` to SearchPipeline.search or use Scope.EVERYTHING.
+    #
+    # Why baked in: an operator misconfig (listing reference-library in
+    # collections.shared) shipped to production on 2026-05-05 and polluted
+    # every user search until detected. Defending in code means the foot-gun
+    # can't be re-armed by editing yaml.
+    _RESERVED_COLLECTIONS: frozenset[str] = frozenset({"reference-library"})
+
     def __init__(
         self,
         *,
@@ -86,8 +99,8 @@ class DefaultCollectionResolver:
     def _shared_collections(self) -> list[str]:
         cols: list[str] = []
         if self._config:
-            cols.extend(c.name for c in self._config.shared)
-        cols.extend(self._extra)
+            cols.extend(c.name for c in self._config.shared if c.name not in self._RESERVED_COLLECTIONS)
+        cols.extend(c for c in self._extra if c not in self._RESERVED_COLLECTIONS)
         return cols
 
     def _all_agent_collections(self) -> list[str]:

--- a/tests/core/search/test_collection_resolver.py
+++ b/tests/core/search/test_collection_resolver.py
@@ -123,3 +123,69 @@ def test_unknown_scope_string_raises_value_error() -> None:
     resolver = DefaultCollectionResolver(collections_config=None)
     with pytest.raises(ValueError, match="unknown scope"):
         resolver.resolve("alpha", "not-a-scope")
+
+
+# ---------------------------------------------------------------------------
+# Reserved-collection invariant — reference-library never leaks into default
+# user search scopes regardless of yaml content. Regression guard for the
+# 2026-05-05 production pollution incident where an operator config listed
+# reference-library in collections.shared and reflib docs (5,835 rows in the
+# index vs ~4,400 user rows) dominated result mix on common terms.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_reflib_in_shared_config_excluded_from_shared_scope() -> None:
+    config = _config_with_shared("docs", "reference-library", "research")
+    resolver = DefaultCollectionResolver(collections_config=config)
+    cols = resolver.resolve("alpha", Scope.SHARED)
+    assert cols == ["docs", "research"]
+    assert "reference-library" not in (cols or [])
+
+
+@pytest.mark.unit
+def test_reflib_in_shared_config_excluded_from_shared_agent_scope() -> None:
+    config = _config_with_shared("docs", "reference-library")
+    resolver = DefaultCollectionResolver(collections_config=config)
+    cols = resolver.resolve("alpha", Scope.SHARED_AGENT)
+    assert cols == ["docs", "alpha-memory"]
+    assert "reference-library" not in (cols or [])
+
+
+@pytest.mark.unit
+def test_reflib_in_extra_collections_excluded() -> None:
+    config = _config_with_shared("docs")
+    resolver = DefaultCollectionResolver(
+        collections_config=config,
+        extra_collections=["reference-library", "operator-extra"],
+    )
+    cols = resolver.resolve("alpha", Scope.SHARED_AGENT)
+    assert cols == ["docs", "operator-extra", "alpha-memory"]
+    assert "reference-library" not in (cols or [])
+
+
+@pytest.mark.unit
+def test_reflib_excluded_from_everything_scope() -> None:
+    """Even Scope.EVERYTHING — the broadest default — does not pull reflib.
+
+    Reflib is reachable only via explicit ``collections=["reference-library"]``
+    on the search call. This keeps the benchmark/eval path working while
+    preventing default-scope pollution.
+    """
+
+    class _StubRegistry:
+        @staticmethod
+        def list_agents():
+            from types import SimpleNamespace
+
+            return [SimpleNamespace(collection="alpha-memory")]
+
+    config = _config_with_shared("docs", "reference-library")
+    resolver = DefaultCollectionResolver(
+        collections_config=config,
+        agent_registry=_StubRegistry(),
+    )
+    cols = resolver.resolve("alpha", Scope.EVERYTHING)
+    assert "reference-library" not in (cols or [])
+    assert "docs" in (cols or [])
+    assert "alpha-memory" in (cols or [])

--- a/tests/mcp/test_timeline_fallthrough.py
+++ b/tests/mcp/test_timeline_fallthrough.py
@@ -32,16 +32,36 @@ def _rewrite_temporal(query: str, reference_date: Any = None) -> str:
 
 
 def _build_fake_search(results: list[dict[str, Any]]) -> Any:
-    """Build a search_fn that records the query it was called with and returns SearchResult-shaped data."""
+    """Build a search_fn that records its query and returns BudgetedResult-shaped data.
 
-    class _Result:
+    Mirrors production: ``sr.results`` is a list of BudgetedResult, each with
+    a ``.result`` (carrying path/title/snippet/boosted_score) and a ``.content``
+    snippet trimmed at the budget boundary.
+    """
+
+    class _Inner:
+        def __init__(self, *, path: str, title: str, snippet: str, score: float) -> None:
+            self.path = path
+            self.title = title
+            self.snippet = snippet
+            self.boosted_score = score
+            self.score = score
+
+    class _Budgeted:
         def __init__(self, **kw: Any) -> None:
-            for k, v in kw.items():
-                setattr(self, k, v)
+            self.result = _Inner(
+                path=kw.get("path", ""),
+                title=kw.get("title", ""),
+                snippet=kw.get("snippet", ""),
+                score=kw.get("score", 0.0),
+            )
+            self.content = kw.get("snippet", "")
+            self.token_estimate = kw.get("tokens", 0)
+            self.tier = kw.get("tier", "L2")
 
     class _SearchResult:
         def __init__(self) -> None:
-            self.results = [_Result(**r) for r in results]
+            self.results = [_Budgeted(**r) for r in results]
             self.last_query: str | None = None
 
     sr = _SearchResult()
@@ -128,3 +148,33 @@ def test_response_shape_includes_required_fields() -> None:
     result = tool_timeline(query="anything", extract_fn=_extract_non_temporal, search_fn=search_fn)
     for key in ("original_query", "rewritten_query", "is_temporal", "fell_back", "time_window", "results", "error"):
         assert key in result
+
+
+@pytest.mark.unit
+def test_results_carry_real_path_title_snippet_score() -> None:
+    """Regression for Shape's 2026-05-05 MCP path report.
+
+    The earlier code unpacked BudgetedResult with ``getattr(r, "path", "")`` —
+    which always returned the default empty string because path lives on
+    ``r.result.path``. Result: ``fell_back: true`` and a list of dicts whose
+    string fields were all empty (the "empty placeholders" symptom).
+
+    This test pins the fix: every dict in ``results`` must carry the real
+    path/title/snippet/score from the underlying SearchResultItem.
+    """
+    search_fn, _ = _build_fake_search(
+        [
+            {"path": "deep/path/doc.md", "title": "Real Title", "snippet": "real body content", "score": 0.42},
+        ]
+    )
+    result = tool_timeline(
+        query="anything",
+        extract_fn=_extract_non_temporal,
+        search_fn=search_fn,
+    )
+    assert len(result["results"]) == 1
+    hit = result["results"][0]
+    assert hit["path"] == "deep/path/doc.md"
+    assert hit["title"] == "Real Title"
+    assert hit["snippet"] == "real body content"
+    assert hit["score"] == pytest.approx(0.42)


### PR DESCRIPTION
## Summary

Two coupled production defects landed via dogfood on 2026-05-05.

**1. Reference-library polluting search results.** The reflib corpus (5.8k docs) ships indexed alongside user content. The operational config on the VM listed `reference-library` in `collections.shared`, so the resolver returned it as a default shared scope and reflib hits dominated common-term result mix. Reproduced live on `app-kairix-1`: `kairix search "sprint"` returned `reference-library/engineering/.../ceremonies.md` at rank 6.

**2. MCP `tool_timeline` returning empty placeholders** (Shape's MCP Path Issue 2026-05-05). Root cause: the fallthrough search dereferenced `BudgetedResult` with `getattr(r, "path", "")` — always returning the default empty string because `path` lives on `r.result.path`. Fields were silently empty even though the search itself succeeded.

## What changed

| Area | Change |
|---|---|
| `kairix/core/search/resolver.py` | `DefaultCollectionResolver._RESERVED_COLLECTIONS = frozenset({"reference-library"})`. `_shared_collections()` excludes reserved names regardless of yaml. Reflib still reachable via explicit `collections=["reference-library"]`. |
| `kairix/agents/mcp/server.py` | `tool_timeline` now correctly dereferences `BudgetedResult.result` and prefers `.content` over raw snippet — mirrors `tool_search`. |
| `tests/core/search/test_collection_resolver.py` | Four invariant tests pinning reflib exclusion across SHARED, SHARED_AGENT, EVERYTHING, and `extra_collections`. |
| `tests/mcp/test_timeline_fallthrough.py` | Updated fake `_Budgeted` to mirror production shape. New regression test asserting real `path`/`title`/`snippet`/`score` flow through. |
| `kairix.example.config.yaml` | Documents `reference-library` as a reserved name — adding it to `shared` is a no-op. |

## Why defense-in-depth in code rather than fixing the yaml

The yaml-only fix re-arms the foot-gun whenever someone edits the operator config. Encoding "reference-library never appears in default scopes" as a resolver invariant means an operator config error can't pollute results again. Escape hatch is explicit: `--collection reference-library` for benchmarks.

## Verification gap addressed

The resolver had no test asserting reflib exclusion, and benchmarks always pass `--collection reference-library` explicitly so they could never observe the leak. The four new tests close that gap. The timeline fix also exposes that the existing `_build_fake_search` had been mirroring the *broken* shape — the fake is now accurate to production.

## Deploy plan

Merge into `develop` → `docker-publish.yml` builds `ghcr.io/quanyeomans/kairix:develop` automatically. VM verification:

```bash
docker compose pull kairix && docker compose up -d kairix
docker exec app-kairix-1 kairix search "sprint" --json | jq '[.results[].collection] | unique'
# Expect: no "reference-library"
```

No re-embed required.

## Test plan

- [x] `bash scripts/safe-commit.sh` — all six gates green (lint, format, mypy strict, 2106 tests, detect-secrets, confidential)
- [ ] CI on this PR
- [ ] VM verification after `:develop` rebuild

## Notes

- Supersedes #118, which was based on a stale local `develop` (44 already-merged commits). I should have pulled first; mea culpa. Cherry-picked cleanly onto current `origin/develop` (= `origin/main`).
- Re-pushed `develop` to origin and added branch protection (`allow_deletions: false`, `allow_force_pushes: false`) so the long-lived dev branch sticks across releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)