### PR TITLE
sec: resolve SonarCloud BLOCKER path-traversal vulnerabilities (S2083)

### DIFF
--- a/kairix/quality/eval/cli.py
+++ b/kairix/quality/eval/cli.py
@@ -135,8 +135,16 @@ def _cmd_report(args: argparse.Namespace) -> int:
     if args.output:
         from pathlib import Path
 
-        Path(args.output).write_text(report, encoding="utf-8")
-        print(f"Report written to {args.output}")
+        output_path = Path(args.output).expanduser().resolve()
+        if not output_path.parent.exists():
+            print(
+                f"Error: parent directory {output_path.parent} does not exist",
+                file=sys.stderr,
+            )
+            return 1
+        # NOSONAR(python:S2083): CLI trust boundary — --output is user-supplied; local process trust model applies.
+        output_path.write_text(report, encoding="utf-8")
+        print(f"Report written to {output_path}")
     else:
         print(report)
 

--- a/kairix/quality/eval/cli.py
+++ b/kairix/quality/eval/cli.py
@@ -142,7 +142,8 @@ def _cmd_report(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
             return 1
-        # NOSONAR(python:S2083): CLI trust boundary — --output is user-supplied; local process trust model applies.
+        # NOSONAR(python:S2083): CLI trust boundary — --output is
+        # user-supplied; local process trust model applies.
         output_path.write_text(report, encoding="utf-8")
         print(f"Report written to {output_path}")
     else:

--- a/scripts/migrate-domain-structure.py
+++ b/scripts/migrate-domain-structure.py
@@ -105,7 +105,8 @@ def rewrite_imports_in_file(filepath: Path, dry_run: bool = False) -> list[str]:
                 new_content = updated
 
     if changes and not dry_run:
-        # NOSONAR(python:S2083): internal one-shot migration script; filepath is from local rglob over the package root, never user input.
+        # NOSONAR(python:S2083): internal one-shot migration script;
+        # filepath is from rglob over the package root, never user input.
         filepath.write_text(new_content, encoding="utf-8")
 
     return changes

--- a/scripts/migrate-domain-structure.py
+++ b/scripts/migrate-domain-structure.py
@@ -105,6 +105,7 @@ def rewrite_imports_in_file(filepath: Path, dry_run: bool = False) -> list[str]:
                 new_content = updated
 
     if changes and not dry_run:
+        # NOSONAR(python:S2083): internal one-shot migration script; filepath is from local rglob over the package root, never user input.
         filepath.write_text(new_content, encoding="utf-8")
 
     return changes


### PR DESCRIPTION
## Summary

Resolves the two SonarCloud BLOCKER VULN findings (rule \`pythonsecurity:S2083\` — "construct path from user-controlled data") that gate v2026.5.4 promotion.

| Site | Type | Mitigation |
|---|---|---|
| \`kairix/quality/eval/cli.py:138\` | CLI \`--output\` argument writes a report to a user-supplied path | Resolve the path, guard parent directory exists, NOSONAR with documented CLI trust boundary |
| \`scripts/migrate-domain-structure.py:108\` | Internal one-shot migration script | NOSONAR with rationale — \`filepath\` is from local \`rglob\` over the package root, never user input |

Both are CLI/script trust-boundary cases — local process trust model applies. The suppressions are explicit and rationale-bearing rather than blanket, so future audits see the reasoning.

## Why this matters

These two BLOCKERs were the only thing keeping the SonarCloud quality gate from passing on the v2026.5.4 release commit. Clearing them unblocks promotion.

## Test plan

- [x] \`bash scripts/safe-commit.sh\` — all six gates green (lint, format, mypy strict, 2106 tests, detect-secrets, confidential)
- [ ] CI on this PR
- [ ] SonarCloud quality gate passes on PR — zero BLOCKER VULN findings

## Notes

- 23 MEDIUM hotspots and 26 LOW hotspots remain. Tracked as SEC-002 / SEC-003 on the BOARD for Release +1 — not in scope for this hotfix-style PR.
- SonarCloud may still report the issues if it doesn't honour \`# NOSONAR(python:S2083)\` comments; if so, the resolution path is to mark them as Reviewed/Safe in the SonarCloud UI with the same rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)