### PR TITLE
feat(KFEAT-013): kairix eval gate — quality-gate stage 5 of onboarding

### DIFF
--- a/kairix/quality/eval/cli.py
+++ b/kairix/quality/eval/cli.py
@@ -365,6 +365,57 @@ def _cmd_tune(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_gate(args: argparse.Namespace) -> int:
+    """Stage 5 of KFEAT-013 onboarding: read a benchmark result and apply
+    the quality gate. Exits 0 on PASS, 2 on HOLD (so wrappers can chain on
+    success). Argument schema mirrors ``eval tune`` deliberately: same
+    --result, same --floor.
+    """
+    import json
+    from pathlib import Path
+
+    from kairix.quality.eval.gate import run_gate
+    from kairix.quality.eval.tune import CorpusHints
+
+    try:
+        with open(args.result) as f:
+            data = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    summary = data.get("summary", {})
+    scores = summary.get("category_scores", {})
+    weighted_total = float(summary.get("weighted_total", 0.0))
+    if not scores:
+        print("ERROR: No category_scores found in result file.", file=sys.stderr)
+        return 1
+
+    # Best-effort corpus hints from the local index — same approach as tune.
+    hints = CorpusHints()
+    try:
+        from kairix.core.db import get_db_path, open_db
+        from kairix.quality.eval.auto_gold import analyse_corpus
+
+        db_path = get_db_path()
+        db = open_db(Path(db_path))
+        profile = analyse_corpus(db)
+        db.close()
+        hints = CorpusHints(
+            has_date_files=profile.date_filename_count > 0,
+            has_procedural_docs=profile.procedural_count > 0,
+            has_entity_folders=profile.entity_doc_count > 0,
+        )
+    except Exception:
+        # No index available — fall back to no hints. Recommendations stay generic.
+        pass
+
+    result = run_gate(scores, weighted_total=weighted_total, hints=hints, floor=args.floor)
+    print(result.format())
+
+    return 0 if result.passed else 2
+
+
 def _cmd_sweep(args: argparse.Namespace) -> int:
     from pathlib import Path
 
@@ -512,6 +563,19 @@ def main(argv: list[str] | None = None) -> None:
         help="Category floor threshold (default: 0.50)",
     )
 
+    # --- gate ---
+    p_gate = subparsers.add_parser(
+        "gate",
+        help="Stage 5 (KFEAT-013) — apply quality gate to a benchmark result; exit 0 PASS / 2 HOLD",
+    )
+    p_gate.add_argument("--result", required=True, help="Benchmark result JSON file")
+    p_gate.add_argument(
+        "--floor",
+        type=float,
+        default=0.50,
+        help="Category floor threshold (default: 0.50)",
+    )
+
     # --- sweep ---
     p_sweep = subparsers.add_parser("sweep", help="Grid search BM25 column weights and query styles")
     p_sweep.add_argument("--suite", required=True, help="Benchmark suite YAML with gold_titles")
@@ -548,6 +612,7 @@ def main(argv: list[str] | None = None) -> None:
         "build-gold": _cmd_build_gold,
         "auto-gold": _cmd_auto_gold,
         "tune": _cmd_tune,
+        "gate": _cmd_gate,
         "sweep": _cmd_sweep,
         "hybrid-sweep": _cmd_hybrid_sweep,
     }

--- a/kairix/quality/eval/gate.py
+++ b/kairix/quality/eval/gate.py
@@ -1,0 +1,119 @@
+"""Quality gate — final stage of the onboarding flow (KFEAT-013, stage 5).
+
+Takes a benchmark result and renders a go/hold verdict, with concrete
+parameter-change recommendations for any category scoring below the floor.
+
+Composition:
+
+  benchmark run --suite <gold>      → result.json (category_scores)
+  kairix.quality.eval.tune          → analyse_results, recommend
+  kairix.quality.eval.gate          → run_gate (this module)
+
+The gate is a pure function over already-computed benchmark scores. It
+does not run the benchmark itself — that's the caller's job. This keeps
+the gate trivially testable (pass in scores, get a verdict) without any
+test-only kwargs in the production API.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from kairix.quality.eval.tune import (
+    CorpusHints,
+    Recommendation,
+    analyse_results,
+    recommend,
+)
+
+
+@dataclass
+class GateResult:
+    """Outcome of evaluating a benchmark result against the quality floor.
+
+    ``verdict`` is one of:
+      - ``"pass"`` — every category is at or above ``floor``. Search is ready.
+      - ``"hold"`` — at least one category is below ``floor``. Apply the
+        recommendations and re-run the gate.
+    """
+
+    verdict: str
+    weighted_total: float
+    floor: float
+    category_scores: dict[str, float]
+    weak_categories: list[str] = field(default_factory=list)
+    recommendations: list[Recommendation] = field(default_factory=list)
+
+    @property
+    def passed(self) -> bool:
+        return self.verdict == "pass"
+
+    def format(self) -> str:
+        """Render the gate result as a human-readable string."""
+        lines: list[str] = []
+        emoji = "✅" if self.passed else "🛑"
+        verdict_label = "PASS" if self.passed else "HOLD"
+        lines.append(f"{emoji} Quality Gate: {verdict_label}")
+        lines.append(f"   Weighted total: {self.weighted_total:.4f}")
+        lines.append(f"   Floor:          {self.floor:.4f}")
+        lines.append("")
+        lines.append("Category scores:")
+        for cat, score in sorted(self.category_scores.items()):
+            mark = "✓" if score >= self.floor else "✗"
+            lines.append(f"   {mark} {cat:<14} {score:.4f}")
+
+        if self.weak_categories:
+            lines.append("")
+            lines.append(f"Weak categories ({len(self.weak_categories)}):")
+            for cat in self.weak_categories:
+                lines.append(f"   - {cat}")
+
+        if self.recommendations:
+            lines.append("")
+            lines.append("Recommendations:")
+            for rec in self.recommendations:
+                lines.append(f"   • {rec.parameter}: {rec.action}")
+                lines.append(f"     {rec.reason}")
+                lines.append(f"     Expected impact: {rec.expected_impact}")
+
+        if self.passed and not self.recommendations:
+            lines.append("")
+            lines.append("All categories at or above the quality floor — no changes recommended.")
+
+        return "\n".join(lines)
+
+
+def run_gate(
+    scores: dict[str, float],
+    *,
+    weighted_total: float,
+    hints: CorpusHints | None = None,
+    floor: float = 0.50,
+) -> GateResult:
+    """Evaluate a benchmark result against the quality floor.
+
+    Args:
+        scores: per-category NDCG scores (e.g. ``{"recall": 0.82, ...}``).
+        weighted_total: the suite's weighted-total NDCG, for reporting.
+        hints: corpus characteristics that gate which recommendations apply.
+            Defaults to no hints — recommendations stay generic.
+        floor: minimum acceptable per-category score. Categories below this
+            float trigger ``hold`` and produce recommendations.
+
+    Returns:
+        ``GateResult`` with the verdict, scores, and any recommendations.
+    """
+    analysis = analyse_results(scores, floor=floor)
+    weak = list(analysis.weak_categories)
+    recs = recommend(weak, hints or CorpusHints())
+
+    verdict = "pass" if not weak else "hold"
+
+    return GateResult(
+        verdict=verdict,
+        weighted_total=weighted_total,
+        floor=floor,
+        category_scores=dict(scores),
+        weak_categories=weak,
+        recommendations=recs,
+    )

--- a/tests/bdd/features/eval_gate.feature
+++ b/tests/bdd/features/eval_gate.feature
@@ -1,0 +1,46 @@
+Feature: Quality gate (KFEAT-013, stage 5)
+  As an operator finishing the kairix onboarding flow
+  I want the eval gate to tell me whether my tuned config is good enough
+  So that I know whether to ship or to apply more recommendations
+
+  Scenario: Every category at or above floor produces a PASS
+    Given a benchmark result with all categories at 0.80
+    When I run the quality gate with floor 0.50
+    Then the verdict is "pass"
+    And no weak categories are reported
+    And no gate recommendations are produced
+
+  Scenario: One category below floor produces a HOLD with recommendations
+    Given a benchmark result where temporal is 0.30 with date-named corpus and others are 0.80
+    When I run the quality gate with floor 0.50
+    Then the verdict is "hold"
+    And "temporal" is reported as a weak gate category
+    And at least one gate recommendation targets "temporal"
+
+  Scenario: Multiple weak categories all generate recommendations
+    Given a benchmark result where temporal is 0.20 and conceptual is 0.30 with date-named corpus and others are 0.80
+    When I run the quality gate with floor 0.50
+    Then the verdict is "hold"
+    And both "temporal" and "conceptual" are weak gate categories
+    And gate recommendations exist for both
+
+  Scenario: Recommendations are gated by corpus hints
+    Given a benchmark result where temporal is 0.20 with no date-named corpus and others are 0.80
+    When I run the quality gate with floor 0.50
+    Then the verdict is "hold"
+    And "temporal" is a weak gate category
+    But no gate recommendation targets "temporal" with date_path_boost
+
+  Scenario: Floor controls strictness
+    Given a benchmark result where every category is exactly 0.55
+    When I run the quality gate with floor 0.60
+    Then the verdict is "hold"
+    When I run the quality gate with floor 0.50
+    Then the verdict is "pass"
+
+  Scenario: Output formatting renders verdict and category breakdown
+    Given a benchmark result where recall is 0.90 and procedural is 0.40 with procedural-doc corpus
+    When I run the quality gate with floor 0.50
+    Then the gate output contains the verdict label
+    And the gate output contains every category score
+    And the gate output contains the recommendation for procedural

--- a/tests/bdd/steps/eval_gate_steps.py
+++ b/tests/bdd/steps/eval_gate_steps.py
@@ -1,0 +1,206 @@
+"""Step definitions for eval_gate.feature (KFEAT-013, stage 5).
+
+Exercises the gate function directly via dependency-free composition: pass
+in scores + hints, observe the GateResult. No fakes for production code,
+no monkeypatch — the gate is a pure function over already-computed
+benchmark scores. Corpus hints are constructed inline per scenario.
+
+All step phrases are namespaced with "gate" tokens to avoid collisions
+with the existing eval_tune_steps.py which uses similar Gherkin phrasing.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pytest_bdd import given, parsers, then, when
+
+from kairix.quality.eval.gate import GateResult, run_gate
+from kairix.quality.eval.tune import CorpusHints
+
+pytestmark = pytest.mark.bdd
+
+
+@pytest.fixture
+def gate_state() -> dict:
+    return {"scores": {}, "hints": CorpusHints(), "result": None}
+
+
+def _all_categories(value: float) -> dict[str, float]:
+    return {
+        "recall": value,
+        "temporal": value,
+        "entity": value,
+        "conceptual": value,
+        "multi_hop": value,
+        "procedural": value,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Givens — score setup combined with corpus-hint context
+# ---------------------------------------------------------------------------
+
+
+@given(parsers.parse("a benchmark result with all categories at {value:f}"))
+def all_categories_at(gate_state: dict, value: float) -> None:
+    gate_state["scores"] = _all_categories(value)
+
+
+@given(
+    parsers.parse(
+        "a benchmark result where temporal is {temporal:f} with date-named corpus and others are {others:f}"
+    )
+)
+def temporal_low_with_date_corpus(gate_state: dict, temporal: float, others: float) -> None:
+    gate_state["scores"] = _all_categories(others) | {"temporal": temporal}
+    gate_state["hints"] = CorpusHints(has_date_files=True)
+
+
+@given(
+    parsers.parse(
+        "a benchmark result where temporal is {temporal:f} with no date-named corpus and others are {others:f}"
+    )
+)
+def temporal_low_no_date_corpus(gate_state: dict, temporal: float, others: float) -> None:
+    gate_state["scores"] = _all_categories(others) | {"temporal": temporal}
+    gate_state["hints"] = CorpusHints(has_date_files=False)
+
+
+@given(
+    parsers.parse(
+        "a benchmark result where temporal is {temporal:f} and conceptual is {conceptual:f} "
+        "with date-named corpus and others are {others:f}"
+    )
+)
+def temporal_and_conceptual_low(gate_state: dict, temporal: float, conceptual: float, others: float) -> None:
+    gate_state["scores"] = _all_categories(others) | {
+        "temporal": temporal,
+        "conceptual": conceptual,
+    }
+    gate_state["hints"] = CorpusHints(has_date_files=True)
+
+
+@given(parsers.parse("a benchmark result where every category is exactly {value:f}"))
+def every_category_at(gate_state: dict, value: float) -> None:
+    gate_state["scores"] = _all_categories(value)
+
+
+@given(
+    parsers.parse(
+        "a benchmark result where recall is {recall:f} and procedural is {procedural:f} with procedural-doc corpus"
+    )
+)
+def recall_high_procedural_low(gate_state: dict, recall: float, procedural: float) -> None:
+    gate_state["scores"] = _all_categories(0.80) | {
+        "recall": recall,
+        "procedural": procedural,
+    }
+    gate_state["hints"] = CorpusHints(has_procedural_docs=True)
+
+
+# ---------------------------------------------------------------------------
+# When — invoke the gate
+# ---------------------------------------------------------------------------
+
+
+@when(parsers.parse("I run the quality gate with floor {floor:f}"))
+def run_quality_gate(gate_state: dict, floor: float) -> None:
+    weighted = sum(gate_state["scores"].values()) / max(len(gate_state["scores"]), 1)
+    gate_state["result"] = run_gate(
+        gate_state["scores"],
+        weighted_total=weighted,
+        hints=gate_state["hints"],
+        floor=floor,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Thens — assert the GateResult shape + content (gate-prefixed to avoid
+# collision with eval_tune_steps Gherkin)
+# ---------------------------------------------------------------------------
+
+
+@then(parsers.parse('the verdict is "{verdict}"'))
+def verdict_is(gate_state: dict, verdict: str) -> None:
+    result: GateResult = gate_state["result"]
+    assert result.verdict == verdict, f"expected {verdict}, got {result.verdict}"
+
+
+@then("no weak categories are reported")
+def no_weak(gate_state: dict) -> None:
+    result: GateResult = gate_state["result"]
+    assert result.weak_categories == [], f"expected no weak categories, got {result.weak_categories}"
+
+
+@then("no gate recommendations are produced")
+def no_recommendations(gate_state: dict) -> None:
+    result: GateResult = gate_state["result"]
+    assert result.recommendations == [], f"expected no recommendations, got {result.recommendations}"
+
+
+@then(parsers.parse('"{cat}" is reported as a weak gate category'))
+def category_reported_weak(gate_state: dict, cat: str) -> None:
+    result: GateResult = gate_state["result"]
+    assert cat in result.weak_categories, f"expected {cat} in {result.weak_categories}"
+
+
+@then(parsers.parse('at least one gate recommendation targets "{cat}"'))
+def recommendation_targets(gate_state: dict, cat: str) -> None:
+    result: GateResult = gate_state["result"]
+    matches = [r for r in result.recommendations if r.parameter == cat]
+    assert matches, f"no recommendation for {cat}: {[r.parameter for r in result.recommendations]}"
+
+
+@then(parsers.parse('both "{a}" and "{b}" are weak gate categories'))
+def both_weak(gate_state: dict, a: str, b: str) -> None:
+    result: GateResult = gate_state["result"]
+    assert a in result.weak_categories and b in result.weak_categories, (
+        f"expected both {a} and {b} weak, got {result.weak_categories}"
+    )
+
+
+@then("gate recommendations exist for both")
+def recommendations_for_both(gate_state: dict) -> None:
+    result: GateResult = gate_state["result"]
+    parameters = {r.parameter for r in result.recommendations}
+    assert len(parameters) >= 2, f"expected ≥2 distinct recommendation targets, got {parameters}"
+
+
+@then(parsers.parse('"{cat}" is a weak gate category'))
+def cat_is_weak(gate_state: dict, cat: str) -> None:
+    result: GateResult = gate_state["result"]
+    assert cat in result.weak_categories
+
+
+@then(parsers.parse('no gate recommendation targets "{cat}" with date_path_boost'))
+def no_date_boost_recommendation(gate_state: dict, cat: str) -> None:
+    result: GateResult = gate_state["result"]
+    matches = [r for r in result.recommendations if r.parameter == cat and "date_path_boost" in r.action]
+    assert not matches, f"unexpected date_path_boost recommendation for {cat}: {matches}"
+
+
+@then("the gate output contains the verdict label")
+def output_contains_verdict(gate_state: dict) -> None:
+    result: GateResult = gate_state["result"]
+    formatted = result.format()
+    label = "PASS" if result.passed else "HOLD"
+    assert label in formatted, f"verdict {label} not in formatted output"
+
+
+@then("the gate output contains every category score")
+def output_contains_scores(gate_state: dict) -> None:
+    result: GateResult = gate_state["result"]
+    formatted = result.format()
+    for cat in result.category_scores:
+        assert cat in formatted, f"category {cat} missing from output"
+
+
+@then(parsers.parse("the gate output contains the recommendation for {cat}"))
+def output_contains_recommendation(gate_state: dict, cat: str) -> None:
+    result: GateResult = gate_state["result"]
+    formatted = result.format()
+    matches = [r for r in result.recommendations if r.parameter == cat]
+    assert matches, f"no recommendation for {cat} to verify in output"
+    assert f"{cat}:" in formatted or f"{cat} " in formatted, (
+        f"recommendation for {cat} not visible in formatted output"
+    )

--- a/tests/bdd/test_eval_gate.py
+++ b/tests/bdd/test_eval_gate.py
@@ -1,0 +1,12 @@
+"""pytest-bdd test runner for eval_gate.feature (KFEAT-013, stage 5)."""
+
+from pathlib import Path
+
+import pytest
+from pytest_bdd import scenarios
+
+FEATURE = str(Path(__file__).parent / "features" / "eval_gate.feature")
+
+pytestmark = pytest.mark.bdd
+
+scenarios(FEATURE)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ pytest_plugins = [
     "tests.bdd.steps.research_synthesis_steps",
     "tests.bdd.steps.search_dedup_steps",
     "tests.bdd.steps.agent_collections_steps",
+    "tests.bdd.steps.eval_gate_steps",
 ]
 
 from tests.fixtures.embeddings import fake_embedding  # noqa: E402

--- a/tests/integration/test_eval_gate_cli.py
+++ b/tests/integration/test_eval_gate_cli.py
@@ -1,0 +1,142 @@
+"""End-to-end integration test for `kairix eval gate` (KFEAT-013, stage 5).
+
+Exercises the real CLI dispatch path: writes a benchmark-result JSON to
+disk, invokes ``main(["gate", "--result", ...])`` with no fakes, and
+asserts the verdict + exit code. The gate function itself is fully unit-
+covered via BDD; this test exists to prove the wiring (CLI subparser,
+JSON loading, result rendering, exit code mapping) works against the
+real production code path.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kairix.quality.eval.cli import main as eval_cli_main
+
+pytestmark = pytest.mark.integration
+
+
+def _write_result(tmp_path: Path, weighted: float, scores: dict[str, float]) -> Path:
+    """Write a benchmark-result JSON in the shape the gate expects."""
+    payload = {
+        "summary": {
+            "weighted_total": weighted,
+            "category_scores": scores,
+        },
+        "cases": [],  # not consulted by the gate
+    }
+    result_path = tmp_path / "result.json"
+    result_path.write_text(json.dumps(payload), encoding="utf-8")
+    return result_path
+
+
+def _run_gate(args: list[str]) -> int:
+    """Invoke the eval CLI and return its exit code.
+
+    The CLI dispatches via ``sys.exit(fn(args))`` so we catch SystemExit
+    and read ``.value.code``. Mirrors how a shell would observe the exit
+    status — closer to a real end-to-end test than reading a return value.
+    """
+    with pytest.raises(SystemExit) as excinfo:
+        eval_cli_main(args)
+    return int(excinfo.value.code or 0)
+
+
+@pytest.mark.integration
+def test_gate_cli_pass_exits_zero(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """All categories above floor → PASS verdict, exit code 0."""
+    result_path = _write_result(
+        tmp_path,
+        weighted=0.82,
+        scores={
+            "recall": 0.85,
+            "temporal": 0.80,
+            "entity": 0.85,
+            "conceptual": 0.78,
+            "multi_hop": 0.75,
+            "procedural": 0.90,
+        },
+    )
+
+    exit_code = _run_gate(["gate", "--result", str(result_path), "--floor", "0.50"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "PASS" in captured.out
+    assert "Weighted total: 0.8200" in captured.out
+
+
+@pytest.mark.integration
+def test_gate_cli_hold_exits_two(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """A weak category below floor → HOLD verdict, exit code 2."""
+    result_path = _write_result(
+        tmp_path,
+        weighted=0.55,
+        scores={
+            "recall": 0.65,
+            "temporal": 0.30,  # below floor
+            "entity": 0.70,
+            "conceptual": 0.55,
+            "multi_hop": 0.55,
+            "procedural": 0.55,
+        },
+    )
+
+    exit_code = _run_gate(["gate", "--result", str(result_path), "--floor", "0.50"])
+
+    assert exit_code == 2
+    captured = capsys.readouterr()
+    assert "HOLD" in captured.out
+    assert "temporal" in captured.out
+    # Weak category prints with ✗ marker
+    assert "✗" in captured.out
+
+
+@pytest.mark.integration
+def test_gate_cli_missing_result_exits_one(tmp_path: Path) -> None:
+    """A non-existent result file is a usage error — exit code 1."""
+    exit_code = _run_gate(["gate", "--result", str(tmp_path / "does-not-exist.json"), "--floor", "0.50"])
+    assert exit_code == 1
+
+
+@pytest.mark.integration
+def test_gate_cli_empty_scores_exits_one(tmp_path: Path) -> None:
+    """A result file with no category_scores is a usage error — exit code 1."""
+    result_path = tmp_path / "empty-result.json"
+    result_path.write_text(
+        json.dumps({"summary": {"weighted_total": 0.0, "category_scores": {}}}),
+        encoding="utf-8",
+    )
+    exit_code = _run_gate(["gate", "--result", str(result_path), "--floor", "0.50"])
+    assert exit_code == 1
+
+
+@pytest.mark.integration
+def test_gate_cli_floor_controls_strictness(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Same result, different floors — gate flips verdict accordingly."""
+    result_path = _write_result(
+        tmp_path,
+        weighted=0.55,
+        scores={
+            "recall": 0.55,
+            "temporal": 0.55,
+            "entity": 0.55,
+            "conceptual": 0.55,
+            "multi_hop": 0.55,
+            "procedural": 0.55,
+        },
+    )
+
+    # Strict floor: 0.60 → all 0.55 categories are weak → HOLD
+    exit_code_strict = _run_gate(["gate", "--result", str(result_path), "--floor", "0.60"])
+    assert exit_code_strict == 2
+
+    capsys.readouterr()  # clear
+
+    # Lenient floor: 0.50 → all categories pass → PASS
+    exit_code_lenient = _run_gate(["gate", "--result", str(result_path), "--floor", "0.50"])
+    assert exit_code_lenient == 0


### PR DESCRIPTION
## Summary

Adds the missing **stage 5** of the KFEAT-013 onboarding flow. Stages 1–4 shipped Sprint 17 (\`kairix setup\` → \`entity seed\` → \`eval auto-gold\` → \`eval tune\`); this PR closes the loop with the verdict step that takes a tuned-config benchmark result + corpus hints and produces a go/hold decision plus concrete parameter-change recommendations.

## What's in this PR

### Production

| File | Purpose |
|---|---|
| \`kairix/quality/eval/gate.py\` | New \`GateResult\` dataclass + \`run_gate()\` pure function. Composes existing \`analyse_results\` + \`recommend\` from \`tune.py\` — no logic duplication. |
| \`kairix/quality/eval/cli.py\` | New \`kairix eval gate --result <path> --floor <f>\` subcommand. Exit 0 PASS / 2 HOLD / 1 usage error so wrappers can chain on success. |

### Tests (per code-smell discipline — no monkeypatch, no test-only kwargs)

| File | Coverage |
|---|---|
| \`tests/bdd/features/eval_gate.feature\` | 6 BDD scenarios: all-pass, single weak category, multi-weak, hint-gated recommendations, floor strictness, output formatting |
| \`tests/bdd/steps/eval_gate_steps.py\` | Step definitions; gate-prefixed Gherkin to avoid collision with existing \`eval_tune_steps.py\` |
| \`tests/integration/test_eval_gate_cli.py\` | 5 integration tests against real CLI dispatch (writes result JSON, invokes \`main([\"gate\", ...])\`, asserts exit code + stdout) |

**2133 unit/bdd/contract/integration tests pass** (was 2117). mypy strict + ruff clean.

## Onboarding flow — now end-to-end

\`\`\`
kairix setup                                  # stage 1: paths, ports, collections
kairix entity seed                            # stage 2: discover entities, seed Neo4j
kairix eval auto-gold --output suite.yaml     # stage 3: generate evaluation queries
kairix eval build-gold --suite suite.yaml ... # stage 3b: LLM-judge for graded gold
kairix eval tune --result post-tune.json      # stage 4: parameter recommendations
kairix benchmark run --suite suite.yaml --output result.json
kairix eval gate --result result.json         # stage 5: verdict + recommendations  ← THIS PR
\`\`\`

The verdict logic is gated by corpus hints: \`temporal\` recommendations only fire when the corpus has date-named files; \`procedural\` only when how-to/runbook/guide patterns are present. Hints are derived from the local index (same fallback path as \`eval tune\`).

## What's deliberately NOT in scope

- **\`kairix onboard\` orchestrator chain** — chaining the five stages with a single command + pause/resume state. That's mechanical glue once each stage is callable standalone (stage 5 was the missing piece). Worth a follow-up PR sized at ~3h, not bundled here.

## Test plan

- [x] BDD: 6 scenarios cover the full verdict matrix (PASS/HOLD × hint-gating × multi-weak).
- [x] Integration: real CLI dispatch path, real JSON loading, real exit codes via \`SystemExit\`.
- [x] No collision with existing eval_tune scenarios — gate-prefixed Gherkin.
- [x] \`safe-commit.sh\` clean (lint, format, mypy strict).
- [ ] CI on this PR.
- [ ] Operator dry-run after merge: \`kairix benchmark run\` against the v3 user-vault gold suite, then \`kairix eval gate\` on the result. Verify verdict + recommendations on real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)