### PR TITLE
feat(eval): Phase 1 — eval protocols + FakeXxx in tests/fakes.py

### DIFF
--- a/kairix/core/protocols.py
+++ b/kairix/core/protocols.py
@@ -153,3 +153,121 @@ class AgentRegistry(Protocol):
     def collection_for(self, name: str) -> str: ...
 
     def validate_write(self, agent_name: str, path: str) -> bool: ...
+
+
+# ---------------------------------------------------------------------------
+# Eval-module protocols (#143 Phase 1 — paired with FakeXxx in tests/fakes.py)
+#
+# These four protocols define the boundary between the eval module and the
+# external systems it depends on (LLM chat, vector retrieval, the corpus
+# itself). Phase 2a/2b refactor judge.py / hybrid_sweep.py / generate.py /
+# gold_builder.py to consume these protocols via constructor injection,
+# eliminating the *_fn=None test-substitution kwargs scattered across the
+# eval surface today.
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class ChatBackend(Protocol):
+    """LLM chat-completion surface — substitutable across Azure / OpenRouter / fakes.
+
+    Wraps the call shape ``kairix._azure.chat_completion`` / OpenAI-API
+    chat completions use. The eval module's LLM judge and query generator
+    consume this protocol so test code can inject a `FakeChatBackend`
+    rather than reaching past `_call_llm` into module-level state.
+
+    Implementations are expected to:
+      - Block until the response is complete (no streaming surface here).
+      - Apply their own retry / rate-limit policy internally.
+      - Raise on credential failure rather than returning empty content.
+    """
+
+    def complete(
+        self,
+        prompt: str,
+        *,
+        api_key: str,
+        endpoint: str,
+        deployment: str,
+        system: str | None = None,
+        temperature: float = 0.0,
+        timeout_s: float = 30.0,
+    ) -> str: ...
+
+
+@runtime_checkable
+class LLMJudge(Protocol):
+    """Pairwise / pointwise relevance judge over (query, document) pairs.
+
+    The judge labels each candidate document for a query with a 0/1/2
+    relevance grade. Production implementations call out to an LLM via
+    `ChatBackend`; tests use `FakeLLMJudge` returning pre-configured grades.
+
+    Implementations are expected to:
+      - Never raise — return all-zero grades on any error.
+      - Shuffle candidate order before judging to prevent positional bias.
+      - Return a `JudgeResult`-shaped value (query, grades, shuffle_order,
+        judge_model, calibration_passed).
+    """
+
+    def grade(
+        self,
+        query: str,
+        candidates: list[tuple[str, str]],
+        *,
+        runs: int = 1,
+    ) -> Any: ...
+
+    def calibrate(self) -> bool: ...
+
+
+@runtime_checkable
+class QueryGenerator(Protocol):
+    """Synthesises retrieval evaluation queries from a corpus document.
+
+    Production implementations call out to an LLM to generate diverse,
+    intent-tagged queries that the source document would be the primary
+    answer for. Tests use `FakeQueryGenerator` returning pre-configured
+    queries.
+
+    Implementations are expected to:
+      - Return between 0 and `n` queries (LLM may produce fewer).
+      - Tag each query with one of the configured intent categories.
+      - Sanitise the source document content against prompt injection.
+    """
+
+    def generate(
+        self,
+        title: str,
+        body: str,
+        *,
+        n: int,
+        categories: list[str],
+    ) -> list[Any]: ...
+
+
+@runtime_checkable
+class Retriever(Protocol):
+    """Hybrid-search facade for sweep / benchmark / gold-builder callers.
+
+    The eval pipeline retrieves candidate documents via this protocol so
+    sweep configurations can be tested against `FakeRetriever` returning
+    pre-configured rankings. Production implementations delegate to the
+    `SearchPipeline.search` surface but accept the eval-shaped argument
+    signature directly.
+
+    Implementations are expected to:
+      - Return results in fused-rank order (best first).
+      - Honour the `collections` filter when supplied.
+      - Surface vec-failed state (e.g. via a `vec_failed: bool` attribute
+        on the result) so callers can distinguish "no results" from
+        "vector index unavailable".
+    """
+
+    def retrieve(
+        self,
+        query: str,
+        *,
+        collections: list[str] | None = None,
+        cfg: Any = None,
+    ) -> Any: ...

--- a/tests/contracts/test_eval_protocols.py
+++ b/tests/contracts/test_eval_protocols.py
@@ -1,0 +1,115 @@
+"""Contract tests for the eval-module protocols (#143 Phase 1).
+
+Verifies that the FakeXxx implementations in tests/fakes.py satisfy each
+protocol via runtime isinstance() checks. Production class conformance
+(LLMJudge wrapping judge_batch, etc.) is added in Phase 2a/2b — those PRs
+extend these contract tests with their concrete classes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kairix.core.protocols import (
+    ChatBackend,
+    LLMJudge,
+    QueryGenerator,
+    Retriever,
+)
+from tests.fakes import (
+    FakeChatBackend,
+    FakeLLMJudge,
+    FakeQueryGenerator,
+    FakeRetriever,
+)
+
+
+@pytest.mark.contract
+class TestChatBackendContract:
+    def test_fake_chat_backend_satisfies_protocol(self) -> None:
+        assert isinstance(FakeChatBackend(), ChatBackend)
+
+    def test_fake_chat_backend_returns_canned_response(self) -> None:
+        backend = FakeChatBackend(responses=["hello", "world"])
+        assert backend.complete("p1", api_key="k", endpoint="e", deployment="d") == "hello"
+        assert backend.complete("p2", api_key="k", endpoint="e", deployment="d") == "world"
+
+    def test_fake_chat_backend_records_calls_for_inspection(self) -> None:
+        backend = FakeChatBackend(responses=["x"])
+        backend.complete("the prompt", api_key="K", endpoint="E", deployment="D", temperature=0.5)
+        assert len(backend.calls) == 1
+        assert backend.calls[0]["prompt"] == "the prompt"
+        assert backend.calls[0]["temperature"] == pytest.approx(0.5)
+
+    def test_fake_chat_backend_raises_when_responses_exhausted(self) -> None:
+        backend = FakeChatBackend(responses=["only-one"])
+        backend.complete("p1", api_key="k", endpoint="e", deployment="d")
+        with pytest.raises(IndexError, match="ran out of canned responses"):
+            backend.complete("p2", api_key="k", endpoint="e", deployment="d")
+
+    def test_fake_chat_backend_raises_configured_error(self) -> None:
+        boom = ValueError("No API credentials")
+        backend = FakeChatBackend(raise_on_call=boom)
+        with pytest.raises(ValueError, match="No API credentials"):
+            backend.complete("p", api_key="k", endpoint="e", deployment="d")
+
+
+@pytest.mark.contract
+class TestLLMJudgeContract:
+    def test_fake_llm_judge_satisfies_protocol(self) -> None:
+        assert isinstance(FakeLLMJudge(), LLMJudge)
+
+    def test_fake_llm_judge_returns_zero_grades_for_unknown_query(self) -> None:
+        judge = FakeLLMJudge()
+        result = judge.grade("unseen", [("doc-a", "snippet"), ("doc-b", "snippet")])
+        assert result.grades == {"doc-a": 0, "doc-b": 0}
+        assert result.shuffle_order == ("doc-a", "doc-b")
+
+    def test_fake_llm_judge_returns_configured_grades(self) -> None:
+        judge = FakeLLMJudge(grades_by_query={"q1": {"doc-a": 2, "doc-b": 1}})
+        result = judge.grade("q1", [("doc-a", "x"), ("doc-b", "y"), ("doc-c", "z")])
+        assert result.grades == {"doc-a": 2, "doc-b": 1, "doc-c": 0}
+
+    def test_fake_llm_judge_calibrate_returns_configured_pass(self) -> None:
+        assert FakeLLMJudge(calibration_passed=True).calibrate() is True
+        assert FakeLLMJudge(calibration_passed=False).calibrate() is False
+
+
+@pytest.mark.contract
+class TestQueryGeneratorContract:
+    def test_fake_query_generator_satisfies_protocol(self) -> None:
+        assert isinstance(FakeQueryGenerator(), QueryGenerator)
+
+    def test_fake_query_generator_returns_empty_for_unknown_title(self) -> None:
+        gen = FakeQueryGenerator()
+        assert gen.generate("unknown.md", "body", n=5, categories=["recall"]) == []
+
+    def test_fake_query_generator_returns_configured_queries_capped_at_n(self) -> None:
+        gen = FakeQueryGenerator(queries_by_title={"deploy.md": ["q1", "q2", "q3"]})
+        assert gen.generate("deploy.md", "body", n=2, categories=["recall"]) == ["q1", "q2"]
+
+
+@pytest.mark.contract
+class TestRetrieverContract:
+    def test_fake_retriever_satisfies_protocol(self) -> None:
+        assert isinstance(FakeRetriever(), Retriever)
+
+    def test_fake_retriever_returns_empty_for_unknown_query(self) -> None:
+        retriever = FakeRetriever()
+        result = retriever.retrieve("unknown query")
+        assert result.results == []
+        assert result.vec_failed is False
+
+    def test_fake_retriever_returns_configured_result(self) -> None:
+        from types import SimpleNamespace
+
+        canned = SimpleNamespace(results=[{"path": "doc.md"}], vec_failed=False)
+        retriever = FakeRetriever(results_by_query={"q1": canned})
+        assert retriever.retrieve("q1") is canned
+
+    def test_fake_retriever_records_calls(self) -> None:
+        retriever = FakeRetriever()
+        retriever.retrieve("q", collections=["c1", "c2"], cfg={"factor": 1.0})
+        assert len(retriever.calls) == 1
+        assert retriever.calls[0]["query"] == "q"
+        assert retriever.calls[0]["collections"] == ["c1", "c2"]

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -296,3 +296,177 @@ class FakeAgentRegistry:
                     return False
                 return path == wp or path.startswith(wp.rstrip("/") + "/")
         return False
+
+
+# ---------------------------------------------------------------------------
+# Eval-module fakes (#143 Phase 1)
+#
+# Paired with the eval protocols in kairix/core/protocols.py — together they
+# replace the *_fn=None test-substitution kwargs scattered through the eval
+# module. Tests inject these via the constructor of the LLMJudge / GoldBuilder /
+# QueryGenerator / SuiteGenerator classes that Phase 2a/2b add.
+# ---------------------------------------------------------------------------
+
+
+class FakeChatBackend:
+    """Configurable ChatBackend that returns canned responses or raises a configured error.
+
+    Usage:
+        backend = FakeChatBackend(responses=['{"A": 2, "B": 1}'])
+        ...
+        backend = FakeChatBackend(raise_on_call=ValueError("No API credentials"))
+
+    `responses` is consumed in order; once exhausted, subsequent calls raise
+    `IndexError` (a deliberate explicit failure rather than silently looping
+    or returning empty — silent fallback is the smell this protocol replaces).
+    """
+
+    def __init__(
+        self,
+        *,
+        responses: list[str] | None = None,
+        raise_on_call: Exception | None = None,
+    ) -> None:
+        self._responses: list[str] = list(responses or [])
+        self._raise_on_call = raise_on_call
+        self.calls: list[dict[str, Any]] = []  # for test inspection
+
+    def complete(
+        self,
+        prompt: str,
+        *,
+        api_key: str,
+        endpoint: str,
+        deployment: str,
+        system: str | None = None,
+        temperature: float = 0.0,
+        timeout_s: float = 30.0,
+    ) -> str:
+        self.calls.append(
+            {
+                "prompt": prompt,
+                "api_key": api_key,
+                "endpoint": endpoint,
+                "deployment": deployment,
+                "system": system,
+                "temperature": temperature,
+                "timeout_s": timeout_s,
+            }
+        )
+        if self._raise_on_call is not None:
+            raise self._raise_on_call
+        if not self._responses:
+            raise IndexError(
+                f"FakeChatBackend: ran out of canned responses on call {len(self.calls)} (prompt[:60]={prompt[:60]!r})"
+            )
+        return self._responses.pop(0)
+
+
+class FakeLLMJudge:
+    """Configurable LLMJudge returning fixed grades per query.
+
+    Usage:
+        judge = FakeLLMJudge(
+            grades_by_query={"deploy docker": {"docker-guide": 2, "ci-cd": 1}},
+            calibration_passed=True,
+        )
+
+    `grade()` returns a JudgeResult-shaped object using the configured grades
+    for the given query, defaulting to all-zero for unknown queries. The fake
+    returns a `_StubJudgeResult` (a small namespace) rather than importing
+    the real `JudgeResult` class to keep the fake import-free of judge.py
+    internals — judge.py's tests can construct real JudgeResults explicitly.
+    """
+
+    def __init__(
+        self,
+        *,
+        grades_by_query: dict[str, dict[str, int]] | None = None,
+        calibration_passed: bool = True,
+    ) -> None:
+        self._grades_by_query = dict(grades_by_query or {})
+        self._calibration_passed = calibration_passed
+        self.grade_calls: list[tuple[str, list[tuple[str, str]]]] = []
+        self.calibrate_calls: int = 0
+
+    def grade(
+        self,
+        query: str,
+        candidates: list[tuple[str, str]],
+        *,
+        runs: int = 1,
+    ) -> Any:
+        self.grade_calls.append((query, candidates))
+        configured = self._grades_by_query.get(query, {})
+        # Build a minimal namespace mimicking JudgeResult — judge_model / shuffle_order
+        # default to deterministic test values.
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            query=query,
+            grades={stem: configured.get(stem, 0) for stem, _ in candidates},
+            shuffle_order=tuple(stem for stem, _ in candidates),
+            judge_model="fake-llm",
+            calibration_passed=self._calibration_passed,
+        )
+
+    def calibrate(self) -> bool:
+        self.calibrate_calls += 1
+        return self._calibration_passed
+
+
+class FakeQueryGenerator:
+    """Configurable QueryGenerator returning fixed queries per (title, body) call.
+
+    Usage:
+        gen = FakeQueryGenerator(
+            queries_by_title={"deploy.md": [GeneratedQuery(...)]},
+        )
+    """
+
+    def __init__(self, *, queries_by_title: dict[str, list[Any]] | None = None) -> None:
+        self._queries_by_title = dict(queries_by_title or {})
+        self.calls: list[dict[str, Any]] = []
+
+    def generate(
+        self,
+        title: str,
+        body: str,
+        *,
+        n: int,
+        categories: list[str],
+    ) -> list[Any]:
+        self.calls.append({"title": title, "body": body[:50], "n": n, "categories": list(categories)})
+        return list(self._queries_by_title.get(title, []))[:n]
+
+
+class FakeRetriever:
+    """Configurable Retriever returning fixed results per query.
+
+    Usage:
+        retriever = FakeRetriever(
+            results_by_query={"deploy docker": _build_retrieval_result([...])},
+        )
+
+    Default empty result is a SimpleNamespace with `results=[]` and
+    `vec_failed=False` — callers that need richer surface should construct
+    a typed RetrievalResult and pass it in via `results_by_query`.
+    """
+
+    def __init__(self, *, results_by_query: dict[str, Any] | None = None) -> None:
+        self._results_by_query = dict(results_by_query or {})
+        self.calls: list[dict[str, Any]] = []
+
+    def retrieve(
+        self,
+        query: str,
+        *,
+        collections: list[str] | None = None,
+        cfg: Any = None,
+    ) -> Any:
+        self.calls.append({"query": query, "collections": collections, "cfg": cfg})
+        if query in self._results_by_query:
+            return self._results_by_query[query]
+        from types import SimpleNamespace
+
+        return SimpleNamespace(results=[], vec_failed=False)


### PR DESCRIPTION
## Summary

Phase 1 of [#143](https://github.com/quanyeomans/kairix/issues/143). Foundation that unblocks Phase 2 parallel work.

**No production code change** — only adds the typed boundary surface that the Phase 2 refactors will plug into.

## Added

`kairix/core/protocols.py`:
- `ChatBackend` — LLM chat-completion surface (substitutable across Azure / OpenRouter / fakes). Wraps the call shape `kairix._azure.chat_completion` uses.
- `LLMJudge` — pairwise / pointwise relevance judge over (query, doc) pairs.
- `QueryGenerator` — synthesises retrieval eval queries from a corpus document.
- `Retriever` — hybrid-search facade for sweep / benchmark / gold-builder callers.

`tests/fakes.py`:
- `FakeChatBackend` — canned-response queue with call recording; raises `IndexError` on exhaustion (deliberate explicit failure rather than silently looping). `raise_on_call` kwarg for credential-failure paths.
- `FakeLLMJudge` — fixed grades per query via `grades_by_query` dict; returns `SimpleNamespace` mimicking `JudgeResult` shape so the fake stays decoupled from `judge.py` internals.
- `FakeQueryGenerator` — fixed queries per title; n-cap honoured.
- `FakeRetriever` — fixed result per query; default empty result has `results=[]` / `vec_failed=False`.

`tests/contracts/test_eval_protocols.py`:
- 16 contract tests asserting each `FakeXxx` satisfies its Protocol via runtime `isinstance` checks. Production conformance tests land in Phase 2a/2b alongside the concrete classes.

## Why this is its own PR

Same Ralph pattern as the paths-DI initiative: define the boundary surface first, then fan out parallel agent work that consumes it. Phase 2a refactors `judge.py` to wrap `judge_batch` / `calibrate` as an `LLMJudge` class with `ChatBackend` constructor injection; Phase 2b agents (sweep / gold_builder / generate) refactor independently against the protocol shape established here.

## Verification
- [x] safe-commit: 2,175 tests pass (lint + format + mypy strict + secrets + confidential — all green)
- [x] Zero `monkeypatch`, zero `@patch`, zero `setattr` introduced
- [x] All 16 new contract tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)