### PR TITLE
feat(WS3-5-114): per-document agent_owner tagging + DB migration (#114)

### DIFF
--- a/kairix/core/db/scanner.py
+++ b/kairix/core/db/scanner.py
@@ -20,6 +20,7 @@ Usage::
 
 import logging
 import sqlite3
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -28,6 +29,11 @@ from kairix.knowledge.reflib.dedup import hash_content as _hash_content
 from kairix.text import extract_title
 
 logger = logging.getLogger(__name__)
+
+# Type alias for the per-path agent resolver. Given a (collection, rel_path)
+# pair the resolver returns the agent name that owns the document, or None
+# for documents not under any agent's write_path (treated as shared).
+AgentOwnerResolver = Callable[[str, str], str | None]
 
 
 @dataclass
@@ -71,9 +77,16 @@ class DocumentScanner:
     and only updates modified documents.
     """
 
-    def __init__(self, db: sqlite3.Connection, document_root: Path | None = None) -> None:
+    def __init__(
+        self,
+        db: sqlite3.Connection,
+        document_root: Path | None = None,
+        *,
+        agent_owner_resolver: AgentOwnerResolver | None = None,
+    ) -> None:
         self._db = db
         self._document_root = document_root or Path.home() / "Documents"
+        self._agent_owner_resolver = agent_owner_resolver
 
     def scan(self, collections: list[CollectionConfig]) -> ScanReport:
         """
@@ -134,17 +147,24 @@ class DocumentScanner:
             )
             return
 
+        agent_owner = (
+            self._agent_owner_resolver(config.name, rel_path) if self._agent_owner_resolver is not None else None
+        )
+
         self._db.execute(
             """
-            INSERT INTO documents (collection, path, title, hash, created_at, modified_at, active)
-            VALUES (?, ?, ?, ?, ?, ?, 1)
+            INSERT INTO documents (
+                collection, path, title, hash, created_at, modified_at, active, agent_owner
+            )
+            VALUES (?, ?, ?, ?, ?, ?, 1, ?)
             ON CONFLICT(collection, path) DO UPDATE SET
                 title = excluded.title,
                 hash = excluded.hash,
                 modified_at = excluded.modified_at,
-                active = 1
+                active = 1,
+                agent_owner = excluded.agent_owner
             """,
-            (config.name, rel_path, title, content_hash, now, now),
+            (config.name, rel_path, title, content_hash, now, now, agent_owner),
         )
         self._db.execute(
             "INSERT OR REPLACE INTO content (hash, doc, created_at) VALUES (?, ?, ?)",

--- a/kairix/core/db/schema.py
+++ b/kairix/core/db/schema.py
@@ -46,6 +46,7 @@ def create_schema(db: sqlite3.Connection, *, dims: int = EMBED_VECTOR_DIMS) -> N
             created_at TEXT,
             modified_at TEXT,
             active INTEGER DEFAULT 1,
+            agent_owner TEXT,
             UNIQUE(collection, path)
         );
 
@@ -73,6 +74,7 @@ def create_schema(db: sqlite3.Connection, *, dims: int = EMBED_VECTOR_DIMS) -> N
         CREATE INDEX IF NOT EXISTS idx_documents_hash ON documents(hash);
         CREATE INDEX IF NOT EXISTS idx_documents_collection ON documents(collection);
         CREATE INDEX IF NOT EXISTS idx_documents_active ON documents(active);
+        CREATE INDEX IF NOT EXISTS idx_documents_agent_owner ON documents(agent_owner);
         CREATE INDEX IF NOT EXISTS idx_content_vectors_chunk_date ON content_vectors(chunk_date);
     """)
 
@@ -155,13 +157,25 @@ def migrate(db: sqlite3.Connection) -> None:
         db.commit()
         logger.info("db.schema: migration — added chunk_date column to content_vectors")
 
-    # Ensure indexes exist (idempotent) — only if the tables exist
+    # agent_owner migration — per-document agent provenance for #114.
+    # Existing rows get NULL (treated as shared / not agent-owned) until a
+    # `kairix embed --backfill-agent-owner` pass re-applies the path → agent
+    # mapping from the configured AgentRegistry.
     tables = {row[0] for row in db.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    if "documents" in tables:
+        existing_doc = {row[1] for row in db.execute("PRAGMA table_info(documents)")}
+        if "agent_owner" not in existing_doc:
+            db.execute("ALTER TABLE documents ADD COLUMN agent_owner TEXT")
+            db.commit()
+            logger.info("db.schema: migration — added agent_owner column to documents")
+
+    # Ensure indexes exist (idempotent) — only if the tables exist
     if "documents" in tables:
         db.executescript("""
             CREATE INDEX IF NOT EXISTS idx_documents_hash ON documents(hash);
             CREATE INDEX IF NOT EXISTS idx_documents_collection ON documents(collection);
             CREATE INDEX IF NOT EXISTS idx_documents_active ON documents(active);
+            CREATE INDEX IF NOT EXISTS idx_documents_agent_owner ON documents(agent_owner);
         """)
     if "content_vectors" in tables:
         db.execute("CREATE INDEX IF NOT EXISTS idx_content_vectors_chunk_date ON content_vectors(chunk_date)")

--- a/kairix/core/embed/cli.py
+++ b/kairix/core/embed/cli.py
@@ -126,11 +126,30 @@ def cmd_embed(args: argparse.Namespace) -> int:
             # Scan document store for new/changed documents before embedding.
             # This ensures first-run embed works without a separate scan step.
             from kairix.core.db.scanner import CollectionConfig, DocumentScanner
-            from kairix.core.search.config_loader import load_collections
+            from kairix.core.search.config_loader import _resolve_config_path, load_collections
+            from kairix.core.search.registry import build_agent_owner_resolver, parse_agent_registry
             from kairix.paths import document_root
 
             droot = document_root()
-            scanner = DocumentScanner(db, document_root=droot)
+
+            # Build agent_owner resolver from the agents: section of kairix.config.yaml
+            # so each scanned document is tagged with its owning agent (#114).
+            # Documents not under any agent's write_path get agent_owner=NULL.
+            agent_resolver = None
+            try:
+                config_path = _resolve_config_path()
+                if config_path is not None:
+                    import yaml as _yaml
+
+                    with config_path.open(encoding="utf-8") as _f:
+                        _raw_yaml = _yaml.safe_load(_f) or {}
+                    _registry = parse_agent_registry(_raw_yaml)
+                    if _registry.list_agents():
+                        agent_resolver = build_agent_owner_resolver(_registry)
+            except Exception as _exc:
+                logging.warning("embed: agent_owner resolver unavailable — %s", _exc)
+
+            scanner = DocumentScanner(db, document_root=droot, agent_owner_resolver=agent_resolver)
 
             # Load collections from config; fall back to scanning entire document root
             collections_cfg = load_collections()

--- a/kairix/core/search/registry.py
+++ b/kairix/core/search/registry.py
@@ -28,6 +28,7 @@ the misconfiguration is loud, not silent.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 
 
@@ -73,6 +74,35 @@ class ConfigDrivenAgentRegistry:
         if not agent.write_path:
             return False
         return path == agent.write_path or path.startswith(agent.write_path.rstrip("/") + "/")
+
+
+def build_agent_owner_resolver(
+    registry: ConfigDrivenAgentRegistry,
+) -> Callable[[str, str], str | None]:
+    """Build the (collection, rel_path) → agent_name resolver for the embed scanner.
+
+    The resolver matches each scanned document against every agent's
+    ``write_path``. The longest-prefix match wins (so ``shared/foo`` doesn't
+    accidentally match an agent whose write_path is ``shared``). Documents
+    not under any agent's write_path return None and land in the database
+    with ``agent_owner=NULL`` (treated as shared).
+
+    Used by ``kairix/core/embed/cli.py`` to wire ``DocumentScanner`` with
+    per-document agent provenance (#114).
+    """
+    # Stable list snapshot at build time so tests / production both bind once.
+    agents = [a for a in registry.list_agents() if a.write_path]
+    # Sort by descending write_path length so longest match wins via "first hit".
+    agents.sort(key=lambda a: len(a.write_path), reverse=True)
+
+    def _resolve(_collection: str, rel_path: str) -> str | None:
+        for agent in agents:
+            wp = agent.write_path.rstrip("/")
+            if rel_path == wp or rel_path.startswith(wp + "/"):
+                return agent.name
+        return None
+
+    return _resolve
 
 
 def parse_agent_registry(data: dict, *, default_pattern: str = "{agent}-memory") -> ConfigDrivenAgentRegistry:

--- a/tests/bdd/steps/reflib_steps.py
+++ b/tests/bdd/steps/reflib_steps.py
@@ -31,24 +31,9 @@ def _build_fixture_db(db_path: Path) -> None:
     if db_path.exists():
         return  # already built
     db = sqlite3.connect(str(db_path))
-    db.executescript("""
-        CREATE TABLE IF NOT EXISTS documents (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            collection TEXT NOT NULL,
-            path TEXT NOT NULL,
-            title TEXT,
-            hash TEXT NOT NULL,
-            created_at TEXT,
-            modified_at TEXT,
-            active INTEGER DEFAULT 1,
-            UNIQUE(collection, path)
-        );
-        CREATE TABLE IF NOT EXISTS content (
-            hash TEXT PRIMARY KEY,
-            doc TEXT,
-            created_at TEXT
-        );
-    """)
+    from kairix.core.db.schema import create_schema
+
+    create_schema(db)
 
     scanner = DocumentScanner(db, document_root=FIXTURE_ROOT)
     collections = []

--- a/tests/core/search/test_agent_registry.py
+++ b/tests/core/search/test_agent_registry.py
@@ -105,3 +105,110 @@ def test_parse_agent_registry_skips_malformed_entries() -> None:
     }
     registry = parse_agent_registry(data)
     assert {a.name for a in registry.list_agents()} == {"alpha", "beta"}
+
+
+# ---------------------------------------------------------------------------
+# build_agent_owner_resolver — used by embed scanner for #114 tagging
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_resolver_returns_agent_for_path_under_write_path() -> None:
+    """A doc under an agent's write_path resolves to that agent's name."""
+    from kairix.core.search.registry import (
+        AgentDef,
+        ConfigDrivenAgentRegistry,
+        build_agent_owner_resolver,
+    )
+
+    registry = ConfigDrivenAgentRegistry(
+        agents=[
+            AgentDef(name="shape", collection="shape-memory", write_path="04-Agent-Knowledge/shape/memory"),
+            AgentDef(name="builder", collection="builder-memory", write_path="04-Agent-Knowledge/builder/memory"),
+        ]
+    )
+    resolver = build_agent_owner_resolver(registry)
+
+    assert resolver("agent-knowledge", "04-Agent-Knowledge/shape/memory/note.md") == "shape"
+    assert resolver("agent-knowledge", "04-Agent-Knowledge/builder/memory/log.md") == "builder"
+
+
+@pytest.mark.unit
+def test_resolver_returns_none_for_path_outside_any_write_path() -> None:
+    """Docs not under any agent's write_path resolve to None (shared)."""
+    from kairix.core.search.registry import (
+        AgentDef,
+        ConfigDrivenAgentRegistry,
+        build_agent_owner_resolver,
+    )
+
+    registry = ConfigDrivenAgentRegistry(
+        agents=[AgentDef(name="shape", collection="shape-memory", write_path="04-Agent-Knowledge/shape/memory")]
+    )
+    resolver = build_agent_owner_resolver(registry)
+    assert resolver("areas", "02-Areas/doc.md") is None
+    assert resolver("knowledge", "05-Knowledge/methods/method.md") is None
+
+
+@pytest.mark.unit
+def test_resolver_longest_prefix_wins() -> None:
+    """If two agents have nested write_paths, the longest prefix wins.
+
+    Prevents ``shared/foo`` accidentally matching agent whose write_path
+    is ``shared`` when a more specific agent owns ``shared/foo``.
+    """
+    from kairix.core.search.registry import (
+        AgentDef,
+        ConfigDrivenAgentRegistry,
+        build_agent_owner_resolver,
+    )
+
+    registry = ConfigDrivenAgentRegistry(
+        agents=[
+            AgentDef(name="general", collection="g", write_path="shared"),
+            AgentDef(name="specific", collection="s", write_path="shared/team-a"),
+        ]
+    )
+    resolver = build_agent_owner_resolver(registry)
+    assert resolver("c", "shared/team-a/note.md") == "specific"
+    assert resolver("c", "shared/team-b/note.md") == "general"
+
+
+@pytest.mark.unit
+def test_resolver_skips_agents_without_write_path() -> None:
+    """Agents with empty write_path are skipped — they own no specific docs."""
+    from kairix.core.search.registry import (
+        AgentDef,
+        ConfigDrivenAgentRegistry,
+        build_agent_owner_resolver,
+    )
+
+    registry = ConfigDrivenAgentRegistry(
+        agents=[
+            AgentDef(name="ghost", collection="g", write_path=""),
+            AgentDef(name="real", collection="r", write_path="memory/real"),
+        ]
+    )
+    resolver = build_agent_owner_resolver(registry)
+    assert resolver("c", "memory/real/log.md") == "real"
+    # The ghost agent doesn't claim anything; this matches no agent
+    assert resolver("c", "anything/else.md") is None
+
+
+@pytest.mark.unit
+def test_resolver_exact_path_match() -> None:
+    """A document at exactly the write_path itself (no trailing component) matches."""
+    from kairix.core.search.registry import (
+        AgentDef,
+        ConfigDrivenAgentRegistry,
+        build_agent_owner_resolver,
+    )
+
+    registry = ConfigDrivenAgentRegistry(agents=[AgentDef(name="shape", collection="s", write_path="shape-area")])
+    resolver = build_agent_owner_resolver(registry)
+    # Normally a directory, but support the edge case of write_path-as-file
+    assert resolver("c", "shape-area") == "shape"
+    # And the prefix case
+    assert resolver("c", "shape-area/sub/doc.md") == "shape"
+    # But not a sibling directory with the same prefix string
+    assert resolver("c", "shape-area-other/doc.md") is None

--- a/tests/db/test_scanner.py
+++ b/tests/db/test_scanner.py
@@ -10,7 +10,18 @@ from kairix.core.db.scanner import (
     ScanReport,
     _hash_content,
 )
+from kairix.core.db.schema import create_schema
 from kairix.knowledge.reflib.frontmatter import extract_title as _extract_title
+
+
+def _setup_schema(db: sqlite3.Connection) -> None:
+    """Build the production schema in a fresh in-memory DB.
+
+    Replaces the previous per-test hand-crafted CREATE TABLE so the test
+    schema is always a single source of truth with production. New columns
+    (e.g. ``agent_owner`` for #114) flow through automatically.
+    """
+    create_schema(db)
 
 
 @pytest.mark.unit
@@ -57,20 +68,7 @@ def test_scan_discovers_new_files(tmp_path: __import__("pathlib").Path) -> None:
     (area / "doc2.md").write_text("---\ntitle: Doc Two\n---\n\nContent of doc two.")
 
     db = sqlite3.connect(":memory:")
-    db.executescript("""
-        CREATE TABLE documents (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            collection TEXT NOT NULL,
-            path TEXT NOT NULL,
-            title TEXT,
-            hash TEXT NOT NULL,
-            created_at TEXT,
-            modified_at TEXT,
-            active INTEGER DEFAULT 1,
-            UNIQUE(collection, path)
-        );
-        CREATE TABLE content (hash TEXT PRIMARY KEY, doc TEXT, created_at TEXT);
-    """)
+    _setup_schema(db)
 
     scanner = DocumentScanner(db, vault)
     report = scanner.scan([CollectionConfig(name="vault-areas", path="02-Areas")])
@@ -94,15 +92,7 @@ def test_scan_detects_unchanged_files(tmp_path: __import__("pathlib").Path) -> N
     (area / "doc.md").write_text("# Stable\n\nUnchanged content.")
 
     db = sqlite3.connect(":memory:")
-    db.executescript("""
-        CREATE TABLE documents (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            collection TEXT NOT NULL, path TEXT NOT NULL, title TEXT,
-            hash TEXT NOT NULL, created_at TEXT, modified_at TEXT,
-            active INTEGER DEFAULT 1, UNIQUE(collection, path)
-        );
-        CREATE TABLE content (hash TEXT PRIMARY KEY, doc TEXT, created_at TEXT);
-    """)
+    _setup_schema(db)
 
     scanner = DocumentScanner(db, vault)
     r1 = scanner.scan([CollectionConfig(name="test", path="02-Areas")])
@@ -123,15 +113,7 @@ def test_scan_detects_updated_files(tmp_path: __import__("pathlib").Path) -> Non
     doc.write_text("# Version 1\n\nOriginal.")
 
     db = sqlite3.connect(":memory:")
-    db.executescript("""
-        CREATE TABLE documents (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            collection TEXT NOT NULL, path TEXT NOT NULL, title TEXT,
-            hash TEXT NOT NULL, created_at TEXT, modified_at TEXT,
-            active INTEGER DEFAULT 1, UNIQUE(collection, path)
-        );
-        CREATE TABLE content (hash TEXT PRIMARY KEY, doc TEXT, created_at TEXT);
-    """)
+    _setup_schema(db)
 
     scanner = DocumentScanner(db, vault)
     scanner.scan([CollectionConfig(name="test", path="02-Areas")])
@@ -154,15 +136,7 @@ def test_scan_marks_removed_files_inactive(
     doc.write_text("# Will Be Removed")
 
     db = sqlite3.connect(":memory:")
-    db.executescript("""
-        CREATE TABLE documents (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            collection TEXT NOT NULL, path TEXT NOT NULL, title TEXT,
-            hash TEXT NOT NULL, created_at TEXT, modified_at TEXT,
-            active INTEGER DEFAULT 1, UNIQUE(collection, path)
-        );
-        CREATE TABLE content (hash TEXT PRIMARY KEY, doc TEXT, created_at TEXT);
-    """)
+    _setup_schema(db)
 
     scanner = DocumentScanner(db, vault)
     scanner.scan([CollectionConfig(name="test", path="02-Areas")])
@@ -184,15 +158,7 @@ def test_scan_excludes_patterns(tmp_path: __import__("pathlib").Path) -> None:
     (area / "templates" / "tmpl.md").write_text("# Template")
 
     db = sqlite3.connect(":memory:")
-    db.executescript("""
-        CREATE TABLE documents (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            collection TEXT NOT NULL, path TEXT NOT NULL, title TEXT,
-            hash TEXT NOT NULL, created_at TEXT, modified_at TEXT,
-            active INTEGER DEFAULT 1, UNIQUE(collection, path)
-        );
-        CREATE TABLE content (hash TEXT PRIMARY KEY, doc TEXT, created_at TEXT);
-    """)
+    _setup_schema(db)
 
     scanner = DocumentScanner(db, vault)
     report = scanner.scan(
@@ -216,16 +182,6 @@ def test_scan_report_str() -> None:
 # Content-hash dedup across collections
 # ---------------------------------------------------------------------------
 
-_SCANNER_SCHEMA = """
-    CREATE TABLE documents (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        collection TEXT NOT NULL, path TEXT NOT NULL, title TEXT,
-        hash TEXT NOT NULL, created_at TEXT, modified_at TEXT,
-        active INTEGER DEFAULT 1, UNIQUE(collection, path)
-    );
-    CREATE TABLE content (hash TEXT PRIMARY KEY, doc TEXT, created_at TEXT);
-"""
-
 
 @pytest.mark.unit
 def test_scan_skips_duplicate_content_across_collections(
@@ -244,7 +200,7 @@ def test_scan_skips_duplicate_content_across_collections(
     (area_b / "shared.md").write_text(content)
 
     db = sqlite3.connect(":memory:")
-    db.executescript(_SCANNER_SCHEMA)
+    _setup_schema(db)
 
     scanner = DocumentScanner(db, vault)
     report = scanner.scan(
@@ -272,7 +228,7 @@ def test_scan_allows_update_to_existing_path(
     (area / "doc.md").write_text("# Version 1\n\nOriginal content.")
 
     db = sqlite3.connect(":memory:")
-    db.executescript(_SCANNER_SCHEMA)
+    _setup_schema(db)
 
     scanner = DocumentScanner(db, vault)
     r1 = scanner.scan([CollectionConfig(name="test", path="docs")])
@@ -287,3 +243,67 @@ def test_scan_allows_update_to_existing_path(
     # Content should be the new version
     row = db.execute("SELECT doc FROM content ORDER BY created_at DESC LIMIT 1").fetchone()
     assert "Version 2" in row[0]
+
+
+# ---------------------------------------------------------------------------
+# agent_owner tagging (#114)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_scan_tags_documents_with_agent_owner(
+    tmp_path: __import__("pathlib").Path,
+) -> None:
+    """Scanner tags rows with agent_owner from the injected resolver.
+
+    Documents under an agent's write_path get the agent name; documents
+    outside any write_path get NULL (treated as shared).
+    """
+    vault = tmp_path / "vault"
+    agent_root = vault / "04-Agent-Knowledge" / "shape" / "memory"
+    shared_root = vault / "02-Areas"
+    agent_root.mkdir(parents=True)
+    shared_root.mkdir(parents=True)
+    (agent_root / "note.md").write_text("# Shape memory note")
+    (shared_root / "doc.md").write_text("# Shared doc")
+
+    def resolver(_collection: str, rel_path: str) -> str | None:
+        if rel_path.startswith("04-Agent-Knowledge/shape/"):
+            return "shape"
+        return None
+
+    db = sqlite3.connect(":memory:")
+    _setup_schema(db)
+
+    scanner = DocumentScanner(db, vault, agent_owner_resolver=resolver)
+    scanner.scan(
+        [
+            CollectionConfig(name="agent-knowledge", path="04-Agent-Knowledge"),
+            CollectionConfig(name="areas", path="02-Areas"),
+        ]
+    )
+
+    rows = db.execute("SELECT path, agent_owner FROM documents WHERE active = 1 ORDER BY path").fetchall()
+    by_path = dict(rows)
+    assert by_path["04-Agent-Knowledge/shape/memory/note.md"] == "shape"
+    assert by_path["02-Areas/doc.md"] is None
+
+
+@pytest.mark.unit
+def test_scan_with_no_resolver_leaves_agent_owner_null(
+    tmp_path: __import__("pathlib").Path,
+) -> None:
+    """When no resolver is injected, agent_owner is NULL for every row."""
+    vault = tmp_path / "vault"
+    area = vault / "02-Areas"
+    area.mkdir(parents=True)
+    (area / "doc.md").write_text("# Doc")
+
+    db = sqlite3.connect(":memory:")
+    _setup_schema(db)
+
+    scanner = DocumentScanner(db, vault)  # no agent_owner_resolver
+    scanner.scan([CollectionConfig(name="areas", path="02-Areas")])
+
+    row = db.execute("SELECT agent_owner FROM documents WHERE active = 1").fetchone()
+    assert row[0] is None

--- a/tests/db/test_schema.py
+++ b/tests/db/test_schema.py
@@ -217,3 +217,83 @@ def test_create_schema_content_vectors_has_chunk_date() -> None:
     assert "hash" in cols
     assert "seq" in cols
     assert "model" in cols
+
+
+# ---------------------------------------------------------------------------
+# agent_owner column (#114)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_create_schema_includes_agent_owner_column() -> None:
+    """Fresh DB has agent_owner column on documents (default NULL)."""
+    db = sqlite3.connect(":memory:")
+    create_schema(db)
+
+    cols = {row[1] for row in db.execute("PRAGMA table_info(documents)")}
+    assert "agent_owner" in cols
+
+
+@pytest.mark.unit
+def test_create_schema_creates_agent_owner_index() -> None:
+    """Index idx_documents_agent_owner is created for filter performance."""
+    db = sqlite3.connect(":memory:")
+    create_schema(db)
+
+    indexes = {row[0] for row in db.execute("SELECT name FROM sqlite_master WHERE type='index'")}
+    assert "idx_documents_agent_owner" in indexes
+
+
+@pytest.mark.unit
+def test_migrate_adds_agent_owner_to_legacy_documents_table() -> None:
+    """A pre-#114 documents table without agent_owner gets migrated additively.
+
+    Existing rows survive with agent_owner=NULL.
+    """
+    db = sqlite3.connect(":memory:")
+    # Build the old schema (pre-agent_owner) and seed a row
+    db.executescript(
+        """
+        CREATE TABLE documents (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            collection TEXT NOT NULL,
+            path TEXT NOT NULL,
+            title TEXT,
+            hash TEXT NOT NULL,
+            created_at TEXT,
+            modified_at TEXT,
+            active INTEGER DEFAULT 1,
+            UNIQUE(collection, path)
+        );
+        CREATE TABLE content (hash TEXT PRIMARY KEY, doc TEXT, created_at TEXT);
+        CREATE TABLE content_vectors (
+            hash TEXT NOT NULL, seq INTEGER NOT NULL, pos INTEGER NOT NULL,
+            model TEXT, embedded_at TEXT,
+            PRIMARY KEY (hash, seq)
+        );
+        INSERT INTO documents (collection, path, title, hash, active)
+        VALUES ('areas', '02-Areas/legacy.md', 'Legacy Doc', 'h1', 1);
+        """
+    )
+
+    migrate(db)
+
+    cols = {row[1] for row in db.execute("PRAGMA table_info(documents)")}
+    assert "agent_owner" in cols
+
+    # Existing row preserved with agent_owner=NULL
+    row = db.execute("SELECT path, title, agent_owner FROM documents").fetchone()
+    assert row[0] == "02-Areas/legacy.md"
+    assert row[1] == "Legacy Doc"
+    assert row[2] is None
+
+
+@pytest.mark.unit
+def test_migrate_idempotent_on_agent_owner() -> None:
+    """Running migrate twice doesn't error (idempotent)."""
+    db = sqlite3.connect(":memory:")
+    create_schema(db)
+    migrate(db)
+    migrate(db)  # second call must not raise
+    cols = {row[1] for row in db.execute("PRAGMA table_info(documents)")}
+    assert "agent_owner" in cols

--- a/tests/integration/test_collections.py
+++ b/tests/integration/test_collections.py
@@ -13,28 +13,10 @@ pytestmark = pytest.mark.integration
 
 
 def _create_scanner_schema(db: sqlite3.Connection) -> None:
-    """Create minimal schema for DocumentScanner."""
-    db.executescript("""
-        CREATE TABLE IF NOT EXISTS documents (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            collection TEXT NOT NULL,
-            path TEXT NOT NULL,
-            title TEXT,
-            hash TEXT NOT NULL,
-            created_at TEXT,
-            modified_at TEXT,
-            active INTEGER DEFAULT 1,
-            UNIQUE(collection, path)
-        );
-        CREATE TABLE IF NOT EXISTS content (
-            hash TEXT PRIMARY KEY,
-            doc TEXT,
-            created_at TEXT
-        );
-        CREATE INDEX IF NOT EXISTS idx_documents_hash ON documents(hash);
-        CREATE INDEX IF NOT EXISTS idx_documents_collection ON documents(collection);
-        CREATE INDEX IF NOT EXISTS idx_documents_active ON documents(active);
-    """)
+    """Create the production schema (single source of truth with kairix.core.db.schema)."""
+    from kairix.core.db.schema import create_schema
+
+    create_schema(db)
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary

Adds first-class agent provenance to the \`documents\` table so per-agent collection isolation can move from path-glob YAML hacks to indexed metadata. Precondition for the multi-path agent collections refactor (#115).

## What changed

### Schema (\`kairix/core/db/schema.py\`)
- Additive nullable \`agent_owner TEXT\` column on \`documents\`.
- Idempotent \`ALTER TABLE\` in \`migrate()\` for legacy DBs; existing rows get \`NULL\`.
- New \`idx_documents_agent_owner\` index for filter performance.

### Scanner (\`kairix/core/db/scanner.py\`)
- \`DocumentScanner.__init__\` accepts \`agent_owner_resolver: Callable[[str, str], str | None] | None\`.
- INSERT/UPSERT writes \`agent_owner\` per document. \`ON CONFLICT\` refresh updates the column so a moved doc retags correctly.
- Default behaviour unchanged: no resolver → all rows have \`agent_owner=NULL\`.

### Registry (\`kairix/core/search/registry.py\`)
- New \`build_agent_owner_resolver(registry)\` factory.
- **Longest-prefix-match** semantics so \`shared/team-a\` wins over \`shared\`.
- Agents without \`write_path\` are skipped — they own no specific docs.

### Embed CLI (\`kairix/core/embed/cli.py\`)
- Loads the \`AgentRegistry\` at scan time via \`parse_agent_registry\`, builds the resolver, passes to \`DocumentScanner\`.
- Registry-load failure is a warning, not a hard error — embed still works (with NULL agent_owner) on deployments without an \`agents:\` section.

### Tests
- \`tests/db/test_scanner.py\` and \`tests/integration/test_collections.py\` refactored to use \`create_schema()\` instead of hand-crafted CREATE TABLE — single source of truth with production schema. New columns (\`agent_owner\` here, more later) flow through automatically.
- \`tests/db/test_scanner.py\`: two new agent_owner resolver wiring tests.
- \`tests/db/test_schema.py\`: column present on fresh DB, index created, \`migrate()\` additively adds column to legacy DBs without data loss, idempotent on repeated calls.
- \`tests/core/search/test_agent_registry.py\`: five resolver tests covering longest-prefix-match, no-write-path skip, exact-path match, sibling-prefix non-match.
- \`tests/bdd/steps/reflib_steps.py\`: same hand-crafted-schema → \`create_schema()\` swap.

## Note on \`agent_owner\` vs \`paths\` (relationship to #115)

Orthogonal. The resolver in #115 will route \`scope=agent\` queries via \`collection IN (...)\` (collection-based, from \`paths\`). \`agent_owner\` is for ad-hoc filters and provenance — they coexist cleanly.

## Test plan

- [x] 2117 unit/bdd/contract tests pass.
- [x] mypy strict clean.
- [x] ruff lint + format clean.
- [ ] CI on this PR.
- [ ] Smoke test on VM after merge: \`docker exec app-kairix-1 kairix embed --backfill-agent-owner\` (next: file follow-up to add the \`--backfill-agent-owner\` flag, or run a one-shot SQL re-tag from the registry).

Closes #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)