### PR TITLE
fix(tests): roll synthetic-agent memory fixture dates to today at session setup

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import shutil
 import sqlite3
+from datetime import date, timedelta
 from pathlib import Path
 
 import pytest
@@ -44,6 +45,47 @@ def _populate_fts(db: sqlite3.Connection) -> None:
     db.commit()
 
 
+def _roll_memory_dates_to_today(tmp_root: Path) -> None:
+    """Shift date-named memory fixture files so the most recent file lands today.
+
+    The synthetic-agent fixture ships with hardcoded date stems (e.g.
+    ``2026-04-28.md``). The briefing source fetcher reads ``today - 7d``
+    onwards by literal filename, so as the calendar advances the fixture's
+    most recent file falls outside the read window and the integration
+    test ``test_briefing_fetches_memory_logs`` flips to FAIL on the day
+    that happens.
+
+    This shifts every date-named file in every ``*/memory/`` directory by
+    ``today - max(fixture_dates)`` so the relative spacing is preserved
+    and the most recent fixture file is always dated today. Non-date
+    filenames are left alone.
+    """
+    today = date.today()
+    for memory_dir in tmp_root.rglob("memory"):
+        if not memory_dir.is_dir():
+            continue
+        dated: list[tuple[date, Path]] = []
+        for f in memory_dir.glob("*.md"):
+            try:
+                dated.append((date.fromisoformat(f.stem), f))
+            except ValueError:
+                continue
+        if not dated:
+            continue
+        latest = max(d for d, _ in dated)
+        shift = today - latest
+        if shift == timedelta(0):
+            continue
+        # Two-pass rename via temp suffix to avoid name collisions when the
+        # shift produces a date that's already used by another fixture file.
+        for _, path in dated:
+            path.rename(path.with_suffix(".md.rolling"))
+        for original_date, path in dated:
+            tmp = path.with_suffix(".md.rolling")
+            new_name = (original_date + shift).isoformat() + ".md"
+            tmp.rename(path.with_name(new_name))
+
+
 @pytest.fixture(scope="session")
 def _integration_env(
     tmp_path_factory: pytest.TempPathFactory,
@@ -66,6 +108,9 @@ def _integration_env(
                 shutil.copytree(child, tmp_root / child.name)
             elif child.name.endswith(".md"):
                 shutil.copy2(child, tmp_root / child.name)
+
+    # Shift date-named memory files so the most recent one is today (see helper).
+    _roll_memory_dates_to_today(tmp_root)
 
     # Create real SQLite database
     db_path = tmp_root / "test_index.sqlite"

--- a/tests/integration/test_timeline_retrieval.py
+++ b/tests/integration/test_timeline_retrieval.py
@@ -1,8 +1,12 @@
 """
 Integration tests: temporal index retrieval against synthetic agent memory logs.
+
+Memory fixture dates are rolled forward to today by the integration conftest
+(see ``_roll_memory_dates_to_today``), so the date range below is computed
+relative to today rather than pinned to the original fixture stems.
 """
 
-from datetime import date
+from datetime import date, timedelta
 
 import pytest
 
@@ -14,10 +18,11 @@ def test_timeline_finds_memory_logs(real_db, real_document_root):
     """Timeline retrieval finds agent memory logs within date range."""
     from kairix.core.temporal.index import query_temporal_chunks
 
+    today = date.today()
     results = query_temporal_chunks(
         "session update",
-        start=date(2026, 4, 28),
-        end=date(2026, 4, 30),
+        start=today - timedelta(days=2),
+        end=today,
     )
     assert len(results) > 0
 


### PR DESCRIPTION
## Summary

Two integration tests had hardcoded April-2026 dates that aged out as the calendar advanced past 2026-05-07. Both flipped from PASS to FAIL on the day the fixture's most recent file fell outside the production code's read window.

| Test | Failure mode |
|---|---|
| `test_briefing_pipeline.py::test_briefing_fetches_memory_logs` | `fetch_memory_logs` reads `{today}.md` … `{today-6d}.md` by literal filename. Fixture's max date `2026-04-30` was 7 days before today, just outside the window. |
| `test_timeline_retrieval.py::test_timeline_finds_memory_logs` | Pinned the query range to `date(2026,4,28)…date(2026,4,30)`; same aging problem on a different surface. |

## Fix

`_roll_memory_dates_to_today` in `tests/integration/conftest.py` shifts every date-named file in every fixture `*/memory/` directory by `today - max(fixture_dates)` at session setup. Relative spacing between files is preserved. Two-pass rename via `.md.rolling` temp suffix avoids name collisions when shifts overlap original date stems.

Timeline test re-pinned to `today-2 … today` so it stays in step with the rolled fixture.

## Why this surfaced now

`'Full integration suite'` runs only on `pull_request → main`. The release PR #134 (develop → main) hit it on the post-#136 sync. Not a regression from #135 (configurable scope) or #136 (changelog roll-forward) — pre-existing date-dependency, latent until 2026-05-07.

## Test plan
- [x] safe-commit: 2,150 tests + lint + format + mypy strict + secrets + confidential — all green
- [x] `pytest -m integration` locally: 69 passed, 5 skipped, 0 failed
- After merge: re-trigger the integration suite on PR #134 and expect it to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)