### PR TITLE
docs: parameterised runbooks → repo (OPS-009 batch 1: vector-search-failure, embedding-lag, rebuild-entity-graph)

### DIFF
--- a/docs/operations/runbooks/INDEX.md
+++ b/docs/operations/runbooks/INDEX.md
@@ -8,6 +8,8 @@ Operational procedures and incident runbooks for kairix deployments.
 
 | Symptom | Runbook |
 |---|---|
+| `kairix search` returns `vec=0, vec_failed=True` | [runbook-vector-search-failure](runbook-vector-search-failure.md) |
+| New documents not appearing in search after the embed cycle | [runbook-embedding-lag](runbook-embedding-lag.md) |
 | Every `mcp-kairix__*` tool returns `-32602 Invalid request parameters` | [MCP-CLIENT-MIGRATION](../MCP-CLIENT-MIGRATION.md) — your client is on `/sse` and needs to move to `/mcp` |
 | NDCG@10 dropped after a config or index change | [runbook-benchmark-regression](runbook-benchmark-regression.md) |
 | Specific queries scoring poorly | [how-to-debug-search-ranking](how-to-debug-search-ranking.md) |
@@ -20,6 +22,8 @@ Operational procedures and incident runbooks for kairix deployments.
 
 | Runbook | What it covers |
 |---|---|
+| [runbook-vector-search-failure](runbook-vector-search-failure.md) | `vec=0, vec_failed=True` — embed credentials, vector index integrity, no-vectors-yet |
+| [runbook-embedding-lag](runbook-embedding-lag.md) | New content not searchable — sync, embed pipeline failures, scheduled-run issues |
 | [runbook-benchmark-regression](runbook-benchmark-regression.md) | NDCG degraded — before/after comparison workflow and rollback |
 
 ---
@@ -31,6 +35,7 @@ Operational procedures and incident runbooks for kairix deployments.
 | [how-to-upgrade-kairix](how-to-upgrade-kairix.md) | Install tagged release, verify, run onboard check |
 | [how-to-run-benchmark](how-to-run-benchmark.md) | Run benchmark suite, interpret results, compare before/after |
 | [how-to-debug-search-ranking](how-to-debug-search-ranking.md) | Query intent dispatch, RRF weights, category-specific tuning |
+| [how-to-rebuild-entity-graph](how-to-rebuild-entity-graph.md) | Drop and rebuild the Neo4j entity graph from the document store |
 | [MCP-DEPLOYMENT](../MCP-DEPLOYMENT.md) | Choose a transport (stdio/http/sse), wire `/mcp` and `/sse` mounts, configure agent registry, verify with `/healthz` |
 | [MCP-CLIENT-MIGRATION](../MCP-CLIENT-MIGRATION.md) | Migrate Claude Desktop / Claude Code / OpenClaw / custom Python or Node clients from `/sse` to `/mcp` |
 

--- a/docs/operations/runbooks/how-to-rebuild-entity-graph.md
+++ b/docs/operations/runbooks/how-to-rebuild-entity-graph.md
@@ -1,0 +1,142 @@
+# How-to — Rebuild the entity graph from scratch
+
+**When to use:** Neo4j entity graph is corrupted, significantly out of sync, or after a document-store restructure that invalidated large numbers of wikilinks. **Not** for normal staleness — use the incremental crawler instead.
+
+**Time:** 2-10 minutes depending on document store size.
+
+**Warning:** Drops all entities and relationships from the graph. Production retrieval that relies on entity boost will degrade until the rebuild completes.
+
+---
+
+## Configure for your environment
+
+| Reference | Substitute with |
+|---|---|
+| `${KAIRIX_DOCUMENT_ROOT}` | `kairix.config.yaml` `paths.document_root`, or `KAIRIX_DOCUMENT_ROOT` env var |
+| `${KAIRIX_NEO4J_URI}` | `bolt://<host>:7687`, set in your env or secrets |
+| `${KAIRIX_NEO4J_USER}` | typically `neo4j` |
+| `${KAIRIX_NEO4J_PASSWORD}` | from your secrets pipeline |
+
+If kairix is in Docker, prefix host commands with `docker exec <container-name>`.
+
+## Architecture
+
+Entity data lives in Neo4j. Kairix populates Neo4j by walking the document store and extracting `[[wikilink]]` references — one entity node per unique wikilink target, one `MENTIONS` edge per occurrence. The crawler is `kairix store crawl`.
+
+The kairix SQLite + usearch index is independent — search continues to work without Neo4j (entity boost is just disabled).
+
+## Before you start
+
+```bash
+# Confirm Neo4j is reachable
+kairix onboard check
+# Look for: "Neo4j: ✓ connected"
+
+# Snapshot the current entity count for comparison
+kairix store health
+# Note the entity count and relationship count.
+
+# Confirm the document store is current — your sync mechanism has propagated
+# any pending changes. If the doc store is stale, the rebuilt graph will
+# inherit that staleness.
+```
+
+## Step 1 — Stop any running crawler
+
+A partial crawl can leave orphan nodes. Either wait for any running crawler to complete, or fail-fast on its lockfile if your deployment uses one. Check whatever scheduler runs `kairix store crawl` periodically and pause it for the duration of the rebuild.
+
+```bash
+# Look for a running kairix store crawl
+pgrep -af "kairix store crawl" || echo "no crawler running"
+```
+
+## Step 2 — Drop all entities and relationships
+
+```bash
+# Using cypher-shell (requires Neo4j password)
+cypher-shell -a "${KAIRIX_NEO4J_URI}" -u "${KAIRIX_NEO4J_USER}" \
+             -p "${KAIRIX_NEO4J_PASSWORD}" \
+             "MATCH (n) DETACH DELETE n"
+
+# Verify: must return 0
+cypher-shell -a "${KAIRIX_NEO4J_URI}" -u "${KAIRIX_NEO4J_USER}" \
+             -p "${KAIRIX_NEO4J_PASSWORD}" \
+             "MATCH (n) RETURN count(n) AS remaining"
+# Expected: remaining = 0
+```
+
+If you don't have `cypher-shell` available, the kairix CLI can do this:
+
+```bash
+kairix store reset --confirm
+```
+
+(Subject to operator policy — `kairix store reset` is destructive and may be disabled in your deployment.)
+
+## Step 3 — Verify wikilinks exist in the document store
+
+Entity relationships come from `[[wikilink]]` syntax. If the document store has no wikilinks, the rebuilt graph will be empty.
+
+```bash
+# Count files containing wikilinks
+grep -rl '\[\[' "${KAIRIX_DOCUMENT_ROOT}" --include="*.md" 2>/dev/null | wc -l
+# A typical knowledge store has 50+ files with wikilinks.
+```
+
+If the count is unexpectedly low, the issue is content authoring rather than kairix — fix the document store content before rebuilding.
+
+## Step 4 — Run a full crawl
+
+```bash
+# Full document-store crawl, populating Neo4j
+kairix store crawl --full
+
+# Watch progress
+tail -f "${KAIRIX_DATA_DIR}/logs/store-crawl.log"
+
+# Healthy completion shows:
+#   "scanned N documents"
+#   "extracted M wikilinks"
+#   "seeded P entities"
+#   "created Q relationships"
+#   "completed in Xs"
+```
+
+The `--full` flag forces a complete re-crawl rather than the incremental hash-comparison mode.
+
+## Step 5 — Verify the rebuild
+
+```bash
+# Health check — entity counts must be > 0
+kairix store health
+# Expected: entity count > 0, relationship count > 0
+
+# Direct Cypher confirmation
+cypher-shell -a "${KAIRIX_NEO4J_URI}" -u "${KAIRIX_NEO4J_USER}" \
+             -p "${KAIRIX_NEO4J_PASSWORD}" \
+             "MATCH ()-[r]->() RETURN count(r) AS relationships"
+# Expected: > 0
+
+# Entity-enriched search smoke test — pick a topic with strong wikilink coverage
+kairix search "<a topic from your knowledge store>" --json \
+  | jq '.intent, .results[0]'
+# Entity-intent results should show entity context where applicable.
+
+# Full onboard check
+kairix onboard check
+# All ✓
+```
+
+## Post-rebuild — verify relationship quality
+
+If entity-enriched search shows no entity context for a topic you expect:
+
+1. Confirm the topic has wikilinks in the document store: `grep -rl '\[\[<Topic>\]\]' "${KAIRIX_DOCUMENT_ROOT}"`.
+2. Wikilink text must match what the crawler extracts — case-sensitive, exact match. If your wikilinks use display-text aliases (`[[canonical|display]]`), the canonical form is what's indexed.
+3. The crawler ignores wikilinks inside code fences and frontmatter — check the wikilinks aren't enclosed in either.
+
+## See also
+
+- `runbook-entity-graph-stale.md` — for incremental staleness; less invasive than a full rebuild.
+- `kairix entity suggest` — discover candidate entities from new content.
+- `kairix entity validate` — Wikidata cross-check on existing entities.

--- a/docs/operations/runbooks/runbook-embedding-lag.md
+++ b/docs/operations/runbooks/runbook-embedding-lag.md
@@ -1,0 +1,136 @@
+# Runbook — Embedding lag (new content not searchable)
+
+**Severity:** P2 — search results stale relative to the document store.
+
+**Symptom:** Documents added or modified more than your embed cycle ago (typically 15-60 minutes) don't appear in `kairix search` results. New chunks should land in `content_vectors` within one cycle of `kairix embed`.
+
+---
+
+## What's happening
+
+`kairix embed` is the pipeline that:
+
+1. Scans `${KAIRIX_DOCUMENT_ROOT}` for new/changed markdown files (`DocumentScanner`).
+2. Hashes content; skips unchanged docs.
+3. Calls the configured `EmbedProvider` to generate vectors for new chunks.
+4. Writes chunks into `content_vectors` and the usearch ANN index.
+
+If new content isn't searchable, one of those four stages is stuck or failing.
+
+## Configure for your environment
+
+| Reference | Substitute with |
+|---|---|
+| `${KAIRIX_DATA_DIR}` | `kairix.config.yaml` `paths.db_path` parent, or `KAIRIX_DATA_DIR` env var |
+| `${KAIRIX_DOCUMENT_ROOT}` | `kairix.config.yaml` `paths.document_root`, or `KAIRIX_DOCUMENT_ROOT` env var |
+| `<embed-cycle>` | how often your scheduled `kairix embed` runs (e.g. 15min via cron, hourly via systemd timer) |
+| `<sync-mechanism>` | your document store sync — Obsidian Sync, git pull, rsync, etc. — kairix doesn't ship one |
+
+## Quick diagnosis
+
+```bash
+# 1. Are new files even on disk?
+find "${KAIRIX_DOCUMENT_ROOT}" -name "*.md" -newer "${KAIRIX_DATA_DIR}/index.sqlite" \
+  | head -10
+# Empty → your sync mechanism hasn't propagated the new docs yet (Cause A)
+
+# 2. Did the last embed run succeed?
+tail -30 "${KAIRIX_DATA_DIR}/logs/embed.log"
+# Look for "embedded N chunks, failed 0" with a recent timestamp.
+
+# 3. Is the embed pipeline actually scheduled?
+# Check whatever scheduler your deployment uses — cron, systemd timer, k8s CronJob.
+
+# 4. Run an embed manually and watch
+kairix embed
+# Expected: "Scanned documents: N new, M updated, K unchanged"
+#           "Embedded N chunks, failed 0"
+```
+
+## Cause A — Document store sync hasn't propagated
+
+The new content you're searching for isn't on disk where kairix is looking.
+
+```bash
+# Confirm the file exists at the expected path
+ls -la "${KAIRIX_DOCUMENT_ROOT}/<your-new-doc>.md"
+
+# Verify document_root is what you expect
+kairix onboard check
+# Look for: "Document root: <path> (✓ exists)"
+```
+
+This is typically a sync issue outside kairix. Restart your sync mechanism or pull the source manually.
+
+## Cause B — Embed pipeline failing
+
+```bash
+# Run the embed pipeline interactively to see live errors
+kairix embed
+
+# Common error signatures and fixes:
+
+# "Embed credentials not set" → see runbook-vector-search-failure.md (Fix A)
+
+# "401 Unauthorized" / "Authorization failed"
+#   → credentials present but invalid or expired; rotate via your secrets path
+
+# "429 Too Many Requests"
+#   → embed provider rate limit. Either:
+#     - reduce concurrent embed runs (single scheduled instance)
+#     - lower batch size (KAIRIX_EMBED_BATCH_SIZE env var; default 250)
+#     - upgrade provider quota
+
+# "disk I/O error" / database is locked
+#   → another kairix process is writing to the same DB. Check the lockfile
+#     at ${KAIRIX_DATA_DIR}/embed.lock and PID inside it. Kill the stale
+#     process and retry.
+
+# "No relevant docs found" but you know files exist
+#   → check the collection definitions in kairix.config.yaml resolve to
+#     your new content's location. `kairix config validate` will flag
+#     unreachable paths.
+```
+
+## Cause C — Scheduled embed not running
+
+If `kairix embed` works manually but stops between scheduled runs:
+
+- Confirm the scheduler entry exists for the user kairix runs as.
+- Confirm the scheduler's environment includes `KAIRIX_*` and any provider credentials (cron resets `PATH` and most env vars by default).
+- Confirm the lockfile at `${KAIRIX_DATA_DIR}/embed.lock` isn't stale — kairix does refuse to start a new run if a lock exists for a live PID.
+
+```bash
+# Check for stale lockfile
+test -f "${KAIRIX_DATA_DIR}/embed.lock" && cat "${KAIRIX_DATA_DIR}/embed.lock"
+# Compare PID against running processes; if dead, kairix self-clears it on next run.
+
+# If schedule still doesn't fire, the scheduler itself is the issue
+# — that's deployment-specific, see your private operator notes.
+```
+
+## Verify fix
+
+```bash
+# Trigger embed manually
+kairix embed
+
+# Confirm completion
+tail -10 "${KAIRIX_DATA_DIR}/logs/embed.log"
+# "Embedded N chunks, failed 0" — look for N > 0 if there were new docs
+
+# Smoke test with content you just added
+kairix search "title or distinctive phrase from the new document"
+# Expected: the new document appears in results
+```
+
+## Prevent recurrence
+
+- Schedule `kairix embed` at a cadence that matches your acceptable lag (15min for active vaults; hourly for stable ones).
+- Wire the embed log to your monitoring — alert on `failed > 0` for two consecutive runs.
+- Keep `kairix onboard check` in your post-deploy smoke test so credential rot is caught early.
+
+## See also
+
+- `runbook-vector-search-failure.md` — vector search returns zero (different symptom; embedding may be working but query-time lookup fails).
+- `runbook-benchmark-regression.md` — search quality dropped (different symptom; new content is searchable but ranking shifted).

--- a/docs/operations/runbooks/runbook-vector-search-failure.md
+++ b/docs/operations/runbooks/runbook-vector-search-failure.md
@@ -1,0 +1,132 @@
+# Runbook — Vector search failure (`vec=0, vec_failed=True`)
+
+**Severity:** P1 — search returns BM25-only results; semantic recall degraded.
+
+**Symptom:** `kairix search "<query>" --json` shows `"vec_count": 0` and `"vec_failed": true` while `bm25_count > 0`. Only keyword results come back.
+
+---
+
+## What's happening
+
+Vector search calls the configured `EmbedProvider` to embed the query, then queries the usearch vector index. Either:
+
+1. **Embedding call fails** — credentials missing, rate-limited, or the provider endpoint is unreachable.
+2. **Vector index is missing or corrupt** — usearch index file absent, or its hash dimensions mismatch the configured `KAIRIX_EMBED_DIMS`.
+3. **No vectors indexed yet** — `kairix embed` hasn't run successfully against this corpus.
+
+BM25 keeps working because it's pure SQLite FTS5 with no external dependency.
+
+## Configure for your environment
+
+This runbook references kairix's standard environment surface. Substitute your operator-specific paths where shown:
+
+| Reference | Substitute with |
+|---|---|
+| `${KAIRIX_DATA_DIR}` | `kairix.config.yaml` `paths.db_path` parent, or `KAIRIX_DATA_DIR` env var (default `~/.cache/kairix/`) |
+| `${KAIRIX_DOCUMENT_ROOT}` | `kairix.config.yaml` `paths.document_root`, or `KAIRIX_DOCUMENT_ROOT` env var |
+| `<your-vm-host>` | hostname of the VM running kairix, if remote |
+| `<embed-provider-creds>` | `KAIRIX_LLM_API_KEY` + `KAIRIX_LLM_ENDPOINT` (or `KAIRIX_EMBED_*` for a separate embed provider), or `OPENAI_API_KEY` for OpenAI |
+
+If kairix is running in Docker, prefix host commands with `docker exec <container-name>`.
+
+## Quick diagnosis
+
+```bash
+# 1. Confirm the symptom
+kairix search "test query" --json | jq '{bm25_count, vec_count, vec_failed}'
+# Healthy:    {"bm25_count": N, "vec_count": M, "vec_failed": false}
+# Failure:    {"bm25_count": N, "vec_count": 0, "vec_failed": true}
+
+# 2. Check vector index file exists and has rows
+sqlite3 "${KAIRIX_DATA_DIR}/index.sqlite" \
+  "SELECT COUNT(*) AS chunks FROM content_vectors"
+# 0 rows → no embeddings yet → run kairix embed (skip to Fix C)
+
+# 3. Check usearch index file size
+ls -la "${KAIRIX_DATA_DIR}/index.usearch"
+# Missing or 0 bytes → corrupt or never built (skip to Fix C)
+
+# 4. Run the recall self-check
+kairix embed recall-check
+# Reports per-query hits/misses; if all skipped → credentials issue (Fix A)
+```
+
+## Fix A — Credentials missing or invalid
+
+```bash
+# Verify credentials are reachable
+kairix onboard check
+# Expected: "Embed provider: ✓ Azure (or OpenAI)"
+# Failure:  "Embed provider: ✗ <reason>"
+
+# Inspect the env vars kairix expects
+env | grep -E "^KAIRIX_(LLM|EMBED)_" | sort
+# Required: KAIRIX_LLM_API_KEY + KAIRIX_LLM_ENDPOINT
+#       OR  KAIRIX_EMBED_API_KEY + KAIRIX_EMBED_ENDPOINT (separate embed provider)
+#       OR  OPENAI_API_KEY (OpenAI fallback)
+```
+
+If your deployment uses a secrets file or vault to populate the environment, the operator-specific recovery procedure for that path lives in your private operations notes — typically:
+
+- Re-run the secrets-fetch service / step that populates the env.
+- Confirm the credentials file (e.g. `/run/secrets/kairix.env`) exists and is readable by the kairix process.
+- Restart the kairix process so the new credentials are picked up.
+
+## Fix B — Provider rate-limited / endpoint unreachable
+
+```bash
+# Test the embed call directly via a one-off embed
+echo "smoke test" | kairix embed --limit 1 2>&1 | tail -10
+# Look for HTTP 429 (rate limit), HTTP 401 (auth), or connection errors
+
+# If 429: the provider has a quota cap. Reduce embed batch size or
+#   slow the cron schedule until the cap resets.
+# If 401: credentials are present but invalid — rotate or re-fetch.
+# If connection error: check network/proxy from the kairix host to the
+#   provider endpoint listed in KAIRIX_LLM_ENDPOINT.
+```
+
+## Fix C — No vectors indexed yet
+
+```bash
+# Run the embed pipeline against the configured document root
+kairix embed
+
+# Watch progress
+kairix embed status
+# Expected: "embedded N chunks, failed M, duration Xs"
+
+# Verify chunks landed
+sqlite3 "${KAIRIX_DATA_DIR}/index.sqlite" \
+  "SELECT COUNT(*) FROM content_vectors"
+# Should be > 0
+
+# Smoke test
+kairix search "topic that's definitely in your corpus" --json \
+  | jq '{vec_count, vec_failed}'
+# vec_count > 0, vec_failed: false
+```
+
+## Verify fix
+
+```bash
+# Vector search must return non-zero
+kairix search "agent memory" --json | jq '{vec_count, vec_failed}'
+# Expected: vec_count > 0, vec_failed: false
+
+# Onboard check fully green
+kairix onboard check
+# All ✓
+```
+
+## Prevent recurrence
+
+- Run `kairix onboard check` on every deploy and after secrets rotation.
+- Wire `kairix embed` into a scheduled job (cron / systemd timer) so new content is indexed within your acceptable lag window.
+- Monitor `KAIRIX_DATA_DIR/logs/embed.log` for repeating failures and alert on `failed > 0` for two consecutive runs.
+
+## See also
+
+- `runbook-embedding-lag.md` — new content not appearing in search after the expected embed cycle.
+- `runbook-benchmark-regression.md` — search quality degraded across the board (NDCG drop).
+- Operator-specific overlays: your private runbooks for credential rotation, secrets-fetch service, and binary-symlink layout (these are deployment-specific and stay private).


### PR DESCRIPTION
## Summary

First batch of the OPS-009 runbook migration. Three high-value vault runbooks ported into \`docs/operations/runbooks/\` as fully parameterised public docs.

## What's in this PR

| New repo doc | Replaces vault runbook | Trigger |
|---|---|---|
| \`runbook-vector-search-failure.md\` | vault \`runbook-vector-search-failure.md\` | \`vec=0, vec_failed=True\` |
| \`runbook-embedding-lag.md\` | vault \`runbook-embedding-lag.md\` | new content not appearing |
| \`how-to-rebuild-entity-graph.md\` | vault \`how-to-rebuild-entity-graph.md\` | Neo4j entity graph corrupted/stale |

Each has a **"Configure for your environment"** table mapping documented placeholders to real env vars / config keys. No deployment-specific paths, hostnames, or service names. Drives off kairix's stable CLI surface (\`kairix embed\`, \`kairix store crawl\`, \`kairix onboard check\`).

INDEX.md updated to surface the new entries in the Quick Links and Incident Runbooks tables.

## What's NOT in this PR (deliberately)

The remaining 14 vault runbooks fall into two buckets:

1. **Deployment-specific (stays vault-private)** — these reference operator infrastructure that has no public analogue:
   - \`how-to-fix-binary-symlink\` — TC's specific \`/opt/openclaw/bin/kairix\` → \`kairix-wrapper.sh\` layout
   - \`how-to-deploy-kairix-cron-scripts\` — \`tc-agent-zone\` repo's \`apply-kairix-config.sh\`
   - \`how-to-configure-azure-keyvault\` — operator's specific managed-identity / KV-instance setup
   - \`how-to-restart-kairix-services\` — operator's systemd service names
   - \`runbook-secrets-fetch-failure\` — secrets backend specific
   - \`runbook-kairix-emergency-recovery\` — references all of the above

2. **Public-shapeable but lower priority** — defer to a follow-up PR if the value is there:
   - \`runbook-entity-graph-stale\` (incremental case; \`how-to-rebuild-entity-graph\` covers the full-rebuild case)
   - \`runbook-curator-health-red\` (curator agent is still a Backlog card; runbook firms up after CA-0..5)
   - \`how-to-onboard-new-installation\` (overlaps with \`kairix onboard check\` + \`how-to-upgrade-kairix\`)
   - \`how-to-run-kairix-search\` (lightweight; overlaps with the \`--help\` text)

## Vault originals

Left in place at \`Operations/Runbooks/\` — the user is actively working in the vault today and we don't touch the vault during their work hours. The vault originals will be retired (or rewritten as operator overlays referencing the public docs) in a follow-up cleanup pass once these public versions land.

## Test plan

- [x] \`safe-commit.sh\` clean: 2106 tests pass, lint+format+mypy strict OK.
- [x] Each runbook self-reviewed for hardcoded paths, hostnames, or operator-specific service names — none found.
- [x] CLI surface referenced (\`kairix embed\`, \`kairix store crawl\`, \`kairix onboard check\`) verified against current \`kairix/cli.py\`.
- [ ] CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)