### PR TITLE
fix(ci): remove continue-on-error from SonarCloud Scan step (closes #180)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -547,7 +547,6 @@ jobs:
         uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        continue-on-error: true  # gate is the separate "SonarCloud Code Analysis" check; this step's failure is benign
 
   # ── Docker build verification ──────────────────────────────────────────────
   docker:


### PR DESCRIPTION
## Summary

Removes the `continue-on-error: true` silencer on the SonarCloud Scan step in `.github/workflows/ci.yml`.

## Context

The silencer was rationalised as: *"gate is the separate 'SonarCloud Code Analysis' check; this step's failure is benign."* That rationale held while SonarCloud's **Automatic Analysis** was running alongside the CI scan — the auto-analysis runner was the actual gate, and the CI scan duplicated the work.

But running both modes in parallel triggered a `cancelled` outcome on the `SonarCloud Code Analysis` check for every PR (the auto-analysis runner aborts when it detects CI analysis). That made every PR `UNSTABLE` and forced `--admin` merges (PRs #178 and #179) which erodes the gate.

Per #180, Automatic Analysis has been disabled at the project level. The CI scan is now the only analyser, so its failure must block the workflow rather than be swallowed.

## What changes

- `.github/workflows/ci.yml:550` — drop `continue-on-error: true` from the `SonarCloud Scan` step. If the scan fails, the workflow fails.

The 3-layer enforcement remains intact:
1. `sonar-gate` poll in this workflow (unchanged)
2. Branch protection requires the `CI gate` job to pass
3. `sonar-gate` job in `docker-publish.yml` and `publish-pypi.yml` (unchanged)

## Test plan

- [ ] CI green on this PR — proves the Sonar scan step now hard-fails on real errors and passes cleanly when the QG is OK.
- [ ] `SonarCloud Code Analysis` check reports the CI scan's outcome (pass) instead of `cancelled`.
- [ ] PR can be merged via standard squash, not `--admin`.

Closes #180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)