### PR TITLE
fix: benchmark crash on date-shaped gold titles (#103)

### DIFF
--- a/kairix/quality/benchmark/suite.py
+++ b/kairix/quality/benchmark/suite.py
@@ -166,6 +166,28 @@ def derive_gold_path_from_gold_lists(
     return None
 
 
+def _coerce_gold_list(items: list[dict] | None, ref_field: str) -> list[dict] | None:
+    """Coerce the ref-field of each item in a gold list to ``str``.
+
+    PyYAML parses unquoted ISO-shaped values like ``2026-04-07`` as
+    ``datetime.date`` objects. Downstream scoring calls ``.endswith(".md")``
+    on these refs, which raises AttributeError on date objects. Coerce here
+    at the suite-load boundary so scoring sees only strings.
+    """
+    if not isinstance(items, list):
+        return None
+    coerced: list[dict] = []
+    for item in items:
+        if not isinstance(item, dict):
+            coerced.append(item)
+            continue
+        new_item = dict(item)
+        if ref_field in new_item and new_item[ref_field] is not None:
+            new_item[ref_field] = str(new_item[ref_field])
+        coerced.append(new_item)
+    return coerced
+
+
 def build_benchmark_case(
     i: int,
     case_id: str | None,
@@ -189,9 +211,9 @@ def build_benchmark_case(
         score_method=str(score_method) if score_method else "",
         notes=str(notes) if notes else None,
         expected_type=str(expected_type) if expected_type else None,
-        gold_paths=gold_paths if isinstance(gold_paths, list) else None,
+        gold_paths=_coerce_gold_list(gold_paths, "path"),
         gold_title=str(gold_title) if gold_title else None,
-        gold_titles=gold_titles if isinstance(gold_titles, list) else None,
+        gold_titles=_coerce_gold_list(gold_titles, "title"),
         agent=str(case_agent) if case_agent else None,
     )
 

--- a/tests/benchmark/test_suite.py
+++ b/tests/benchmark/test_suite.py
@@ -821,3 +821,65 @@ def test_gold_titles_highest_relevance_derives_gold_path(tmp_path: Path) -> None
     suite = load_suite(str(p))
     # gold_path derived from the relevance-2 entry
     assert suite.cases[0].gold_path == "projects"
+
+
+def test_gold_titles_with_unquoted_iso_date_coerces_to_str(tmp_path: Path) -> None:
+    """Regression for #103. PyYAML parses unquoted ISO date titles as datetime.date,
+    which crashes downstream scoring (str.endswith on a date object).
+
+    The suite loader must coerce title/path refs to str at the boundary."""
+    import textwrap
+
+    from kairix.quality.benchmark.suite import load_suite
+
+    content = textwrap.dedent("""\
+        meta:
+          name: dated
+          version: "1.0"
+        cases:
+          - id: D01
+            category: recall
+            query: "what happened on this day"
+            score_method: ndcg
+            gold_titles:
+              - title: 2026-04-07
+                relevance: 2
+              - title: 2026-04-08
+                relevance: 1
+    """)
+    p = tmp_path / "dated-suite.yaml"
+    p.write_text(content)
+
+    suite = load_suite(str(p))
+    case = suite.cases[0]
+    assert case.gold_titles is not None
+    assert all(isinstance(g["title"], str) for g in case.gold_titles)
+    assert case.gold_titles[0]["title"] == "2026-04-07"
+
+
+def test_gold_paths_with_unquoted_iso_date_coerces_to_str(tmp_path: Path) -> None:
+    """Regression for #103. Same coercion guarantee for gold_paths."""
+    import textwrap
+
+    from kairix.quality.benchmark.suite import load_suite
+
+    content = textwrap.dedent("""\
+        meta:
+          name: dated
+          version: "1.0"
+        cases:
+          - id: D02
+            category: recall
+            query: "what happened on this day"
+            score_method: ndcg
+            gold_paths:
+              - path: 2026-04-07
+                relevance: 2
+    """)
+    p = tmp_path / "dated-suite.yaml"
+    p.write_text(content)
+
+    suite = load_suite(str(p))
+    case = suite.cases[0]
+    assert case.gold_paths is not None
+    assert all(isinstance(g["path"], str) for g in case.gold_paths)


### PR DESCRIPTION
## Summary

PyYAML parses unquoted ISO-shaped values like \`2026-04-07\` as \`datetime.date\` objects. Downstream scoring in \`kairix/quality/eval/metrics.py\` calls \`.endswith('.md')\` on these refs and crashes with \`AttributeError\`. The bundled \`suites/example.yaml\` itself triggers this because it uses dated note titles without quoting — first-run quick-start broken.

## Fix

Coerce ref fields to \`str\` at the suite-load boundary in \`build_benchmark_case\`:

\`\`\`python
def _coerce_gold_list(items: list[dict] | None, ref_field: str) -> list[dict] | None:
    if not isinstance(items, list):
        return None
    coerced: list[dict] = []
    for item in items:
        if not isinstance(item, dict):
            coerced.append(item)
            continue
        new_item = dict(item)
        if ref_field in new_item and new_item[ref_field] is not None:
            new_item[ref_field] = str(new_item[ref_field])
        coerced.append(new_item)
    return coerced
\`\`\`

Single source of truth at the boundary — downstream scorers see only strings.

## Test plan

- [x] Two regression tests in \`tests/benchmark/test_suite.py\`: unquoted ISO dates in \`gold_titles\` and \`gold_paths\` load without crash; refs are \`str\`-typed after load.
- [x] \`safe-commit.sh\` clean: 2106 tests pass.
- [ ] Smoke test on VM: \`docker exec app-kairix-1 kairix benchmark run --suite /opt/kairix/suites/example.yaml\` completes without \`AttributeError\` (after this lands on \`:develop\`).

Closes #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)