### PR TITLE
sec(SEC-002): NOSONAR rationale on 23 MEDIUM SonarCloud hotspots

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
 
+# NOSONAR(docker:S6470): the `setup.cfg* setup.py*` globs are bounded to
+# specific filenames at the repo root — they only pick up legitimate Python
+# package metadata, never secrets. `.dockerignore` (root of repo) excludes
+# anything sensitive (.env, .git, secrets/) before context is sent to the
+# builder. Reviewed and safe.
 COPY pyproject.toml setup.cfg* setup.py* README.md /opt/kairix/src/
 COPY kairix/ /opt/kairix/src/kairix/
 
@@ -14,6 +19,11 @@ RUN pip install --no-cache-dir torch --index-url https://download.pytorch.org/wh
     && python -m spacy download en_core_web_sm || true
 
 # ── Runtime stage: slim image with only installed packages ───────────────────
+# NOSONAR(docker:S6504): kairix runs as root inside the container by design —
+# it needs to write to /data/kairix/ and bind-mounted document roots whose
+# host ownership varies per deployment. Operators isolate the container with
+# user-namespace remapping or a non-root host user via docker-compose `user:`
+# rather than baking a fixed UID into the image. Reviewed and safe.
 FROM python:3.12-slim AS runtime
 
 # Copy installed Python packages from builder (no build-essential, no source)

--- a/docker/vault-agent/Dockerfile
+++ b/docker/vault-agent/Dockerfile
@@ -1,3 +1,7 @@
+# NOSONAR(docker:S6504): vault-agent is a sidecar that runs only at boot to
+# fetch secrets from a managed-identity-authenticated Key Vault, then exits.
+# It writes to a tmpfs at /run/secrets/ and never accepts user input — root
+# is the expected user for the upstream azure-cli base image. Reviewed and safe.
 FROM mcr.microsoft.com/azure-cli:2.73.0
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/kairix/core/temporal/chunker.py
+++ b/kairix/core/temporal/chunker.py
@@ -74,9 +74,12 @@ _DATE_FIELD_RE = re.compile(
 _MEMORY_LOG_RE = re.compile(r"^(\d{4})-(\d{2})-(\d{2})\.md$")
 
 # Card line: starts with "- [ ]" or "- [x]" (checklist item)
+# NOSONAR(python:S5852): no quantifiers on character classes that overlap;
+# anchored to start-of-line via re.MULTILINE — no backtracking risk.
 _CARD_LINE_RE = re.compile(r"^[-*]\s+\[[ xX]\]\s+", re.MULTILINE)
 
 # Section heading for boards (## Heading at start of line)
+# NOSONAR(python:S5852): single-line via re.MULTILINE — bounded by line length.
 _SECTION_H2_RE = re.compile(r"^##\s+(.+)$", re.MULTILINE)
 
 

--- a/kairix/knowledge/reflib/extract.py
+++ b/kairix/knowledge/reflib/extract.py
@@ -203,6 +203,8 @@ _FRAMEWORK_PATTERN = re.compile(
 )
 
 # Matches title-case proper nouns (2-5 words starting with capitals)
+# NOSONAR(python:S5852): bounded repetition `{1,4}` and word-boundary anchors;
+# no nested quantifiers — backtracking is linear in input length.
 _PROPER_NOUN_PATTERN = re.compile(r"\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,4})\b")
 
 # Heading extraction

--- a/kairix/knowledge/reflib/frontmatter.py
+++ b/kairix/knowledge/reflib/frontmatter.py
@@ -14,6 +14,8 @@ from kairix.knowledge.reflib.sources import SourceDef
 from kairix.text import extract_title, strip_frontmatter
 
 # YAML frontmatter block — \A anchor ensures match only at string start
+# NOSONAR(python:S5852): non-greedy `.*?` bounded by literal `\n---\s*\n`
+# terminator; input is markdown frontmatter (file-bounded, not user request).
 _FRONTMATTER_RE = re.compile(r"\A---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 
 # Re-export for backwards compatibility

--- a/kairix/knowledge/reflib/markdown.py
+++ b/kairix/knowledge/reflib/markdown.py
@@ -16,15 +16,20 @@ _BADGE_RE = re.compile(
 )
 
 # HTML block tags to strip (but preserve content between them)
+# NOSONAR(python:S5852): bounded by `>` terminator and a fixed alternation
+# of well-known tag names; input is reflib markdown (file-bounded).
 _HTML_BLOCK_STRIP_RE = re.compile(
     r"</?(?:div|span|center|font|b|i|u|em|strong|br|hr)\s*[^>]*?>",
     re.IGNORECASE,
 )
 
 # HTML img tags — strip entirely (content is in the tag, not between)
+# NOSONAR(python:S5852): bounded by `>` terminator; reflib input.
 _HTML_IMG_RE = re.compile(r"<img\s[^>]*?>", re.IGNORECASE)
 
 # HTML anchor tags — convert to markdown links
+# NOSONAR(python:S5852): all `?` quantifiers are non-greedy and bounded by
+# literal terminators (`["\']`, `>`, `</a>`); reflib input.
 _HTML_ANCHOR_RE = re.compile(
     r'<a\s+(?:[^>]*?\s+)?href=["\']([^"\']*)["\'][^>]*?>(.*?)</a>',
     re.IGNORECASE | re.DOTALL,

--- a/kairix/knowledge/reflib/splitter.py
+++ b/kairix/knowledge/reflib/splitter.py
@@ -13,6 +13,8 @@ MAX_FILE_SIZE: int = 50_000  # 50KB
 MIN_FILE_SIZE: int = 500  # 500 bytes
 
 # Match h1 and h2 headings
+# NOSONAR(python:S5852): bounded `{1,2}` repetition; line-anchored via
+# re.MULTILINE — backtracking is linear in line length.
 _HEADING_RE = re.compile(r"^(#{1,2})\s+(.+)$", re.MULTILINE)
 
 

--- a/kairix/knowledge/store/crawler.py
+++ b/kairix/knowledge/store/crawler.py
@@ -311,6 +311,8 @@ def _parse_frontmatter(path: Path) -> dict[str, Any]:
         # No frontmatter found at all — also try lenient match (no trailing newline)
         import re
 
+        # NOSONAR(python:S5852): non-greedy `.*?` bounded by literal `\n---`
+        # terminator; input is markdown frontmatter (file-bounded).
         lenient = re.match(r"\A---\s*\n(.*?)\n---", text, re.DOTALL)
         if not lenient:
             return {}
@@ -319,6 +321,7 @@ def _parse_frontmatter(path: Path) -> dict[str, Any]:
         # Re-extract the raw YAML block for full yaml.safe_load parsing
         import re
 
+        # NOSONAR(python:S5852): same bounded-input rationale as above.
         match = re.match(r"\A---\s*\n(.*?)\n---", text, re.DOTALL)
         if not match:
             return dict(simple_parsed)  # fallback to simple parsing

--- a/kairix/knowledge/wikilinks/audit.py
+++ b/kairix/knowledge/wikilinks/audit.py
@@ -124,6 +124,8 @@ def find_unlinked_mentions(
 
     # Sample
     if len(eligible) > sample_size:
+        # NOSONAR(python:S2245): non-security audit sampling — picking a
+        # representative subset of files for human review; no security boundary.
         sampled = random.sample(eligible, sample_size)
     else:
         sampled = list(eligible)

--- a/kairix/knowledge/wikilinks/resolver.py
+++ b/kairix/knowledge/wikilinks/resolver.py
@@ -57,6 +57,9 @@ def _make_link(name: str) -> str:
 # Matches table rows like:
 #   | Acme-Corp | `[[Acme-Corp]]` | `02-Areas/Clients/Acme-Corp/` |
 #   | Gamma Systems | `[[Gamma-Systems\|Gamma Systems]]` | `02-Areas/Clients/Gamma-Systems/` |
+# NOSONAR(python:S5852): each capture is bounded by a distinct literal
+# delimiter (`|` or backtick); no nested quantifiers — backtracking is
+# linear in line length. Input is the bootstrap entity-table markdown file.
 _TABLE_ROW_RE = re.compile(r"^\|\s*(?P<entity>[^|]+?)\s*\|\s*`(?P<link>\[\[[^\]]+\]\])`\s*\|\s*`(?P<path>[^`]+)`\s*\|")
 
 
@@ -115,6 +118,8 @@ def load_entities_from_bootstrap(
             continue
         # Skip vault path annotations like "(general reference)" - keep just path part
         # Strip trailing parenthetical notes from vault_path
+        # NOSONAR(python:S5852): non-greedy `.*?` bounded by `)` and end-anchor;
+        # operates on a single short path string (≤ a few hundred chars).
         vault_path = re.sub(r"\s*\(.*?\)\s*$", "", vault_path).strip()
         if not vault_path or not entity_name:
             continue

--- a/kairix/quality/eval/generate.py
+++ b/kairix/quality/eval/generate.py
@@ -228,6 +228,8 @@ def sample_documents(
         return []
 
     docs = filter_and_process_sampled_rows(rows, _MIN_DOC_LENGTH)
+    # NOSONAR(python:S2245): non-security shuffle for benchmark sample
+    # ordering — repeatable via random.seed() in tests; no trust boundary.
     random.shuffle(docs)
     return docs[:n]
 

--- a/kairix/quality/eval/judge.py
+++ b/kairix/quality/eval/judge.py
@@ -325,6 +325,8 @@ def judge_batch(
     indexed = list(enumerate(candidates))  # (original_index, (stem, snippet))
 
     if shuffle:
+        # NOSONAR(python:S2245): non-security shuffle to prevent positional
+        # bias in LLM judge prompts; deterministic via random.seed() in tests.
         random.shuffle(indexed)
 
     shuffle_order = [candidates[i][0] for i, _ in indexed]

--- a/kairix/text.py
+++ b/kairix/text.py
@@ -40,12 +40,17 @@ def truncate_to_tokens(text: str, max_tokens: int) -> str:
 # ---------------------------------------------------------------------------
 
 # YAML frontmatter block — \A anchor ensures match only at string start
+# NOSONAR(python:S5852): non-greedy `.*?` bounded by literal `\n---\s*\n`
+# terminator; input is markdown frontmatter (file-bounded, not user request).
 _FRONTMATTER_RE = re.compile(r"\A---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 
 # Same pattern without capture group, for strip_frontmatter
+# NOSONAR(python:S5852): same rationale as _FRONTMATTER_RE — bounded input.
 _FRONTMATTER_STRIP_RE = re.compile(r"\A---\s*\n.*?\n---\s*\n", re.DOTALL)
 
-# First markdown heading
+# First markdown heading — `(.+)` is anchored to a single line via re.MULTILINE
+# so backtracking is bounded by line length.
+# NOSONAR(python:S5852): single-line input via re.MULTILINE — no polynomial blowup.
 _FIRST_HEADING_RE = re.compile(r"^#{1,3}\s+(.+)$", re.MULTILINE)
 
 

--- a/scripts/audit-date-formats.py
+++ b/scripts/audit-date-formats.py
@@ -31,6 +31,8 @@ from typing import Any
 
 _ISO_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 _DATETIME_RE = re.compile(r"^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}")
+# NOSONAR(python:S5852): line-anchored via re.MULTILINE; capture is bounded
+# by literal `"` and `\n` terminators; field name is a fixed alternation.
 _FRONTMATTER_FIELD_RE = re.compile(
     r'^(?:date|created|updated|created_at)\s*:\s*"?([^"\n]+)"?\s*$',
     re.MULTILINE | re.IGNORECASE,

--- a/scripts/build-reflib-queries.py
+++ b/scripts/build-reflib-queries.py
@@ -131,6 +131,8 @@ def generate_query_for_document(doc: dict, category: str) -> dict:
     }
 
     query_templates = templates.get(category, templates["recall"])
+    # NOSONAR(python:S2245): non-security template selection for benchmark
+    # query generation; deterministic via random.seed() in build_suite().
     query_text = random.choice(query_templates)
 
     # Normalise title for gold matching
@@ -171,6 +173,8 @@ def build_suite(
         if not available:
             available = list(TARGET_DISTRIBUTION.keys())
 
+        # NOSONAR(python:S2245): non-security category selection for
+        # benchmark distribution; deterministic via random.seed() above.
         category = random.choice(available)
         case = generate_query_for_document(doc, category)
         case_counter[category] += 1


### PR DESCRIPTION
## Summary

Per-finding triage of every MEDIUM-probability SonarCloud hotspot. Each gets an explicit \`# NOSONAR(<rule-code>)\` comment with rationale specific to the call site so future audits see why the rule was filed and accepted.

## Distribution

| Category | Count | Treatment |
|---|---|---|
| **ReDoS** (\`python:S5852\`) | 14 | Bounded-input regex. Each comment names the specific bound: literal terminator (\`\\n---\\s*\\n\`), line anchor (\`re.MULTILINE\`), fixed alternation (\`(?:div\|span\|...)\`), bounded \`{n,m}\` repetition. |
| **weak-cryptography** (\`python:S2245\`) | 5 | Non-security \`random.*\` — benchmark sample shuffling, eval judge ordering, query-template selection. All deterministic via \`random.seed()\` in the surrounding context. |
| **permission** (\`docker:S6470\` / \`S6504\`) | 4 | Dockerfile glob COPY (bounded to package metadata; \`.dockerignore\` excludes secrets). Root user in main image (required for \`/data/kairix\` writes; operators isolate via user-namespace remap). vault-agent root (boot-only sidecar, no user input). |

## Files touched (15)

All comment-only; **no behaviour change**.

| File | Findings |
|---|---|
| \`Dockerfile\` | 2 (glob COPY, root user) |
| \`docker/vault-agent/Dockerfile\` | 1 (root user) |
| \`kairix/core/temporal/chunker.py\` | 2 ReDoS |
| \`kairix/knowledge/reflib/{extract,frontmatter,markdown,splitter}.py\` | 5 ReDoS |
| \`kairix/knowledge/store/crawler.py\` | 2 ReDoS |
| \`kairix/knowledge/wikilinks/{audit,resolver}.py\` | 1 weak-crypto + 2 ReDoS |
| \`kairix/quality/eval/{generate,judge}.py\` | 2 weak-crypto |
| \`kairix/text.py\` | 3 ReDoS |
| \`scripts/{audit-date-formats,build-reflib-queries}.py\` | 1 ReDoS + 2 weak-crypto |

## Test plan

- [x] \`safe-commit.sh\` clean: 2106 tests pass, lint+format+mypy strict OK.
- [x] All NOSONAR comments use the canonical \`NOSONAR(<rule-code>)\` syntax with explicit rationale.
- [x] Comment-only changes — no behaviour modified.
- [ ] CI on this PR.
- [ ] Next SonarCloud scan should re-evaluate the hotspots; any that remain TO_REVIEW can be marked Reviewed/Safe in the UI using the same rationale already in the code comments.

## What's NOT in this PR

- **26 LOW \`others\` hotspots** — tracked separately as SEC-003. Most of those are subprocess invocations or hardcoded test paths; batch-triage in a follow-up.

Closes SEC-002.

🤖 Generated with [Claude Code](https://claude.com/claude-code)