### PR TITLE
sec: inline NOSONAR comments so SonarCloud honours suppression

### DIFF
--- a/kairix/core/embed/cli.py
+++ b/kairix/core/embed/cli.py
@@ -74,10 +74,10 @@ def acquire_lock() -> IO[str]:
     lock_fh.close()
     try:
         holder_pid = int(LOCKFILE.read_text().strip())
-        # NOSONAR(python:S4828): signal 0 is documented as a process-existence
-        # probe — does not deliver a real signal. Used here to detect a stale
-        # lockfile from a dead PID before taking it over.
-        os.kill(holder_pid, 0)
+        # signal 0 is documented as a process-existence probe — does not
+        # deliver a real signal. Used here to detect a stale lockfile from a
+        # dead PID before taking it over.
+        os.kill(holder_pid, 0)  # NOSONAR(python:S4828) — signal 0 is a process-existence probe, not a delivered signal
         # Process is alive — genuine contention
         logging.error(
             "Could not acquire lock after %ds — PID %d is still running",

--- a/tests/wikilinks/test_injector.py
+++ b/tests/wikilinks/test_injector.py
@@ -22,9 +22,8 @@ from kairix.knowledge.wikilinks.resolver import WikiEntity
 # paths on the filesystem. The "/tmp" prefix matches what
 # tests/wikilinks/conftest.py sets via KAIRIX_DOCUMENT_ROOT /
 # KAIRIX_WORKSPACE_ROOT for the same fixture-string purpose.
-# NOSONAR(python:S5443): no actual /tmp filesystem access — string fixtures.
-_TEST_VAULT_ROOT = "/tmp/test-vault"
-_TEST_WORKSPACES_ROOT = "/tmp/test-workspaces"
+_TEST_VAULT_ROOT = "/tmp/test-vault"  # NOSONAR(python:S5443) — fixture string, not used as a path
+_TEST_WORKSPACES_ROOT = "/tmp/test-workspaces"  # NOSONAR(python:S5443) — fixture string, not used as a path
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three Security Hotspots flagged on PR #134 dropped the New Code Security Rating to E (gate requires ≥ A) — the same findings #129 triaged with NOSONAR rationale, but the suppression didn't take effect because SonarCloud's Python plugin requires the NOSONAR token on the **same physical line** as the offending statement, not in a preceding block comment.

| File | Line | Rule | Was | Fix |
|---|---|---|---|---|
| `kairix/core/embed/cli.py` | 80 | S4828 (signal usage) | NOSONAR comment 3 lines above on :77 | inline `# NOSONAR(python:S4828) — …` |
| `tests/wikilinks/test_injector.py` | 26, 27 | S5443 (publicly writable dirs) | one NOSONAR block comment on :25 covering both | per-line inline `# NOSONAR(python:S5443) — …` |

Block-comment rationale preserved adjacent to each statement; NOSONAR token moved inline. **No code-behaviour change.**

## Why this surfaced now
Same chicken-and-egg as the integration-suite issue: PRs #128 and #129 introduced the NOSONAR comments, but those PRs are part of the same release that hasn't landed on main yet. SonarCloud's "new code" baseline is `main`, so from its perspective these statements are new code with unsuppressed hotspots. Once the suppression is correctly placed, the gate clears.

## Test plan
- [x] safe-commit: 2,150 tests, lint, format, mypy strict, secrets, confidential — all green
- After merge into develop → release PR #134 picks up the change automatically; SonarCloud re-analyses; expect Security Rating A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)