### PR TITLE
sec(SEC-003): remove importlib.reload smell from wikilinks fixture; triage 26 LOW SonarCloud hotspots

### DIFF
--- a/kairix/core/embed/cli.py
+++ b/kairix/core/embed/cli.py
@@ -74,7 +74,10 @@ def acquire_lock() -> IO[str]:
     lock_fh.close()
     try:
         holder_pid = int(LOCKFILE.read_text().strip())
-        os.kill(holder_pid, 0)  # signal 0 = existence check
+        # NOSONAR(python:S4828): signal 0 is documented as a process-existence
+        # probe — does not deliver a real signal. Used here to detect a stale
+        # lockfile from a dead PID before taking it over.
+        os.kill(holder_pid, 0)
         # Process is alive — genuine contention
         logging.error(
             "Could not acquire lock after %ds — PID %d is still running",

--- a/kairix/knowledge/wikilinks/injector.py
+++ b/kairix/knowledge/wikilinks/injector.py
@@ -28,18 +28,6 @@ from kairix.paths import document_root, workspace_root
 # Injection log path
 _LOG_PATH = str(Path.home() / ".cache" / "kairix" / "wikilinks-log.jsonl")
 
-_DOCUMENT_ROOT = str(document_root())
-_WORKSPACE_ROOT = str(workspace_root())
-
-# Eligible base paths for injection
-_ELIGIBLE_PREFIXES = (
-    f"{_WORKSPACE_ROOT}/",
-    f"{_DOCUMENT_ROOT}/04-Agent-Knowledge/",
-    f"{_DOCUMENT_ROOT}/01-Projects/",
-    f"{_DOCUMENT_ROOT}/02-Areas/",
-    f"{_DOCUMENT_ROOT}/05-Knowledge/",
-)
-
 _INELIGIBLE_SUBSTRINGS = (
     "/archive/",
     "/archived/",
@@ -47,6 +35,25 @@ _INELIGIBLE_SUBSTRINGS = (
 )
 
 MAX_FILE_SIZE = 500 * 1024  # 500 KB
+
+
+def _eligible_prefixes() -> tuple[str, ...]:
+    """Compute the eligible-path prefixes lazily.
+
+    Reads ``document_root()`` and ``workspace_root()`` on each call so
+    operators (or tests) can change the env vars without having to reload
+    this module. Both helpers cache their own resolution; the per-call
+    cost here is a function-call + dict-get for env lookup, not real I/O.
+    """
+    doc_root = str(document_root())
+    ws_root = str(workspace_root())
+    return (
+        f"{ws_root}/",
+        f"{doc_root}/04-Agent-Knowledge/",
+        f"{doc_root}/01-Projects/",
+        f"{doc_root}/02-Areas/",
+        f"{doc_root}/05-Knowledge/",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -85,16 +92,19 @@ def should_inject(path: str) -> bool:
     except OSError:
         pass  # file may not exist yet; defer to caller
 
+    prefixes = _eligible_prefixes()
+    workspace_prefix = prefixes[0]
+
     # workspace memory files: <workspace-root>/*/memory/*.md
-    if path.startswith(f"{_WORKSPACE_ROOT}/"):
-        parts = path[len(f"{_WORKSPACE_ROOT}/") :].split("/")
+    if path.startswith(workspace_prefix):
+        parts = path[len(workspace_prefix) :].split("/")
         # parts[0] = workspace name, parts[1] = 'memory', parts[-1] = filename
         if len(parts) >= 3 and parts[1] == "memory":
             return True
         return False
 
     # Obsidian vault paths
-    for prefix in _ELIGIBLE_PREFIXES[1:]:  # skip /data/workspaces/ already handled
+    for prefix in prefixes[1:]:  # skip <workspace-root>/ already handled
         if path.startswith(prefix):
             return True
 
@@ -160,7 +170,7 @@ def _entities_for_own_page(source_path: str, entities: list[WikiEntity]) -> set[
         return set()
 
     # Normalise source_path to a relative document path for comparison
-    doc_root = f"{_DOCUMENT_ROOT}/"
+    doc_root = f"{document_root()}/"
     if source_path.startswith(doc_root):
         rel = source_path[len(doc_root) :]
     else:
@@ -385,7 +395,7 @@ def inject_file(path: str, entities: list[WikiEntity], dry_run: bool = False) ->
 def _log_injection(file_path: str, injected: list[str], dry_run: bool) -> None:
     """Append an entry to the injection log."""
     # Use relative document path when possible
-    doc_root = f"{_DOCUMENT_ROOT}/"
+    doc_root = f"{document_root()}/"
     rel_path = file_path
     if file_path.startswith(doc_root):
         rel_path = file_path[len(doc_root) :]

--- a/scripts/chunk-crm-interactions.py
+++ b/scripts/chunk-crm-interactions.py
@@ -231,8 +231,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--output-dir",
         type=Path,
-        default=Path("/tmp/crm-chunks"),
-        help="Output directory for chunk files (default: /tmp/crm-chunks)",
+        default=Path.home() / ".cache" / "kairix" / "crm-chunks",
+        help="Output directory for chunk files (default: ~/.cache/kairix/crm-chunks)",
     )
     parser.add_argument(
         "--vault-root",

--- a/scripts/chunk-daily-files.py
+++ b/scripts/chunk-daily-files.py
@@ -154,8 +154,8 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--vault-root", required=True, help="Path to vault root")
     parser.add_argument(
         "--output-dir",
-        default="/tmp/daily-chunks",
-        help="Output directory for chunk files (default: /tmp/daily-chunks)",
+        default=str(Path.home() / ".cache" / "kairix" / "daily-chunks"),
+        help="Output directory for chunk files (default: ~/.cache/kairix/daily-chunks)",
     )
     parser.add_argument(
         "--dry-run",

--- a/tests/eval/test_monitor.py
+++ b/tests/eval/test_monitor.py
@@ -30,6 +30,8 @@ def _make_log_entry(weighted_ndcg: float, days_ago: float = 0.0, regression: boo
     ts = (datetime.now(tz=timezone.utc) - timedelta(days=days_ago)).isoformat()
     return {
         "ts": ts,
+        # NOSONAR(python:S5443): suite_path is an opaque label string in the
+        # monitor log JSON — never used as a real filesystem path in this test.
         "suite_path": "/tmp/canary.yaml",
         "n_cases": 10,
         "ndcg_by_category": {"recall": weighted_ndcg},

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -176,7 +176,9 @@ def test_shutdown_handler_sets_running_false() -> None:
         nonlocal call_count
         call_count += 1
         if call_count == 1:
-            # Send SIGTERM to our own process — signal handler should fire
+            # NOSONAR(python:S4828): test sends a real SIGTERM to itself to
+            # exercise the worker's shutdown handler. Self-targeted; no
+            # external reach.
             os.kill(os.getpid(), signal.SIGTERM)
 
     main(
@@ -204,6 +206,7 @@ def test_main_loop_runs_embed_on_interval() -> None:
         nonlocal call_count
         call_count += 1
         if call_count >= 2:
+            # NOSONAR(python:S4828): self-signal to drive worker shutdown loop.
             os.kill(os.getpid(), signal.SIGTERM)
 
     def entity_then_noop() -> None:
@@ -242,6 +245,7 @@ def test_shutdown_handler_via_sigint() -> None:
         nonlocal call_count
         call_count += 1
         if call_count == 1:
+            # NOSONAR(python:S4828): self-signal to drive Ctrl-C path on the worker.
             os.kill(os.getpid(), signal.SIGINT)
 
     main(

--- a/tests/wikilinks/conftest.py
+++ b/tests/wikilinks/conftest.py
@@ -2,16 +2,28 @@
 
 import pytest
 
+from kairix.paths import _resolve_cached
+
 
 @pytest.fixture(autouse=True)
 def _set_test_roots(monkeypatch):
-    """Set document store/workspace roots before wikilinks module resolves them."""
+    """Set document store/workspace roots for wikilinks tests.
+
+    The injector reads these via ``document_root()`` / ``workspace_root()``
+    helpers in ``kairix.paths``, which are ``@lru_cache``-d. We use
+    ``monkeypatch.setenv`` (environment fixturing — the only mutation
+    primitive kairix tests should use) plus ``cache_clear()`` on the
+    paths-resolution cache so the new env vars take effect immediately.
+
+    No ``importlib.reload`` and no kairix-code patching — the injector
+    refactor (`_eligible_prefixes()` is lazy now) means the env override
+    propagates naturally on the next call.
+
+    NOSONAR(python:S5443): /tmp paths are string fixtures used to drive
+    path-resolution logic under test — never touched on the filesystem.
+    """
     monkeypatch.setenv("KAIRIX_DOCUMENT_ROOT", "/tmp/test-vault")
     monkeypatch.setenv("KAIRIX_WORKSPACE_ROOT", "/tmp/test-workspaces")
-
-    # Force reimport so module-level variables pick up the new env vars
-    import importlib
-
-    import kairix.knowledge.wikilinks.injector
-
-    importlib.reload(kairix.knowledge.wikilinks.injector)
+    _resolve_cached.cache_clear()
+    yield
+    _resolve_cached.cache_clear()

--- a/tests/wikilinks/test_injector.py
+++ b/tests/wikilinks/test_injector.py
@@ -16,6 +16,17 @@ import pytest
 from kairix.knowledge.wikilinks.injector import inject_wikilinks, should_inject
 from kairix.knowledge.wikilinks.resolver import WikiEntity
 
+# Test-fixture path roots. These are *strings only* — they're consumed by
+# should_inject() and inject_wikilinks() as opaque path strings to drive
+# eligibility / self-link logic. Nothing is ever read or written under these
+# paths on the filesystem. The "/tmp" prefix matches what
+# tests/wikilinks/conftest.py sets via KAIRIX_DOCUMENT_ROOT /
+# KAIRIX_WORKSPACE_ROOT for the same fixture-string purpose.
+# NOSONAR(python:S5443): no actual /tmp filesystem access — string fixtures.
+_TEST_VAULT_ROOT = "/tmp/test-vault"
+_TEST_WORKSPACES_ROOT = "/tmp/test-workspaces"
+
+
 # ---------------------------------------------------------------------------
 # Fixtures / helpers
 # ---------------------------------------------------------------------------
@@ -189,7 +200,7 @@ def test_no_self_link_on_own_page() -> None:
     modified, injected = inject_wikilinks(
         content,
         [ACME_CORP],
-        source_path="/tmp/test-vault/02-Areas/Clients/Acme-Corp/Overview.md",
+        source_path=f"{_TEST_VAULT_ROOT}/02-Areas/Clients/Acme-Corp/Overview.md",
     )
     assert injected == []
     assert "[[Acme-Corp]]" not in modified
@@ -202,7 +213,7 @@ def test_self_link_check_different_entity() -> None:
     modified, injected = inject_wikilinks(
         content,
         [ACME_CORP, GAMMA_SYSTEMS],
-        source_path="/tmp/test-vault/02-Areas/Clients/Acme-Corp/Overview.md",
+        source_path=f"{_TEST_VAULT_ROOT}/02-Areas/Clients/Acme-Corp/Overview.md",
     )
     # Acme Corp suppressed (self-link on own page); Gamma Systems still linked
     assert "[[Acme-Corp]]" not in modified
@@ -241,27 +252,27 @@ def test_primary_name_triggers_link() -> None:
 
 @pytest.mark.unit
 def test_should_inject_memory_log() -> None:
-    assert should_inject("/tmp/test-workspaces/builder/memory/2026-03-23.md") is True
+    assert should_inject(f"{_TEST_WORKSPACES_ROOT}/builder/memory/2026-03-23.md") is True
 
 
 @pytest.mark.unit
 def test_should_inject_agent_knowledge() -> None:
-    assert should_inject("/tmp/test-vault/04-Agent-Knowledge/builder/patterns.md") is True
+    assert should_inject(f"{_TEST_VAULT_ROOT}/04-Agent-Knowledge/builder/patterns.md") is True
 
 
 @pytest.mark.unit
 def test_should_inject_projects() -> None:
-    assert should_inject("/tmp/test-vault/01-Projects/202603-Kairix/README.md") is True
+    assert should_inject(f"{_TEST_VAULT_ROOT}/01-Projects/202603-Kairix/README.md") is True
 
 
 @pytest.mark.unit
 def test_should_inject_areas() -> None:
-    assert should_inject("/tmp/test-vault/02-Areas/Clients/Acme-Corp/Overview.md") is True
+    assert should_inject(f"{_TEST_VAULT_ROOT}/02-Areas/Clients/Acme-Corp/Overview.md") is True
 
 
 @pytest.mark.unit
 def test_should_inject_knowledge() -> None:
-    assert should_inject("/tmp/test-vault/05-Knowledge/01-Strategy/notes.md") is True
+    assert should_inject(f"{_TEST_VAULT_ROOT}/05-Knowledge/01-Strategy/notes.md") is True
 
 
 @pytest.mark.unit
@@ -281,13 +292,13 @@ def test_should_not_inject_shape_cache() -> None:
 
 @pytest.mark.unit
 def test_should_not_inject_non_md() -> None:
-    assert should_inject("/tmp/test-workspaces/builder/memory/notes.txt") is False
+    assert should_inject(f"{_TEST_WORKSPACES_ROOT}/builder/memory/notes.txt") is False
 
 
 @pytest.mark.unit
 def test_should_not_inject_workspace_non_memory() -> None:
     """Workspace files outside /memory/ subfolder should NOT be eligible."""
-    assert should_inject("/tmp/test-workspaces/builder/some-other-dir/notes.md") is False
+    assert should_inject(f"{_TEST_WORKSPACES_ROOT}/builder/some-other-dir/notes.md") is False
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

The headline fix in this PR is a **real refactor**, not just NOSONAR sprinkles: remove the \`importlib.reload(kairix.knowledge.wikilinks.injector)\` anti-pattern from the wikilinks test fixture. This was a long-standing code smell — production module read env vars at import time, so tests had to reload the whole module to override them. Production now reads paths lazily; tests just clear the documented lru_cache.

## Why this was a smell

\`tests/wikilinks/conftest.py\` was doing:

\`\`\`python
monkeypatch.setenv("KAIRIX_DOCUMENT_ROOT", "/tmp/test-vault")
monkeypatch.setenv("KAIRIX_WORKSPACE_ROOT", "/tmp/test-workspaces")
import importlib
import kairix.knowledge.wikilinks.injector
importlib.reload(kairix.knowledge.wikilinks.injector)  # ← the smell
\`\`\`

Root cause: \`kairix/knowledge/wikilinks/injector.py\` lines 31-32 captured \`document_root()\` and \`workspace_root()\` into module-level constants at import time. Once that module was loaded, the tests' env-var overrides had no effect — hence the reload.

## What changed

**Production (\`kairix/knowledge/wikilinks/injector.py\`):**
- Drop module-level \`_DOCUMENT_ROOT\`, \`_WORKSPACE_ROOT\`, \`_ELIGIBLE_PREFIXES\` constants.
- Add \`_eligible_prefixes()\` function — computes on each call. Cheap because \`kairix.paths\` is already \`@lru_cache\`-d.
- \`_entities_for_own_page\` reads \`document_root()\` lazily.
- **No behaviour change** — 30 wikilinks tests pass unchanged.

**Test (\`tests/wikilinks/conftest.py\`):**
- Remove \`importlib.reload\`.
- Add \`from kairix.paths import _resolve_cached\` and call \`cache_clear()\` on the lru_cache. That's a documented \`functools.lru_cache\` API — no module-level meta-programming, no import-order coupling.
- \`monkeypatch.setenv\` stays — that's environment fixturing, the only mutation primitive kairix tests should use per \`CLAUDE.md\`.

**Test refactor (\`tests/wikilinks/test_injector.py\`):**
- Add \`_TEST_VAULT_ROOT\` / \`_TEST_WORKSPACES_ROOT\` constants.
- Replace 9 scattered \`/tmp/test-...\` literals with f-strings using the constants. Single NOSONAR documents the rationale (path-string fixtures, no filesystem access).

## SEC-003 hotspot triage (26 LOW)

| Category | Count | Treatment |
|---|---|---|
| Signal usage (\`python:S4828\`) | 4 | NOSONAR — embed/cli \`os.kill(pid, 0)\` is a documented process-existence probe; test \`os.kill(getpid(), SIGTERM)\` drives self-shutdown loops |
| Publicly-writable dirs (\`python:S5443\`) | 14 | **Real fix**: \`scripts/chunk-{crm,daily}-files.py\` default \`--output-dir\` changed from \`/tmp/*\` to \`~/.cache/kairix/*\`. **NOSONAR**: test fixture path-strings (\`tests/wikilinks/*\`, \`tests/eval/test_monitor.py\`) |
| GH Actions SHA pinning (\`githubactions:S7637\`) | 8 | **Deferred to a dedicated supply-chain hardening sprint** — needs Dependabot config alignment. Not suppressed here so the signal is preserved. |

## Test plan

- [x] 30 wikilinks tests pass without \`importlib.reload\`.
- [x] \`safe-commit.sh\` clean: 2106 tests, lint+format+mypy strict OK.
- [x] Behaviour preserved: \`should_inject\`, \`inject_wikilinks\`, self-link rules all green.
- [ ] CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)