### PR TITLE
release: kairix v2026.5.10.2 — SonarCloud QG is hard, not advisory

### DIFF
--- a/.github/workflows/benchmark-gate.yml
+++ b/.github/workflows/benchmark-gate.yml
@@ -41,9 +41,9 @@ jobs:
       issues: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
           cache: pip
@@ -132,7 +132,7 @@ jobs:
 
       - name: Post PR comment
         if: always() && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -544,10 +544,13 @@ jobs:
         continue-on-error: true  # artifact missing on path-filtered runs; Sonar still scans without it
 
       - name: SonarCloud Scan
+        # NO continue-on-error here. If SonarCloud is unavailable or the
+        # scan fails to upload, the security stage fails, the CI gate
+        # fails, and the merge is blocked. Releasing without a Sonar
+        # verdict is not allowed — wait for Sonar to recover.
         uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        continue-on-error: true  # gate is the separate "SonarCloud Code Analysis" check; this step's failure is benign
 
   # ── Docker build verification ──────────────────────────────────────────────
   docker:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
         with:
           fail-on-severity: moderate
           comment-summary-in-pr: always

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,19 +21,58 @@ env:
   IMAGE: ghcr.io/quanyeomans/kairix
 
 jobs:
+  sonar-gate:
+    name: SonarCloud Quality Gate (release)
+    # Hard gate. Only required on release events — develop pushes
+    # already go through the CI gate which enforces the QG. Skipped
+    # for develop pushes to avoid duplicate checks.
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: SonarCloud quality gate verdict for release
+        env:
+          PROJECT_KEY: quanyeomans_kairix
+          BRANCH_REF: main
+        run: |
+          set -euo pipefail
+          URL="https://sonarcloud.io/api/qualitygates/project_status?projectKey=${PROJECT_KEY}&branch=${BRANCH_REF}"
+          for i in 1 2 3 4 5 6; do
+              RESPONSE=$(curl -fsS --max-time 10 "$URL" || echo '{}')
+              STATUS=$(echo "$RESPONSE" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('projectStatus',{}).get('status','MISSING'))" 2>/dev/null || echo "MISSING")
+              if [ "$STATUS" = "OK" ]; then
+                  echo "SonarCloud Quality Gate OK for ${BRANCH_REF}"
+                  exit 0
+              fi
+              if [ "$STATUS" = "ERROR" ]; then
+                  echo "SonarCloud Quality Gate ERROR — release blocked."
+                  echo "$RESPONSE" | python3 -m json.tool 2>/dev/null || echo "$RESPONSE"
+                  echo
+                  echo "Triage at https://sonarcloud.io/project/issues?id=${PROJECT_KEY}"
+                  exit 1
+              fi
+              echo "SonarCloud verdict not ready (status=${STATUS}); attempt ${i}/6, sleeping 15 s..."
+              sleep 15
+          done
+          echo "FAILED: SonarCloud Quality Gate verdict still unavailable after 90 s — release blocked."
+          exit 1
+
   build-and-push:
+    needs: sonar-gate
+    if: ${{ always() && (needs.sonar-gate.result == 'success' || needs.sonar-gate.result == 'skipped') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -53,7 +92,7 @@ jobs:
           fi
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           push: true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,10 +19,10 @@ jobs:
       pull-requests: read
     if: github.event.pull_request.draft == false
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Check PR description completeness
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         with:
           script: |
             const pr = context.payload.pull_request;
@@ -85,9 +85,9 @@ jobs:
     needs: pr-gates
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
           cache: pip

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -13,17 +13,55 @@ on:
     types: [created]
 
 jobs:
-  build:
-    name: Build package
+  sonar-gate:
+    name: SonarCloud Quality Gate (release)
+    # Hard gate at release time. The CI gate enforces the QG on every PR
+    # to main, but a manually-created release event still needs an
+    # independent check — neither Docker publish nor PyPI publish will
+    # run unless SonarCloud reports OK on the released SHA.
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - name: SonarCloud quality gate verdict for release
+        env:
+          PROJECT_KEY: quanyeomans_kairix
+          BRANCH_REF: main
+        run: |
+          set -euo pipefail
+          URL="https://sonarcloud.io/api/qualitygates/project_status?projectKey=${PROJECT_KEY}&branch=${BRANCH_REF}"
+          for i in 1 2 3 4 5 6; do
+              RESPONSE=$(curl -fsS --max-time 10 "$URL" || echo '{}')
+              STATUS=$(echo "$RESPONSE" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('projectStatus',{}).get('status','MISSING'))" 2>/dev/null || echo "MISSING")
+              if [ "$STATUS" = "OK" ]; then
+                  echo "SonarCloud Quality Gate OK for ${BRANCH_REF}"
+                  exit 0
+              fi
+              if [ "$STATUS" = "ERROR" ]; then
+                  echo "SonarCloud Quality Gate ERROR — release blocked."
+                  echo "$RESPONSE" | python3 -m json.tool 2>/dev/null || echo "$RESPONSE"
+                  echo
+                  echo "Triage at https://sonarcloud.io/project/issues?id=${PROJECT_KEY}"
+                  exit 1
+              fi
+              echo "SonarCloud verdict not ready (status=${STATUS}); attempt ${i}/6, sleeping 15 s..."
+              sleep 15
+          done
+          echo "FAILED: SonarCloud Quality Gate verdict still unavailable after 90 s — release blocked."
+          exit 1
+
+  build:
+    name: Build package
+    needs: sonar-gate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0  # setuptools-scm needs full history
 
-      - uses: hynek/build-and-inspect-python-package@v2
+      - uses: hynek/build-and-inspect-python-package@e6f4945c542cb46284a23bdb29121f4593636894 # v2
 
   publish:
     name: Publish to PyPI
@@ -33,19 +71,19 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: Packages
           path: dist/
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
 
   verify:
     name: Verify install
     needs: publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 

--- a/.github/workflows/reflib-benchmark-gate.yml
+++ b/.github/workflows/reflib-benchmark-gate.yml
@@ -21,9 +21,9 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
           cache: pip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ Git tags: `v2026.04.18`. Deploy by pinning to a tag: `pip install git+...@v2026.
 
 ## [Unreleased]
 
+## [2026.5.10.2] - 2026-05-10 — SonarCloud Quality Gate is hard, not advisory
+
+> **Upgrading?** No code changes for end users. CI/release behaviour changes: the SonarCloud Quality Gate is now a true blocking gate at every layer. Releases will not proceed unless SonarCloud reports `OK` on the released SHA — there is no longer any path through which a release can ship while the QG is `ERROR`.
+
+### Changed
+
+- **`continue-on-error: true` removed from the SonarCloud Scan step** in `ci.yml`. The previous wiring tolerated SonarCloud being unreachable so transient outages didn't block merge — that was the wrong tradeoff. If SonarCloud is unavailable or the scan fails to upload, the security stage now fails, the CI gate fails, and the merge is blocked. Wait for Sonar to recover; do not merge with no Sonar verdict.
+- **Release-event SonarCloud QG enforcement added.** Both `docker-publish.yml` and `publish-pypi.yml` now begin with a `sonar-gate` job that polls SonarCloud's `/api/qualitygates/project_status` for the `main` branch and fails on `ERROR`. Even a manually-created release event won't trigger image push or PyPI upload until Sonar reports `OK`. This is the third independent enforcement layer (alongside the CI gate poll and branch protection's `SonarCloud Code Analysis` requirement).
+- **Five `githubactions:S7637` hotspots fixed.** Sonar flagged that several actions in `docker-publish.yml`, `publish-pypi.yml`, `benchmark-gate.yml`, `reflib-benchmark-gate.yml`, `integration.yml`, and `dependency-review.yml` were pinned by tag rather than commit SHA. All swept to commit-SHA pins with the tag preserved in a sidecar comment.
+
+### Documentation
+
+- The "absorbs Sonar outages" framing in `CHANGELOG [2026.5.10.1]` and `quality-harness-setup-guide.md §G17` corrected. Hard answer: if Sonar isn't OK, the release doesn't ship.
+
+### Known follow-up
+
+- **#174** tracks the 30 remaining SonarCloud hotspots (regex-DoS reviews, pseudorandom usage, tempfile, asyncio sync primitives, two Docker-runtime). Until they're triaged, the project-level QG remains `ERROR` and merges to main will be blocked. This is the intended behaviour — the QG is blocking now, and it is correctly catching the backlog.
+
+---
+
 ## [2026.5.10.1] - 2026-05-10 — PyPI distribution rename + SonarCloud now blocks merge
 
 > **Upgrading?** End users `import kairix` exactly as before; the **install command changes** to use the long-form distribution name: `pip install "kairix-agentic-knowledge-mgt[<extras>]"`. The Python package name (`kairix`), the console script (`kairix`), and every CLI / MCP surface are unchanged.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Pre-existing violations are grandfathered in `.architecture/baseline/`; net-new 
 
 Stages: arch-fitness (Stage 0, F1-F6+F8) → pre-commit → contracts → unit+bdd+contract+mypy (Stage 2, includes F7 per-file 85% floor) → integration → security (incl. SonarCloud) → Docker. All must pass before merge.
 
-**SonarCloud Quality Gate is blocking** as of v2026.5.10.1. Two layers of enforcement: (i) the `check` (CI gate) job polls SonarCloud's `/api/qualitygates/project_status` and fails on `ERROR`; (ii) GitHub branch protection on `main` requires the separate `SonarCloud Code Analysis` check posted by the Sonar app. Either layer alone would catch a regression; both together survive workflow drift. Triage failing hotspots at https://sonarcloud.io/project/issues?id=quanyeomans_kairix.
+**SonarCloud Quality Gate is blocking** as of v2026.5.10.2. Three intentionally redundant layers: (i) the `check` (CI gate) job polls SonarCloud's `/api/qualitygates/project_status` and fails on `ERROR`; (ii) GitHub branch protection on `main` requires the separate `SonarCloud Code Analysis` check posted by the Sonar app; (iii) `docker-publish.yml` and `publish-pypi.yml` begin with a `sonar-gate` job so manually-created release events also can't ship without Sonar OK. The Sonar scan step does NOT have `continue-on-error: true` — if Sonar is unavailable, the gate fails and we wait. Triage failing hotspots at https://sonarcloud.io/project/issues?id=quanyeomans_kairix.
 
 Codecov surfaces:
 - **Coverage**: `unit` flag (Stage 2) and `integration` flag (Stage 3) upload via `codecov/codecov-action@v5`. `codecov.yml` carryforwards both flags so the dashboard merges correctly when only one stage runs. Patch target = 85% (matches F7).

--- a/CONSTRAINTS.md
+++ b/CONSTRAINTS.md
@@ -8,7 +8,7 @@ The fitness functions are mechanical, blocking checks that encode rejected patte
 
 F7 (per-file unit coverage floor) and F9 (union coverage floor) run in CI only because they need the test runtime — F7 in Stage 2 and F9 in Stage 5 (after both unit and integration suites finish so their coverage data can be combined). See [docs/architecture/fitness-functions.md](docs/architecture/fitness-functions.md) for the full rule set, why each rule exists, and how to fix violations.
 
-**SonarCloud Quality Gate is blocking** as of v2026.5.10.1. The CI gate polls SonarCloud's `/api/qualitygates/project_status` and fails on `ERROR`; GitHub branch protection on `main` additionally requires the `SonarCloud Code Analysis` check posted by the Sonar app. Either layer alone catches a regression; both together survive workflow drift. Triage failing hotspots at https://sonarcloud.io/project/issues?id=quanyeomans_kairix.
+**SonarCloud Quality Gate is blocking** as of v2026.5.10.2. Three intentionally redundant layers — (i) the CI gate polls SonarCloud's `/api/qualitygates/project_status` and fails on `ERROR`; (ii) GitHub branch protection on `main` requires the `SonarCloud Code Analysis` check posted by the Sonar app; (iii) the Docker and PyPI publish workflows each begin with a `sonar-gate` job so even manual release events can't ship without Sonar OK. The Sonar scan step does NOT have `continue-on-error: true` — if Sonar is unavailable, the gate fails and we wait. Triage failing hotspots at https://sonarcloud.io/project/issues?id=quanyeomans_kairix; current backlog tracked in #174.
 
 ---
 

--- a/docs/architecture/quality-harness-setup-guide.md
+++ b/docs/architecture/quality-harness-setup-guide.md
@@ -350,13 +350,13 @@ If you fix G7 only on `ci.yml`, SonarCloud will start flagging the next workflow
 
 **Symptom:** A release ships with SonarCloud reporting `ERROR` on the dashboard (e.g. 35 unreviewed security hotspots, `new_security_hotspots_reviewed = 0%`) and the merge went through silently.
 
-**Cause:** The default wiring is advisory by accident, in three layers:
+**Cause:** The default wiring is advisory in three accidental layers:
 
-1. The Sonar scan step in `ci.yml` typically has `continue-on-error: true` so transient SonarCloud outages don't block merge. That's defensible — but it means the *job* always reports success regardless of the QG verdict.
-2. The CI gate fan-in job depends on the Sonar *job*'s success, not the SonarCloud QG verdict. So a failing QG with a successful job (i.e. the common case) doesn't trip the gate.
+1. The Sonar scan step in `ci.yml` may have been added with `continue-on-error: true` to tolerate Sonar outages. **This is the wrong tradeoff** — it means the *job* always reports success regardless of the QG verdict, and a release ships with no Sonar signal at all. If Sonar is down, the right answer is to wait, not to merge blind.
+2. The CI gate fan-in job depends on the Sonar *job*'s success, not the SonarCloud QG verdict. So a failing QG with a successful job (i.e. the common case if continue-on-error is set) doesn't trip the gate.
 3. The SonarCloud app posts a separate GitHub status check called `SonarCloud Code Analysis` that DOES carry the QG verdict — but unless branch protection requires that specific check, GitHub's merge UI ignores it.
 
-**Fix — both of the following, intentionally redundant:**
+**Fix — three intentionally redundant enforcement layers:**
 
 1. **In the `check` (CI gate) job, poll the SonarCloud QG API and fail on ERROR.** The kairix workflow does this with up to 90 s of polling to absorb the upload-vs-verdict lag:
 
@@ -390,9 +390,32 @@ If you fix G7 only on `ci.yml`, SonarCloud will start flagging the next workflow
        --input - <<<'["SonarCloud Code Analysis"]'
    ```
 
-Both layers protect against the other failing. The CI gate poll catches QG regressions even if branch protection drifts; the branch-protection check catches them even if the workflow's poll is removed or skipped. Fixing only one is fragile.
+3. **Add a `sonar-gate` job to release-event workflows** (Docker publish, PyPI publish). Even a manually-created release event will not trigger image push or PyPI upload until SonarCloud reports `OK` for `main`:
 
-**Triage:** failing hotspots are at `https://sonarcloud.io/project/issues?id=<projectKey>`. The `new_security_hotspots_reviewed` condition checks the new-code window only; clearing the backlog of pre-existing hotspots is a one-time hygiene task that doesn't repeat.
+   ```yaml
+   jobs:
+     sonar-gate:
+       name: SonarCloud Quality Gate (release)
+       runs-on: ubuntu-latest
+       steps:
+         - name: SonarCloud quality gate verdict for release
+           env:
+             PROJECT_KEY: <owner>_<repo>
+             BRANCH_REF: main
+           run: |
+             # Same poll-and-fail logic as the CI gate above
+             ...
+
+     build-and-push:
+       needs: sonar-gate   # release-event publish gated on Sonar OK
+       ...
+   ```
+
+4. **Do NOT use `continue-on-error: true` on the Sonar scan step.** If Sonar is unavailable, the security stage MUST fail. The "tolerate outages" tradeoff sounds reasonable but produces silent releases without verdict — exactly what the gate is supposed to prevent.
+
+All three layers — CI gate poll, branch-protection check, release-event poll — protect against each other failing. Fixing only one is fragile.
+
+**Triage:** failing hotspots are at `https://sonarcloud.io/project/issues?id=<projectKey>`. The `new_security_hotspots_reviewed` condition checks the new-code window only; clearing the backlog of pre-existing hotspots is a one-time hygiene task that doesn't repeat. See kairix #174 for the canonical triage runbook.
 
 ---
 


### PR DESCRIPTION
## v2026.5.10.2

Corrects v2026.5.10.1's framing. The previous wiring tolerated SonarCloud being unavailable (`continue-on-error: true` on the scan step) — which produces silent releases without verdict. That tradeoff was wrong. Hard answer: if Sonar isn't OK, we don't ship.

### Three independent enforcement layers

1. **Sonar scan step**: `continue-on-error` REMOVED from `ci.yml`. If SonarCloud is unreachable, the security stage fails, the CI gate fails, the merge blocks. Wait for Sonar; don't merge blind.
2. **CI gate poll** (carried over from v2026.5.10.1): polls `/api/qualitygates/project_status` and fails on `ERROR`.
3. **Release-event sonar-gate jobs** (NEW) in `docker-publish.yml` and `publish-pypi.yml`. Even a manually-created GitHub Release won't trigger image push or PyPI upload until Sonar reports `OK` on `main`.

All three protect against each other failing. Workflow drift, branch-protection drift, or a future maintainer adding `continue-on-error` back would each be caught by the other two layers.

### Plus 5 hotspots fixed

`githubactions:S7637` — every action across every workflow file now pinned to a 40-char commit SHA with the tag preserved in a sidecar comment. Files swept: `docker-publish.yml`, `publish-pypi.yml`, `benchmark-gate.yml`, `reflib-benchmark-gate.yml`, `integration.yml`, `dependency-review.yml`.

### Documentation

- `CHANGELOG [2026.5.10.2]` documents the harder stance.
- `quality-harness-setup-guide.md §G17` corrected: "do NOT use `continue-on-error` on the Sonar scan step" is now explicit, with the third release-event enforcement layer documented.
- `CLAUDE.md` and `CONSTRAINTS.md` describe all three layers.

### Known follow-up

**#174** tracks the **30 remaining SonarCloud hotspots** to triage (14 regex-DoS reviews, 5 PRNG, 4 tempfile, 3 asyncio, 2 docker root, 2 docker copy chown). **Until those are triaged the project-level QG remains `ERROR` and merges to main will block** — exactly the intended behaviour now that the gate is hard.

This PR's own CI gate will exercise the new release-event sonar-gate. If the project QG is ERROR (because of the #174 backlog), this PR's PR-scoped QG should still be OK (PR scope = new code only) — but the post-merge release event would be blocked. So this is the last release that ships before #174 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)