### PR TITLE
docs(OPS-008): PyPI trusted-publisher setup runbook

### DIFF
--- a/docs/operations/runbooks/INDEX.md
+++ b/docs/operations/runbooks/INDEX.md
@@ -36,6 +36,7 @@ Operational procedures and incident runbooks for kairix deployments.
 | [how-to-run-benchmark](how-to-run-benchmark.md) | Run benchmark suite, interpret results, compare before/after |
 | [how-to-debug-search-ranking](how-to-debug-search-ranking.md) | Query intent dispatch, RRF weights, category-specific tuning |
 | [how-to-rebuild-entity-graph](how-to-rebuild-entity-graph.md) | Drop and rebuild the Neo4j entity graph from the document store |
+| [how-to-configure-pypi-trusted-publisher](how-to-configure-pypi-trusted-publisher.md) | One-time PyPI Trusted Publisher setup so GitHub Releases auto-publish without long-lived tokens |
 | [MCP-DEPLOYMENT](../MCP-DEPLOYMENT.md) | Choose a transport (stdio/http/sse), wire `/mcp` and `/sse` mounts, configure agent registry, verify with `/healthz` |
 | [MCP-CLIENT-MIGRATION](../MCP-CLIENT-MIGRATION.md) | Migrate Claude Desktop / Claude Code / OpenClaw / custom Python or Node clients from `/sse` to `/mcp` |
 

--- a/docs/operations/runbooks/how-to-configure-pypi-trusted-publisher.md
+++ b/docs/operations/runbooks/how-to-configure-pypi-trusted-publisher.md
@@ -1,0 +1,97 @@
+# How-to — Configure PyPI trusted publisher for first release
+
+**When to use:** One-time setup before publishing kairix to PyPI for the first time, OR after migrating the PyPI project to a new GitHub repo.
+
+**Time:** ~10 minutes (mostly waiting for PyPI to verify the OIDC token).
+
+---
+
+## What this configures
+
+GitHub Actions can publish to PyPI without storing a long-lived API token by using **PyPI Trusted Publishers** — an OIDC trust relationship between a specific repo+workflow+environment and the PyPI project. The `publish-pypi.yml` workflow in this repo is already wired to use this pattern; what's missing on first run is the PyPI-side configuration.
+
+The pieces:
+
+| Piece | Where it lives |
+|---|---|
+| `publish-pypi.yml` workflow | `.github/workflows/publish-pypi.yml` (already present) |
+| `release` environment | GitHub repo settings (you create it once) |
+| Trusted Publisher rule | PyPI project settings (you create it once) |
+| `id-token: write` permission | Already declared in the workflow |
+
+## One-time setup
+
+### Step 1 — Create the GitHub `release` environment
+
+GitHub repo → Settings → Environments → New environment → name it `release`.
+
+Optional but recommended:
+
+- **Required reviewers**: add yourself / a release-approver list. Each release will pause for approval before publishing — gives you a chance to bail if the build looks wrong.
+- **Deployment branches**: restrict to `main` (so a feature-branch tag can't accidentally publish).
+
+The workflow's `publish` job has `environment: release`; matching that name here is what gates it.
+
+### Step 2 — Create the PyPI project (first publish only)
+
+If `kairix` doesn't exist on PyPI yet, you have two options:
+
+**Option A — Pre-create via GitHub OIDC (recommended for new projects):**
+1. Go to https://pypi.org/manage/account/publishing/
+2. Add a new "pending publisher" with these fields:
+   - **PyPI project name**: `kairix`
+   - **Owner**: `quanyeomans`
+   - **Repository name**: `kairix`
+   - **Workflow filename**: `publish-pypi.yml`
+   - **Environment name**: `release`
+3. The first GitHub Actions run that matches this rule will **claim the project name** and become its owner.
+
+**Option B — If `kairix` already exists on PyPI:**
+1. Sign in to PyPI as the project owner.
+2. Project → Publishing → Add a new publisher → fill in the same four fields as Option A.
+3. Existing API tokens / passwords can stay configured but no longer needed for publishes.
+
+### Step 3 — Verify the trust chain
+
+Before cutting a real release, verify the wiring with a dry-run release. Easiest path:
+
+1. Create a pre-release tag: `git tag v2026.5.6-rc1 && git push origin v2026.5.6-rc1`.
+2. On GitHub: Releases → Draft new release → pick the tag → mark as **pre-release** → publish.
+3. Watch the `7 · PyPI Publish` workflow run.
+
+Expected outcome:
+- `build` job runs (creates the wheel + sdist artefact).
+- `publish` job pauses for approval if you set required reviewers.
+- After approval, `pypa/gh-action-pypi-publish` exchanges the GitHub OIDC token for PyPI upload credentials and pushes the wheel.
+- `verify` job runs in a clean python environment, installs `kairix=={version}` from PyPI, and runs `kairix --version` to confirm.
+
+If the dry run succeeds, you're ready for real releases.
+
+## Routine release flow (after setup)
+
+1. Merge the release PR into `main`.
+2. Tag: `git tag v2026.5.6 && git push origin v2026.5.6` — version follows CalVer per `CHANGELOG.md` convention.
+3. Create a GitHub Release pointing at the tag → publish release notes.
+4. Workflow fires automatically. Approve the `release` environment if reviewers are required. Verify job confirms the wheel installs.
+
+## Troubleshooting
+
+**"trusted-publisher token rejected"**
+PyPI couldn't match the OIDC token to a configured publisher. Re-check the four fields in Step 2 — they must match exactly (case-sensitive). The repo owner / name / workflow filename / environment name must all align.
+
+**"package name is taken" on first publish**
+Someone else already registered `kairix`. Check the project page on PyPI; if it's a name-squat, [contact PyPI support](https://pypi.org/help/#project-name) for a transfer. If it's a legit project, this repo will need a different package name (update `pyproject.toml`).
+
+**Workflow runs but skips publish**
+Check the run's logs for the `publish` job. The most common reasons:
+- Required-reviewer approval pending — the job is waiting on you.
+- The release event is a `prereleased` rather than `created` — the workflow currently triggers on `types: [created]`. Adjust the trigger if you want pre-releases to publish.
+
+**Verify job fails with `pip install kairix==X.Y.Z` not found**
+PyPI's CDN can lag a few seconds after publish. The workflow already has `sleep 60` before the install attempt. If it still fails, manually `pip install kairix==X.Y.Z` from your machine — if that works too, the verify job's network may be slow; bump the sleep.
+
+## See also
+
+- [`docs/upgrades/`](../../upgrades/) — version-specific migration guides for end users.
+- [`CHANGELOG.md`](../../../CHANGELOG.md) — what gets published per release.
+- PyPI trusted publishers docs: https://docs.pypi.org/trusted-publishers/


### PR DESCRIPTION
## Summary

The remaining OPS-008 work was to document the one-time operator action that wires PyPI to GitHub Actions so \`pypa/gh-action-pypi-publish\` can publish on release events without long-lived API tokens.

The \`publish-pypi.yml\` workflow is already wired correctly: \`id-token: write\`, \`environment: release\`, OIDC dance. What was missing was the operator-facing setup procedure for the PyPI side and the GitHub environment.

## What's in this PR

\`docs/operations/runbooks/how-to-configure-pypi-trusted-publisher.md\` — concrete step-by-step:

- **Step 1**: Create the GitHub \`release\` environment (with optional required-reviewers + branch restriction).
- **Step 2**: Pre-claim the PyPI project via Trusted Publisher OIDC (Option A) or link the existing project (Option B).
- **Step 3**: Dry-run verification via a prerelease tag — full audit of the trust chain before a real release.
- **Routine release flow** post-setup.
- **Troubleshooting**: token rejection, name-squat, skipped publish, slow CDN propagation.

INDEX.md updated.

## What this enables

Once the operator follows the runbook (~10 minutes one-time), every GitHub Release will:

1. Trigger \`publish-pypi.yml\`.
2. Build wheel + sdist.
3. Pause for approval if required reviewers are configured.
4. Exchange the GitHub OIDC token for PyPI upload credentials.
5. Push the wheel to PyPI.
6. Verify via clean install + \`kairix --version\` smoke test.

No long-lived API tokens stored anywhere.

## What's NOT in this PR

The PyPI-side configuration is necessarily a **manual operator action** — neither I nor the workflow can perform it. That's why this is a runbook PR rather than a code PR. Once you've followed the runbook, the next \`gh release create v2026.5.X\` will publish automatically.

## Test plan

- [x] \`safe-commit.sh\` clean: 2106 tests pass.
- [x] Runbook reviewed for completeness — all four critical fields (owner / repo / workflow filename / environment name) explicitly called out.
- [ ] CI on this PR.
- [ ] Operator dry-run: create a prerelease tag and verify the end-to-end flow per the runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)