### PR TITLE
release: kairix v2026.5.10.1 — PyPI dist rename + SonarCloud QG now blocks merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -655,3 +655,53 @@ jobs:
             fi
           done
           echo "All required jobs passed or were skipped."
+
+      - name: SonarCloud quality gate verdict
+        # Fail the merge gate if SonarCloud's Quality Gate is ERROR.
+        # The sonar-scan step in Stage 4 has continue-on-error: true (so
+        # transient SonarCloud outages don't block merge), so the QG result
+        # is NOT carried by RESULT_SECURITY. We check it here authoritatively
+        # via SonarCloud's public API.
+        #
+        # Resolves the v2026.5.10 dogfood report: Sonar reported ERROR with
+        # 35 unreviewed hotspots and the merge still went through because
+        # nothing in the gate read the QG verdict.
+        env:
+          PROJECT_KEY: quanyeomans_kairix
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BRANCH_REF: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [ -n "$PR_NUMBER" ]; then
+              URL="https://sonarcloud.io/api/qualitygates/project_status?projectKey=${PROJECT_KEY}&pullRequest=${PR_NUMBER}"
+              CTX="PR #${PR_NUMBER}"
+          else
+              URL="https://sonarcloud.io/api/qualitygates/project_status?projectKey=${PROJECT_KEY}&branch=${BRANCH_REF}"
+              CTX="branch ${BRANCH_REF}"
+          fi
+          # Sonar may not have processed the new analysis yet; allow up to
+          # 90 s of polling before declaring the verdict missing. A missing
+          # verdict is treated as failure — operators must wait for Sonar
+          # to finish, or fix scan upload, rather than merge with no signal.
+          for i in 1 2 3 4 5 6; do
+              RESPONSE=$(curl -fsS --max-time 10 "$URL" || echo '{}')
+              STATUS=$(echo "$RESPONSE" | python3 -c "import json,sys; d=json.load(sys.stdin) if sys.stdin.readable() else {}; print(d.get('projectStatus', {}).get('status', 'MISSING'))" 2>/dev/null || echo "MISSING")
+              if [ "$STATUS" = "OK" ]; then
+                  echo "SonarCloud Quality Gate OK for ${CTX}"
+                  exit 0
+              fi
+              if [ "$STATUS" = "ERROR" ]; then
+                  echo "SonarCloud Quality Gate ERROR for ${CTX}:"
+                  echo "$RESPONSE" | python3 -m json.tool 2>/dev/null || echo "$RESPONSE"
+                  echo
+                  echo "Triage at https://sonarcloud.io/project/issues?id=${PROJECT_KEY}"
+                  exit 1
+              fi
+              # WARN, MISSING, or transient — wait and retry.
+              echo "SonarCloud verdict not ready (status=${STATUS}); attempt ${i}/6, sleeping 15 s..."
+              sleep 15
+          done
+          echo "FAILED: SonarCloud Quality Gate verdict still unavailable after 90 s."
+          echo "Either the Sonar scan never uploaded, or Sonar is degraded."
+          echo "Re-run the workflow once Sonar processes the analysis."
+          exit 1

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -53,10 +53,14 @@ jobs:
         run: sleep 60
 
       - name: Install and smoke test
+        # The PyPI distribution name (kairix-agentic-knowledge-mgt) is
+        # different from the Python import name (kairix). pip resolves
+        # the long form; ``import kairix`` and the ``kairix`` console
+        # script are unchanged for end users.
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
           VERSION="${TAG_NAME#v}"
-          pip install "kairix==${VERSION}"
+          pip install "kairix-agentic-knowledge-mgt==${VERSION}"
           python -c "import kairix; print(f'kairix {kairix.__version__} installed successfully')"
           kairix --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ Git tags: `v2026.04.18`. Deploy by pinning to a tag: `pip install git+...@v2026.
 
 ## [Unreleased]
 
+## [2026.5.10.1] - 2026-05-10 — PyPI distribution rename + SonarCloud now blocks merge
+
+> **Upgrading?** End users `import kairix` exactly as before; the **install command changes** to use the long-form distribution name: `pip install "kairix-agentic-knowledge-mgt[<extras>]"`. The Python package name (`kairix`), the console script (`kairix`), and every CLI / MCP surface are unchanged.
+
+### Changed
+
+- **PyPI distribution name is now `Kairix-agentic-knowledge-mgt`.** The short `kairix` slot on PyPI was reserved by an unrelated publisher with no releases, so we publish under the long-form name. The Python import path (`import kairix`), the source layout (`kairix/...`), and the console script entry (`kairix`) are unchanged. Existing imports and CLI invocations require no change. Operator install commands updated in `OPERATIONS.md` and the upgrade runbook.
+- **SonarCloud Quality Gate now blocks merge.** Pre-fix the Sonar QG verdict was advisory (the scan step had `continue-on-error: true` and the CI gate didn't read the QG status), so a release with 35 unreviewed security hotspots and `new_security_hotspots_reviewed = 0%` could be merged silently. Two enforcement layers added:
+  - The `check` (CI gate) job now polls SonarCloud's `/api/qualitygates/project_status` and fails when status is `ERROR`. Up to 90 s of polling absorbs the lag between scan upload and QG verdict; a missing verdict after 90 s also fails (rather than letting the merge through with no Sonar signal).
+  - GitHub branch protection on `main` now requires both `check` and `SonarCloud Code Analysis` checks. Belt-and-braces: even if a future workflow change skips the CI gate's Sonar poll, branch protection still won't allow merge without Sonar's own verdict.
+
+### Operational note
+
+If the SonarCloud QG fires due to a backlog of pre-existing hotspots (not net-new findings), triage them at https://sonarcloud.io/project/issues?id=quanyeomans_kairix. The `new_security_hotspots_reviewed` condition checks the new-code window only — clearing the backlog is a one-time hygiene task that subsequent merges will not need to repeat.
+
+---
+
 ## [2026.5.10] - 2026-05-10 — Worker stability, layered health probes, deploy self-heal
 
 > **Upgrading?** Drop-in. The worker now survives recall-gate alerts (which were silently killing the process before this release). The `/healthz/ready` endpoint is new but additive — `/healthz` is unchanged for back-compat with existing load-balancer probes. systemd-managed deployments should adopt the example unit files in `scripts/install/` to fix the post-reboot self-heal gap (#167).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,8 @@ Pre-existing violations are grandfathered in `.architecture/baseline/`; net-new 
 
 Stages: arch-fitness (Stage 0, F1-F6+F8) → pre-commit → contracts → unit+bdd+contract+mypy (Stage 2, includes F7 per-file 85% floor) → integration → security (incl. SonarCloud) → Docker. All must pass before merge.
 
+**SonarCloud Quality Gate is blocking** as of v2026.5.10.1. Two layers of enforcement: (i) the `check` (CI gate) job polls SonarCloud's `/api/qualitygates/project_status` and fails on `ERROR`; (ii) GitHub branch protection on `main` requires the separate `SonarCloud Code Analysis` check posted by the Sonar app. Either layer alone would catch a regression; both together survive workflow drift. Triage failing hotspots at https://sonarcloud.io/project/issues?id=quanyeomans_kairix.
+
 Codecov surfaces:
 - **Coverage**: `unit` flag (Stage 2) and `integration` flag (Stage 3) upload via `codecov/codecov-action@v5`. `codecov.yml` carryforwards both flags so the dashboard merges correctly when only one stage runs. Patch target = 85% (matches F7).
 - **Test analytics**: JUnit XMLs from contracts / unit / integration upload via `codecov/test-results-action@v1` for flaky-test and slow-test tracking.

--- a/CONSTRAINTS.md
+++ b/CONSTRAINTS.md
@@ -8,6 +8,8 @@ The fitness functions are mechanical, blocking checks that encode rejected patte
 
 F7 (per-file unit coverage floor) and F9 (union coverage floor) run in CI only because they need the test runtime — F7 in Stage 2 and F9 in Stage 5 (after both unit and integration suites finish so their coverage data can be combined). See [docs/architecture/fitness-functions.md](docs/architecture/fitness-functions.md) for the full rule set, why each rule exists, and how to fix violations.
 
+**SonarCloud Quality Gate is blocking** as of v2026.5.10.1. The CI gate polls SonarCloud's `/api/qualitygates/project_status` and fails on `ERROR`; GitHub branch protection on `main` additionally requires the `SonarCloud Code Analysis` check posted by the Sonar app. Either layer alone catches a regression; both together survive workflow drift. Triage failing hotspots at https://sonarcloud.io/project/issues?id=quanyeomans_kairix.
+
 ---
 
 ## Architecture patterns

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ No GPU. No per-seat licensing. One VM serves your entire team of agents and huma
 ### Option A: pip install
 
 ```bash
-pip install "kairix[agents,neo4j]"
+pip install "kairix-agentic-knowledge-mgt[agents,neo4j]"
 kairix setup                   # interactive wizard — picks your paths, ports, collections
 kairix embed                   # index your documents
 kairix search "your question"  # find answers

--- a/docs/architecture/fitness-functions.md
+++ b/docs/architecture/fitness-functions.md
@@ -1640,11 +1640,25 @@ enforcement mechanism (review, runtime check, or human judgement):
   guidance (commit hygiene, naming, agent collaboration).
 - **`docs/architecture/ENGINEERING.md`** — broader architecture rules
   (Protocol-driven boundaries, factory composition, repository pattern).
+- **`docs/architecture/quality-harness-setup-guide.md`** — companion
+  setup guide (G1–G17 gotchas, including the SonarCloud blocking-gate
+  configuration in G17).
 - **`docs/architecture/cli-mcp-feature-parity.md`** — issue #168, the
   CLI/MCP convergence initiative; its Phase 2 work will reduce CLI
   body coverage gaps that F7 currently flags.
 - **`scripts/checks/`** — implementation source-of-truth.
 - **`.architecture/baseline/`** — current grandfathered violations.
+
+### External quality gates
+
+The SonarCloud Quality Gate is **not a fitness function** — it's an
+external service whose verdict the merge gate consumes. Like the
+fitness functions it is blocking (since v2026.5.10.1): the CI gate
+polls SonarCloud's `/api/qualitygates/project_status` and fails on
+`ERROR`, and GitHub branch protection requires the separate
+`SonarCloud Code Analysis` check the Sonar app posts. See
+quality-harness-setup-guide.md §G17 for the rationale and the exact
+wiring.
 
 ---
 

--- a/docs/architecture/quality-harness-setup-guide.md
+++ b/docs/architecture/quality-harness-setup-guide.md
@@ -94,7 +94,7 @@ Copy `.github/workflows/ci.yml`'s job structure. The pipeline runs five stages:
 | **4** | `security` | bandit, pip-audit, SonarCloud |
 | **5** | `union-coverage` | downloads .coverage from Stages 2 and 3, runs F9 on the union |
 
-Plus a `check` fan-in job that gates branch protection on every required job's result.
+Plus a `check` fan-in job that gates branch protection on every required job's result. The `check` job ALSO polls SonarCloud's `/api/qualitygates/project_status` and fails on `ERROR` — a Sonar QG regression is an immediate merge block, not advisory. See §G17 for the rationale.
 
 ### 6. Wire Codecov
 
@@ -345,6 +345,54 @@ Workflow names (the `name:` line at the top of `.yml`) drive only the GitHub Act
 ### G16. Pin every `uses:` in every workflow
 
 If you fix G7 only on `ci.yml`, SonarCloud will start flagging the next workflow file you write. **Sweep every workflow file** at setup time. The SHA-resolution shell snippet is already in G7.
+
+### G17. SonarCloud Quality Gate must be a hard gate, not advisory
+
+**Symptom:** A release ships with SonarCloud reporting `ERROR` on the dashboard (e.g. 35 unreviewed security hotspots, `new_security_hotspots_reviewed = 0%`) and the merge went through silently.
+
+**Cause:** The default wiring is advisory by accident, in three layers:
+
+1. The Sonar scan step in `ci.yml` typically has `continue-on-error: true` so transient SonarCloud outages don't block merge. That's defensible — but it means the *job* always reports success regardless of the QG verdict.
+2. The CI gate fan-in job depends on the Sonar *job*'s success, not the SonarCloud QG verdict. So a failing QG with a successful job (i.e. the common case) doesn't trip the gate.
+3. The SonarCloud app posts a separate GitHub status check called `SonarCloud Code Analysis` that DOES carry the QG verdict — but unless branch protection requires that specific check, GitHub's merge UI ignores it.
+
+**Fix — both of the following, intentionally redundant:**
+
+1. **In the `check` (CI gate) job, poll the SonarCloud QG API and fail on ERROR.** The kairix workflow does this with up to 90 s of polling to absorb the upload-vs-verdict lag:
+
+   ```yaml
+   - name: SonarCloud quality gate verdict
+     env:
+       PROJECT_KEY: <owner>_<repo>
+       PR_NUMBER: ${{ github.event.pull_request.number }}
+       BRANCH_REF: ${{ github.ref_name }}
+     run: |
+       set -euo pipefail
+       if [ -n "$PR_NUMBER" ]; then
+           URL="https://sonarcloud.io/api/qualitygates/project_status?projectKey=${PROJECT_KEY}&pullRequest=${PR_NUMBER}"
+       else
+           URL="https://sonarcloud.io/api/qualitygates/project_status?projectKey=${PROJECT_KEY}&branch=${BRANCH_REF}"
+       fi
+       for i in 1 2 3 4 5 6; do
+           RESPONSE=$(curl -fsS --max-time 10 "$URL" || echo '{}')
+           STATUS=$(echo "$RESPONSE" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('projectStatus',{}).get('status','MISSING'))" 2>/dev/null || echo "MISSING")
+           [ "$STATUS" = "OK" ] && exit 0
+           [ "$STATUS" = "ERROR" ] && { echo "$RESPONSE"; exit 1; }
+           sleep 15
+       done
+       exit 1   # missing verdict after 90s = fail; do not merge with no Sonar signal
+   ```
+
+2. **Add `SonarCloud Code Analysis` to the branch protection's required status checks**, alongside `check`:
+
+   ```bash
+   gh api -X POST "repos/<owner>/<repo>/branches/main/protection/required_status_checks/contexts" \
+       --input - <<<'["SonarCloud Code Analysis"]'
+   ```
+
+Both layers protect against the other failing. The CI gate poll catches QG regressions even if branch protection drifts; the branch-protection check catches them even if the workflow's poll is removed or skipped. Fixing only one is fragile.
+
+**Triage:** failing hotspots are at `https://sonarcloud.io/project/issues?id=<projectKey>`. The `new_security_hotspots_reviewed` condition checks the new-code window only; clearing the backlog of pre-existing hotspots is a one-time hygiene task that doesn't repeat.
 
 ---
 

--- a/docs/operations/OPERATIONS.md
+++ b/docs/operations/OPERATIONS.md
@@ -269,13 +269,13 @@ This creates `/opt/kairix/.venv/` (legacy pip path), installs kairix into it, in
 ```bash
 # Create venv and install (core)
 python3 -m venv /opt/kairix/.venv
-/opt/kairix/.venv/bin/pip install kairix
+/opt/kairix/.venv/bin/pip install kairix-agentic-knowledge-mgt
 
 # With Neo4j entity graph support (recommended for full feature set)
-/opt/kairix/.venv/bin/pip install "kairix[neo4j]"
+/opt/kairix/.venv/bin/pip install "kairix-agentic-knowledge-mgt[neo4j]"
 
 # With MCP server for agent integration
-/opt/kairix/.venv/bin/pip install "kairix[agents]"
+/opt/kairix/.venv/bin/pip install "kairix-agentic-knowledge-mgt[agents]"
 
 # Verify
 /opt/kairix/.venv/bin/kairix --help
@@ -570,7 +570,7 @@ After embedding, kairix automatically generates L0 (abstract-level) summaries fo
 For MULTI_HOP and SEMANTIC intent queries, kairix can apply a cross-encoder re-ranker after initial retrieval to improve result ordering. This requires the `rerank` extra:
 
 ```bash
-pip install "kairix[rerank]"
+pip install "kairix-agentic-knowledge-mgt[rerank]"
 ```
 
 Re-ranking is applied automatically when the extra is installed. Without it, kairix falls back to the standard fusion ranking (no degradation, just no cross-encoder pass).
@@ -580,7 +580,7 @@ Re-ranking is applied automatically when the extra is installed. Without it, kai
 Entity suggestion uses spaCy NLP models to detect named entities in your documents. This requires the `nlp` extra:
 
 ```bash
-pip install "kairix[nlp]"
+pip install "kairix-agentic-knowledge-mgt[nlp]"
 ```
 
 This is required for `kairix entity suggest` to work, including inside Docker containers. The Docker image includes the `nlp` extra by default.
@@ -811,10 +811,10 @@ For deeper diagnostic procedures and less common failure modes, see [`docs/opera
 
 ```bash
 # Upgrade to latest
-/opt/kairix/.venv/bin/pip install --upgrade kairix
+/opt/kairix/.venv/bin/pip install --upgrade kairix-agentic-knowledge-mgt
 
 # Or pin to a specific version
-/opt/kairix/.venv/bin/pip install "kairix==2026.4.27"
+/opt/kairix/.venv/bin/pip install "kairix-agentic-knowledge-mgt==2026.4.27"
 
 # Verify
 kairix onboard check
@@ -829,7 +829,7 @@ bash scripts/install.sh --skip-smoke   # re-downloads and re-installs wrapper
 
 ```bash
 # Install new version
-pip install --force-reinstall --no-deps "kairix==<new-version>"
+pip install --force-reinstall --no-deps "kairix-agentic-knowledge-mgt==<new-version>"
 
 # Run schema tests to verify compatibility
 pytest tests/ -k "schema" -v

--- a/docs/operations/runbooks/how-to-configure-pypi-trusted-publisher.md
+++ b/docs/operations/runbooks/how-to-configure-pypi-trusted-publisher.md
@@ -87,8 +87,8 @@ Check the run's logs for the `publish` job. The most common reasons:
 - Required-reviewer approval pending — the job is waiting on you.
 - The release event is a `prereleased` rather than `created` — the workflow currently triggers on `types: [created]`. Adjust the trigger if you want pre-releases to publish.
 
-**Verify job fails with `pip install kairix==X.Y.Z` not found**
-PyPI's CDN can lag a few seconds after publish. The workflow already has `sleep 60` before the install attempt. If it still fails, manually `pip install kairix==X.Y.Z` from your machine — if that works too, the verify job's network may be slow; bump the sleep.
+**Verify job fails with `pip install kairix-agentic-knowledge-mgt==X.Y.Z` not found**
+PyPI's CDN can lag a few seconds after publish. The workflow already has `sleep 60` before the install attempt. If it still fails, manually `pip install kairix-agentic-knowledge-mgt==X.Y.Z` from your machine — if that works too, the verify job's network may be slow; bump the sleep.
 
 ## See also
 

--- a/docs/operations/runbooks/how-to-upgrade-kairix.md
+++ b/docs/operations/runbooks/how-to-upgrade-kairix.md
@@ -41,7 +41,7 @@ Kairix is installed into a virtualenv at `/opt/kairix/.venv`.
 
 ```bash
 # Install new version
-sudo /opt/kairix/.venv/bin/pip install kairix==<NEW_VERSION>
+sudo /opt/kairix/.venv/bin/pip install kairix-agentic-knowledge-mgt==<NEW_VERSION>
 
 kairix --version
 # Should show new version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,13 @@ requires = ["setuptools>=61", "wheel", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "kairix"
+# PyPI distribution name. The Python import path is still ``kairix``
+# (source layout under kairix/, console script entry remains ``kairix``).
+# The dist name here matches the trusted-publisher record on PyPI;
+# the short ``kairix`` slot was already reserved by another account
+# with no releases, so we publish under the long-form name and users
+# can still ``import kairix`` after install.
+name = "Kairix-agentic-knowledge-mgt"
 dynamic = ["version"]
 description = "Self-contained knowledge retrieval engine — hybrid search, entity graph, temporal reasoning, session briefing"
 readme = "README.md"


### PR DESCRIPTION
## v2026.5.10.1 — hotfix

Two changes:

### 1. PyPI distribution renamed to `Kairix-agentic-knowledge-mgt`

The short `kairix` slot on PyPI was reserved by another publisher with no releases. Per the Pending Publisher configured on PyPI, we publish under the long-form name. Python import path is **unchanged** (`import kairix`), console script is **unchanged** (`kairix`); only the install command differs:

```bash
# Old (didn't work; PyPI rejected the trusted-publisher exchange)
pip install kairix

# New
pip install "kairix-agentic-knowledge-mgt[agents]"
```

All operator install docs updated.

### 2. SonarCloud Quality Gate now blocks merge (v2026.5.10 dogfood report)

Pre-fix, a release shipped with SonarCloud reporting `ERROR` and 35 unreviewed hotspots. The merge went through silently because:
- The `sonar-scan` step has `continue-on-error: true` (rationaled — protects against Sonar outages).
- The CI gate fan-in only reads the *job* result, not the SonarCloud QG verdict.
- Branch protection required only the `check` job, not the separate `SonarCloud Code Analysis` check the Sonar app posts.

**Two intentionally redundant enforcement layers added:**

- The `check` (CI gate) job polls SonarCloud's `/api/qualitygates/project_status` with up to 90 s of polling (absorbs scan-upload-vs-verdict lag) and fails on `ERROR`. A missing verdict also fails — operators wait for Sonar or fix the upload, not merge blind.
- GitHub branch protection on `main` now requires both `check` and `SonarCloud Code Analysis` status checks.

Either layer alone catches a regression; both together survive workflow drift.

### Documentation

- `CLAUDE.md` — CI section now states the QG is blocking.
- `CONSTRAINTS.md` — commit-gate description names SonarCloud explicitly.
- `docs/architecture/quality-harness-setup-guide.md` — new §G17 with full rationale and the exact wiring (curl + sleep loop + branch-protection API call).
- `docs/architecture/fitness-functions.md` — new "External quality gates" subsection in cross-references.
- `CHANGELOG.md [2026.5.10.1]` — operator-facing notes for both changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)