### PR TITLE
fix: schema migrate() runs between table create and index create (#114 follow-on)

### DIFF
--- a/kairix/core/db/schema.py
+++ b/kairix/core/db/schema.py
@@ -36,6 +36,9 @@ def create_schema(db: sqlite3.Connection, *, dims: int = EMBED_VECTOR_DIMS) -> N
         db:   Open sqlite3.Connection.
         dims: Vector embedding dimensions (for metadata only — vectors stored in usearch).
     """
+    # Tables only — indexes that depend on migrated columns (agent_owner,
+    # chunk_date) come after migrate() runs, otherwise legacy DBs that don't
+    # yet have those columns fail with "no such column" on CREATE INDEX.
     db.executescript("""
         CREATE TABLE IF NOT EXISTS documents (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -74,6 +77,16 @@ def create_schema(db: sqlite3.Connection, *, dims: int = EMBED_VECTOR_DIMS) -> N
         CREATE INDEX IF NOT EXISTS idx_documents_hash ON documents(hash);
         CREATE INDEX IF NOT EXISTS idx_documents_collection ON documents(collection);
         CREATE INDEX IF NOT EXISTS idx_documents_active ON documents(active);
+    """)
+
+    # Run migrations to bring legacy schemas up to current (adds agent_owner,
+    # chunk_date columns to existing tables). On a fresh DB this is a no-op
+    # because the CREATE TABLE above already declared the columns.
+    migrate(db)
+
+    # Indexes that depend on migrated columns — must come after migrate() so
+    # the columns exist on legacy DBs.
+    db.executescript("""
         CREATE INDEX IF NOT EXISTS idx_documents_agent_owner ON documents(agent_owner);
         CREATE INDEX IF NOT EXISTS idx_content_vectors_chunk_date ON content_vectors(chunk_date);
     """)

--- a/tests/bdd/steps/eval_gate_steps.py
+++ b/tests/bdd/steps/eval_gate_steps.py
@@ -47,9 +47,7 @@ def all_categories_at(gate_state: dict, value: float) -> None:
 
 
 @given(
-    parsers.parse(
-        "a benchmark result where temporal is {temporal:f} with date-named corpus and others are {others:f}"
-    )
+    parsers.parse("a benchmark result where temporal is {temporal:f} with date-named corpus and others are {others:f}")
 )
 def temporal_low_with_date_corpus(gate_state: dict, temporal: float, others: float) -> None:
     gate_state["scores"] = _all_categories(others) | {"temporal": temporal}
@@ -201,6 +199,4 @@ def output_contains_recommendation(gate_state: dict, cat: str) -> None:
     formatted = result.format()
     matches = [r for r in result.recommendations if r.parameter == cat]
     assert matches, f"no recommendation for {cat} to verify in output"
-    assert f"{cat}:" in formatted or f"{cat} " in formatted, (
-        f"recommendation for {cat} not visible in formatted output"
-    )
+    assert f"{cat}:" in formatted or f"{cat} " in formatted, f"recommendation for {cat} not visible in formatted output"

--- a/tests/db/test_schema.py
+++ b/tests/db/test_schema.py
@@ -297,3 +297,64 @@ def test_migrate_idempotent_on_agent_owner() -> None:
     migrate(db)  # second call must not raise
     cols = {row[1] for row in db.execute("PRAGMA table_info(documents)")}
     assert "agent_owner" in cols
+
+
+@pytest.mark.unit
+def test_create_schema_on_legacy_db_runs_migration() -> None:
+    """create_schema() must work on a pre-#114 documents table without agent_owner.
+
+    Regression for VM hotfix 2026-05-06: deploying the WS3-5-114 schema to a
+    running VM with an existing index.sqlite raised
+    `sqlite3.OperationalError: no such column: agent_owner` because the
+    CREATE INDEX for idx_documents_agent_owner ran inside the same
+    executescript as the CREATE TABLE IF NOT EXISTS — the IF NOT EXISTS
+    skipped the table create on legacy DBs (table already there without the
+    column), but the CREATE INDEX still fired.
+
+    Fix: split the executescript so migrate() runs *between* table creation
+    and index creation. This test asserts the upgrade path works.
+    """
+    db = sqlite3.connect(":memory:")
+    # Build a pre-#114 documents schema (no agent_owner column) and seed a row
+    db.executescript(
+        """
+        CREATE TABLE documents (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            collection TEXT NOT NULL,
+            path TEXT NOT NULL,
+            title TEXT,
+            hash TEXT NOT NULL,
+            created_at TEXT,
+            modified_at TEXT,
+            active INTEGER DEFAULT 1,
+            UNIQUE(collection, path)
+        );
+        CREATE TABLE content (hash TEXT PRIMARY KEY, doc TEXT, created_at TEXT);
+        CREATE TABLE content_vectors (
+            hash TEXT NOT NULL, seq INTEGER NOT NULL, pos INTEGER NOT NULL,
+            model TEXT, embedded_at TEXT,
+            PRIMARY KEY (hash, seq)
+        );
+        INSERT INTO documents (collection, path, title, hash, active)
+        VALUES ('areas', '02-Areas/legacy.md', 'Legacy Doc', 'h1', 1);
+        """
+    )
+
+    # Must not raise — this is the bug the hotfix repairs
+    create_schema(db)
+
+    # Both columns are now present
+    doc_cols = {row[1] for row in db.execute("PRAGMA table_info(documents)")}
+    cv_cols = {row[1] for row in db.execute("PRAGMA table_info(content_vectors)")}
+    assert "agent_owner" in doc_cols
+    assert "chunk_date" in cv_cols
+
+    # Indexes for migrated columns are present
+    indexes = {row[0] for row in db.execute("SELECT name FROM sqlite_master WHERE type='index'")}
+    assert "idx_documents_agent_owner" in indexes
+    assert "idx_content_vectors_chunk_date" in indexes
+
+    # The pre-existing row survived migration with NULL agent_owner
+    row = db.execute("SELECT path, agent_owner FROM documents").fetchone()
+    assert row[0] == "02-Areas/legacy.md"
+    assert row[1] is None


### PR DESCRIPTION
## Summary

Hotfix for the WS3-5-114 schema migration. Caught when promoting \`:develop\` to the production VM during sprint closure 2026-05-06 — the worker container hit \`sqlite3.OperationalError: no such column: agent_owner\` on every embed cycle.

## Root cause

\`create_schema()\` ran a single executescript that did **both** \`CREATE TABLE IF NOT EXISTS\` and \`CREATE INDEX\`. On a fresh DB this worked because the table CREATE included the new \`agent_owner\` column. On a **legacy DB** (table already exists from a pre-#114 deploy), \`CREATE TABLE IF NOT EXISTS\` was a no-op, \`agent_owner\` stayed missing, and the subsequent \`CREATE INDEX idx_documents_agent_owner\` raised.

## Fix

Split the executescript into two halves with \`migrate(db)\` between them:

1. \`CREATE TABLE IF NOT EXISTS\` for all tables + indexes that **don't** depend on migrated columns.
2. **\`migrate(db)\`** — adds \`agent_owner\` / \`chunk_date\` to legacy tables via idempotent \`ALTER TABLE\`.
3. \`CREATE INDEX IF NOT EXISTS\` for the migrated-column indexes — runs after step 2 so the columns exist.

On a fresh DB step 2 is a no-op (columns already declared at step 1). On a legacy DB step 2 brings the table up to current shape before the indexes try to reference the new columns.

## Regression test

\`test_create_schema_on_legacy_db_runs_migration\` in \`tests/db/test_schema.py\` — builds a pre-#114 documents schema, seeds a row, calls \`create_schema()\`, asserts both columns and both indexes are present afterwards and the seed row survives.

## Test plan

- [x] \`safe-commit.sh\` clean: 2162 tests pass (was 2133), mypy strict + ruff format/lint OK.
- [x] New regression test added.
- [ ] CI on this PR.
- [ ] **VM verify**: pull the rebuilt \`:develop\` after merge; worker should no longer restart-loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)