### PR TITLE
feat(use_cases): brief use case + mcp__brief — Phase 3a of #168

### DIFF
--- a/.architecture/baseline/per-file-coverage-floor-files.txt
+++ b/.architecture/baseline/per-file-coverage-floor-files.txt
@@ -29,5 +29,6 @@ kairix/platform/setup/agent.py
 kairix/platform/setup/wizard.py
 kairix/quality/eval/cli.py
 kairix/secrets.py
+kairix/use_cases/_brief_defaults.py
 kairix/use_cases/_contradict_defaults.py
 kairix/use_cases/_search_defaults.py

--- a/.architecture/baseline/per-file-coverage-floor-union-files.txt
+++ b/.architecture/baseline/per-file-coverage-floor-union-files.txt
@@ -28,3 +28,4 @@ kairix/platform/setup/agent.py
 kairix/platform/setup/wizard.py
 kairix/quality/eval/cli.py
 kairix/secrets.py
+kairix/use_cases/_brief_defaults.py

--- a/kairix/agents/briefing/cli.py
+++ b/kairix/agents/briefing/cli.py
@@ -2,24 +2,24 @@
 kairix brief — session briefing synthesis.
 
 Usage:
-  kairix brief <agent>
+  kairix brief <agent> [--print] [--memory-root PATH]
 
-Generates a session briefing at /data/kairix/briefing/<agent>-latest.md
-and prints the path and first 30 lines to stdout.
+Generates a session briefing at the configured briefing dir and prints
+the path and first 30 lines to stdout.
+
+Adapter only — business logic lives in
+``kairix.use_cases.brief.run_brief``.
 """
 
 from __future__ import annotations
 
+import argparse
 import sys
 
+from kairix.use_cases.brief import BriefOutput, run_brief
 
-def main(args: list[str] | None = None) -> None:
-    """Entry point for `kairix brief`."""
-    import argparse
 
-    if args is None:
-        args = sys.argv[2:]  # strip 'kairix brief'
-
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="kairix brief",
         description="Generate a session briefing for an agent.",
@@ -41,48 +41,43 @@ def main(args: list[str] | None = None) -> None:
         default=None,
         help="Root directory containing agent subdirectories (e.g. /path/to/04-Agent-Knowledge).",
     )
+    return parser
 
-    parsed = parser.parse_args(args)
-    agent = parsed.agent.lower().strip()
+
+def format_output(out: BriefOutput, *, print_full: bool) -> str:
+    """Render the operator-facing stdout — preview or full content."""
+    if not out.content:
+        return ""
+    if print_full:
+        return out.content
+    lines = out.content.splitlines()
+    preview = "\n".join(lines[:30])
+    if len(lines) > 30:
+        preview = f"{preview}\n\n... ({len(lines) - 30} more lines — see {out.path})"
+    return preview
+
+
+def main(args: list[str] | None = None) -> None:
+    """Entry point for ``kairix brief``."""
+    if args is None:
+        args = sys.argv[2:]  # strip 'kairix brief'
+    parsed = build_parser().parse_args(args)
 
     if parsed.memory_root:
         import os
 
         os.environ["KAIRIX_AGENT_MEMORY_ROOT"] = parsed.memory_root
 
-    valid_agents = {"builder", "shape", "growth", "consultant"}
-    if agent not in valid_agents:
-        print(
-            f"Error: invalid agent {agent!r}. Must be one of: {sorted(valid_agents)}",
-            file=sys.stderr,
-        )
+    print(f"Generating briefing for agent: {parsed.agent} ...", file=sys.stderr)
+    out = run_brief(parsed.agent)
+
+    if out.error:
+        print(f"Error generating briefing: {out.error}", file=sys.stderr)
         sys.exit(1)
 
-    print(f"Generating briefing for agent: {agent} ...", file=sys.stderr)
+    if out.path:
+        print(f"Briefing written to: {out.path}", file=sys.stderr)
 
-    try:
-        from kairix.agents.briefing.pipeline import generate_briefing
-        from kairix.agents.briefing.writer import BRIEFING_DIR
-
-        content = generate_briefing(agent)
-
-        out_path = BRIEFING_DIR / f"{agent}-latest.md"
-        print(f"Briefing written to: {out_path}", file=sys.stderr)
-
-        if parsed.print_output:
-            print(
-                content
-            )  # lgtm[py/clear-text-logging-sensitive-data] — intentional: user requested --print-output flag; briefing is user's own document
-        else:
-            # Print first 30 lines to stdout
-            lines = content.splitlines()
-            preview = "\n".join(lines[:30])
-            print(
-                preview
-            )  # lgtm[py/clear-text-logging-sensitive-data] — intentional: CLI preview output for user review
-            if len(lines) > 30:
-                print(f"\n... ({len(lines) - 30} more lines — see {out_path})")
-
-    except Exception as e:
-        print(f"Error generating briefing: {e}", file=sys.stderr)
-        sys.exit(1)
+    rendered = format_output(out, print_full=parsed.print_output)
+    if rendered:
+        print(rendered)  # lgtm[py/clear-text-logging-sensitive-data] — intentional CLI output of user's own briefing

--- a/kairix/agents/briefing/cli.py
+++ b/kairix/agents/briefing/cli.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import argparse
 import sys
 
-from kairix.use_cases.brief import BriefOutput, run_brief
+from kairix.use_cases.brief import BriefDeps, BriefOutput, run_brief
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -57,8 +57,12 @@ def format_output(out: BriefOutput, *, print_full: bool) -> str:
     return preview
 
 
-def main(args: list[str] | None = None) -> None:
-    """Entry point for ``kairix brief``."""
+def main(args: list[str] | None = None, *, deps: BriefDeps | None = None) -> None:
+    """Entry point for ``kairix brief``.
+
+    The optional ``deps`` parameter forwards a ``BriefDeps`` directly
+    to the use case — production callers leave it None.
+    """
     if args is None:
         args = sys.argv[2:]  # strip 'kairix brief'
     parsed = build_parser().parse_args(args)
@@ -69,7 +73,7 @@ def main(args: list[str] | None = None) -> None:
         os.environ["KAIRIX_AGENT_MEMORY_ROOT"] = parsed.memory_root
 
     print(f"Generating briefing for agent: {parsed.agent} ...", file=sys.stderr)
-    out = run_brief(parsed.agent)
+    out = run_brief(parsed.agent, deps=deps)
 
     if out.error:
         print(f"Error generating briefing: {out.error}", file=sys.stderr)

--- a/kairix/agents/mcp/server.py
+++ b/kairix/agents/mcp/server.py
@@ -491,6 +491,26 @@ def tool_contradict(
     return contradict_output_to_envelope(out)
 
 
+def tool_brief(
+    agent: str,
+    *,
+    deps: Any = None,
+) -> dict[str, Any]:
+    """Generate a session briefing and return its content + path.
+
+    Thin adapter around ``kairix.use_cases.brief.run_brief``. Use before
+    starting work — gives an agent the operator's recent decisions,
+    notes, and entity stub in one structured payload.
+
+    The optional ``deps`` parameter forwards a ``BriefDeps`` directly to
+    the use case — production callers leave it None.
+    """
+    from kairix.use_cases.brief import brief_output_to_envelope, run_brief
+
+    out = run_brief(agent, deps=deps)
+    return brief_output_to_envelope(out)
+
+
 # ---------------------------------------------------------------------------
 # FastMCP server — only constructed when mcp package is available
 # ---------------------------------------------------------------------------
@@ -594,5 +614,11 @@ def build_server(host: str = "127.0.0.1", port: int = 8080) -> Any:
     def usage_guide(topic: str = "") -> dict[str, Any]:
         """Return the kairix agent usage guide. Call this when unsure how to use kairix."""
         return tool_usage_guide(topic=topic)
+
+    @server.tool()
+    @async_tool_handler
+    def brief(agent: str) -> dict[str, Any]:
+        """Generate a session briefing for an agent. Returns content + on-disk path."""
+        return tool_brief(agent=agent)
 
     return server

--- a/kairix/use_cases/_brief_defaults.py
+++ b/kairix/use_cases/_brief_defaults.py
@@ -1,0 +1,17 @@
+"""Production wiring for ``run_brief``."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def default_generate(agent: str, **kwargs: Any) -> str:
+    from kairix.agents.briefing.pipeline import generate_briefing
+
+    return generate_briefing(agent, **kwargs)
+
+
+def default_briefing_dir() -> Any:
+    from kairix.agents.briefing.writer import BRIEFING_DIR
+
+    return BRIEFING_DIR

--- a/kairix/use_cases/brief.py
+++ b/kairix/use_cases/brief.py
@@ -1,0 +1,110 @@
+"""Brief use case — session briefing generation shared by CLI and MCP.
+
+Phase 3a of the CLI/MCP feature parity initiative (#168). Pre-Phase-3a
+``kairix brief`` was CLI-only — agents had to shell out via subprocess
+to read their own briefing. This use case wraps the existing
+``generate_briefing`` pipeline and surfaces both the content and the
+on-disk path through a uniform dataclass; the new MCP tool
+``tool_brief`` calls it directly.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from kairix.use_cases import _brief_defaults as _defaults
+
+logger = logging.getLogger(__name__)
+
+_VALID_AGENTS = {"builder", "shape", "growth", "consultant"}
+
+
+@dataclass(frozen=True)
+class BriefOutput:
+    """Outcome of one ``run_brief`` invocation.
+
+    Attributes:
+        agent: The agent name used to generate the briefing.
+        content: Full briefing markdown (header + body). Empty when
+            ``error`` is set.
+        path: On-disk path of the briefing file (may be empty if the
+            writer step was skipped or failed). The CLI prints this
+            for operators; agents prefer ``content``.
+        preview: First 30 lines of ``content``, useful for stdout
+            previews without re-splitting.
+        error: Empty string on success; structured ``"<Class>: <msg>"``
+            on top-level failure, or ``invalid agent: <name>`` when
+            the agent name is unknown.
+    """
+
+    agent: str
+    content: str = ""
+    path: str = ""
+    preview: str = ""
+    error: str = ""
+
+
+@dataclass(frozen=True)
+class BriefDeps:
+    """Injectable dependencies for ``run_brief``."""
+
+    generate_fn: Callable[..., str] | None = None
+    briefing_dir_fn: Callable[[], Path] | None = None
+
+
+def run_brief(
+    agent: str,
+    *,
+    deps: BriefDeps | None = None,
+) -> BriefOutput:
+    """Generate a session briefing and return a structured result.
+
+    Never raises — failures populate ``BriefOutput.error``.
+
+    Args:
+        agent: Agent name (builder / shape / growth / consultant).
+        deps: Injectable dependencies; production callers leave None.
+    """
+    normalised = (agent or "").lower().strip()
+    if normalised not in _VALID_AGENTS:
+        return BriefOutput(
+            agent=agent,
+            error=f"invalid agent: {agent!r}. Must be one of: {sorted(_VALID_AGENTS)}",
+        )
+
+    d = deps or BriefDeps()
+    generate = d.generate_fn or _defaults.default_generate
+    briefing_dir = d.briefing_dir_fn or _defaults.default_briefing_dir
+
+    try:
+        content = generate(normalised)
+        out_dir = briefing_dir()
+        path = str(out_dir / f"{normalised}-latest.md") if out_dir else ""
+        preview = "\n".join(content.splitlines()[:30])
+        return BriefOutput(
+            agent=normalised,
+            content=content,
+            path=path,
+            preview=preview,
+        )
+    except Exception as exc:
+        logger.warning("run_brief failed: %s", exc, exc_info=True)
+        return BriefOutput(
+            agent=normalised,
+            error=f"{type(exc).__name__}: {exc}",
+        )
+
+
+def brief_output_to_envelope(out: BriefOutput) -> dict[str, Any]:
+    """Project a ``BriefOutput`` to the JSON envelope MCP callers receive."""
+    return {
+        "agent": out.agent,
+        "content": out.content,
+        "path": out.path,
+        "preview": out.preview,
+        "error": out.error,
+    }

--- a/tests/briefing/test_cli.py
+++ b/tests/briefing/test_cli.py
@@ -1,0 +1,129 @@
+"""Unit tests for ``kairix.agents.briefing.cli`` pure helpers + main orchestrator.
+
+The CLI is a thin adapter — argv parsing + run_brief + stdout formatting.
+Logic belongs to ``run_brief``. These tests drive each pure helper
+directly and the ``main`` orchestrator with a ``BriefDeps`` injection.
+"""
+
+from __future__ import annotations
+
+import io
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+import pytest
+
+from kairix.agents.briefing.cli import build_parser, format_output, main
+from kairix.use_cases.brief import BriefDeps, BriefOutput
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# build_parser
+# ---------------------------------------------------------------------------
+
+
+def test_build_parser_minimal_invocation() -> None:
+    args = build_parser().parse_args(["builder"])
+    assert args.agent == "builder"
+    assert args.print_output is False
+    assert args.memory_root is None
+
+
+def test_build_parser_accepts_print_and_memory_root() -> None:
+    args = build_parser().parse_args(["shape", "--print", "--memory-root", "/path/to/agents"])
+    assert args.agent == "shape"
+    assert args.print_output is True
+    assert args.memory_root == "/path/to/agents"
+
+
+def test_build_parser_requires_agent() -> None:
+    with pytest.raises(SystemExit):
+        build_parser().parse_args([])
+
+
+# ---------------------------------------------------------------------------
+# format_output
+# ---------------------------------------------------------------------------
+
+
+def test_format_output_short_content_returned_unchanged() -> None:
+    out = BriefOutput(agent="builder", content="line 1\nline 2", path="/p", preview="line 1\nline 2")
+    assert format_output(out, print_full=False) == "line 1\nline 2"
+
+
+def test_format_output_long_content_truncates_with_remainder() -> None:
+    lines = [f"line {i}" for i in range(45)]
+    out = BriefOutput(agent="builder", content="\n".join(lines), path="/var/brief.md", preview="\n".join(lines[:30]))
+    rendered = format_output(out, print_full=False)
+    assert "line 0" in rendered
+    assert "line 29" in rendered
+    assert "line 30" not in rendered
+    assert "15 more lines" in rendered
+    assert "/var/brief.md" in rendered
+
+
+def test_format_output_print_full_returns_complete_content() -> None:
+    out = BriefOutput(agent="builder", content="\n".join([f"l {i}" for i in range(50)]))
+    assert "l 49" in format_output(out, print_full=True)
+
+
+def test_format_output_empty_content_returns_empty_string() -> None:
+    out = BriefOutput(agent="x", content="", error="invalid agent")
+    assert format_output(out, print_full=False) == ""
+
+
+# ---------------------------------------------------------------------------
+# main orchestrator — driven through deps. No monkeypatch / no @patch.
+# ---------------------------------------------------------------------------
+
+
+def _build_deps(content: str = "x", out_dir: Path = Path("/tmp/brief")) -> BriefDeps:
+    return BriefDeps(
+        generate_fn=lambda agent, **_: content,
+        briefing_dir_fn=lambda: out_dir,
+    )
+
+
+def _run(argv: list[str], deps: BriefDeps | None = None) -> tuple[int, str, str]:
+    out_buf = io.StringIO()
+    err_buf = io.StringIO()
+    exit_code = 0
+    try:
+        with redirect_stdout(out_buf), redirect_stderr(err_buf):
+            main(argv, deps=deps)
+    except SystemExit as e:  # NOSONAR — CLI test captures exit code; reraising would defeat the test
+        exit_code = int(e.code) if e.code is not None else 0
+    return exit_code, out_buf.getvalue(), err_buf.getvalue()
+
+
+def test_main_invalid_agent_exits_nonzero() -> None:
+    exit_code, _stdout, stderr = _run(["rogue"], _build_deps())
+    assert exit_code == 1
+    assert "Error generating briefing" in stderr
+    assert "invalid agent" in stderr
+
+
+def test_main_happy_path_prints_path_and_preview() -> None:
+    deps = _build_deps(
+        content="\n".join([f"row {i}" for i in range(40)]),
+        out_dir=Path("/tmp/brief"),
+    )
+    exit_code, stdout, stderr = _run(["builder"], deps)
+    assert exit_code == 0
+    assert "Briefing written to" in stderr
+    assert "/tmp/brief/builder-latest.md" in stderr
+    assert "row 0" in stdout
+    assert "10 more lines" in stdout
+
+
+def test_main_print_flag_emits_full_content() -> None:
+    deps = _build_deps(content="\n".join([f"r{i}" for i in range(50)]))
+    exit_code, stdout, _stderr = _run(["shape", "--print"], deps)
+    assert exit_code == 0
+    assert "r49" in stdout
+
+
+# --memory-root operator flag is end-to-end behaviour covered at integration;
+# no unit test here (would require env-var manipulation forbidden by F2/F4).

--- a/tests/contracts/test_cli_mcp_parity_brief.py
+++ b/tests/contracts/test_cli_mcp_parity_brief.py
@@ -1,0 +1,62 @@
+"""Contract: CLI ↔ MCP parity for the ``brief`` operation (Phase 3a of #168)."""
+
+from __future__ import annotations
+
+import inspect
+import typing
+
+import pytest
+
+
+@pytest.mark.contract
+def test_cli_main_calls_run_brief_use_case() -> None:
+    from kairix.agents.briefing import cli
+
+    src = inspect.getsource(cli)
+    assert "from kairix.use_cases.brief import" in src
+    assert "run_brief(" in src
+
+
+@pytest.mark.contract
+def test_mcp_tool_brief_calls_run_brief_use_case() -> None:
+    from kairix.agents.mcp import server
+
+    src = inspect.getsource(server.tool_brief)
+    assert "from kairix.use_cases.brief import" in src
+    assert "run_brief(" in src
+
+
+@pytest.mark.contract
+def test_cli_does_not_call_generate_briefing_directly() -> None:
+    """CLI must NOT bypass the use case to invoke generate_briefing itself."""
+    from kairix.agents.briefing import cli
+
+    src = inspect.getsource(cli)
+    assert "generate_briefing" not in src, "CLI bypasses run_brief — see #168 Phase 3a"
+
+
+@pytest.mark.contract
+def test_use_case_returns_brief_output_dataclass() -> None:
+    from kairix.use_cases.brief import BriefOutput, run_brief
+
+    hints = typing.get_type_hints(run_brief)
+    assert hints.get("return") is BriefOutput
+
+
+@pytest.mark.contract
+def test_envelope_keys_match_brief_output_fields() -> None:
+    from kairix.use_cases import brief as uc
+
+    src = inspect.getsource(uc.brief_output_to_envelope)
+    for key in ("agent", "content", "path", "preview", "error"):
+        assert f'"{key}"' in src, f"envelope projector missing key {key!r}"
+
+
+@pytest.mark.contract
+def test_mcp_tool_brief_signature_minimal() -> None:
+    """tool_brief takes ``agent`` (positional) plus ``deps`` (test seam)."""
+    from kairix.agents.mcp.server import tool_brief
+
+    params = list(inspect.signature(tool_brief).parameters)
+    assert params[0] == "agent"
+    assert "deps" in params

--- a/tests/integration/test_mcp_build_server.py
+++ b/tests/integration/test_mcp_build_server.py
@@ -32,6 +32,7 @@ _EXPECTED_TOOLS = {
     "research",
     "contradict",
     "usage_guide",
+    "brief",
 }
 
 
@@ -46,7 +47,7 @@ def _call_tool(server: Any, name: str, arguments: dict[str, Any]) -> Any:
 
 
 @pytest.mark.integration
-def test_build_server_returns_fastmcp_with_all_seven_kairix_tools() -> None:
+def test_build_server_returns_fastmcp_with_all_kairix_tools() -> None:
     """The constructed server must register every kairix tool by name."""
     from mcp.server.fastmcp import FastMCP
 

--- a/tests/mcp/test_tool_brief.py
+++ b/tests/mcp/test_tool_brief.py
@@ -1,0 +1,51 @@
+"""Unit tests for ``kairix.agents.mcp.server.tool_brief``.
+
+The MCP adapter is a 4-line glue function. Coverage for the use-case
+body lives in ``tests/use_cases/test_brief.py``; this test drives the
+adapter shell via the typed-deps forwarder so the projection through
+``brief_output_to_envelope`` is exercised end-to-end.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kairix.agents.mcp.server import tool_brief
+from kairix.use_cases.brief import BriefDeps
+
+pytestmark = pytest.mark.unit
+
+
+def test_tool_brief_happy_path_returns_envelope_dict() -> None:
+    deps = BriefDeps(
+        generate_fn=lambda agent, **_: "line 1\nline 2\nline 3",
+        briefing_dir_fn=lambda: Path("/var/kairix"),
+    )
+    result = tool_brief(agent="builder", deps=deps)
+
+    assert result == {
+        "agent": "builder",
+        "content": "line 1\nline 2\nline 3",
+        "path": "/var/kairix/builder-latest.md",
+        "preview": "line 1\nline 2\nline 3",
+        "error": "",
+    }
+
+
+def test_tool_brief_invalid_agent_returns_error_envelope() -> None:
+    deps = BriefDeps()
+    result = tool_brief(agent="rogue", deps=deps)
+    assert result["error"].startswith("invalid agent")
+    assert result["content"] == ""
+
+
+def test_tool_brief_generate_failure_returns_error_envelope() -> None:
+    def _boom(agent: str, **_: object) -> str:
+        raise RuntimeError("generate failed")
+
+    deps = BriefDeps(generate_fn=_boom, briefing_dir_fn=lambda: Path("/x"))
+    result = tool_brief(agent="builder", deps=deps)
+    assert result["error"].startswith("RuntimeError")
+    assert result["content"] == ""

--- a/tests/use_cases/test_brief.py
+++ b/tests/use_cases/test_brief.py
@@ -1,0 +1,145 @@
+"""Unit tests for ``kairix.use_cases.brief.run_brief``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kairix.use_cases.brief import (
+    BriefDeps,
+    BriefOutput,
+    brief_output_to_envelope,
+    run_brief,
+)
+
+
+def _build_deps(
+    *,
+    content: str = "",
+    raises: bool = False,
+    out_dir: Path = Path("/tmp/brief"),
+) -> tuple[BriefDeps, dict[str, list]]:
+    captured: dict[str, list] = {"generate": [], "dir": []}
+
+    def fake_generate(agent: str, **kwargs: object) -> str:
+        captured["generate"].append((agent, kwargs))
+        if raises:
+            raise RuntimeError("boom")
+        return content
+
+    def fake_dir() -> Path:
+        captured["dir"].append(True)
+        return out_dir
+
+    return BriefDeps(generate_fn=fake_generate, briefing_dir_fn=fake_dir), captured
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_returns_content_path_and_preview() -> None:
+    deps, captured = _build_deps(
+        content="\n".join([f"line {i}" for i in range(50)]),
+        out_dir=Path("/var/lib/kairix/briefing"),
+    )
+    out = run_brief("builder", deps=deps)
+
+    assert out.error == ""
+    assert out.agent == "builder"
+    assert out.content.startswith("line 0")
+    assert out.path == "/var/lib/kairix/briefing/builder-latest.md"
+    # Preview is first 30 lines, joined by newlines.
+    assert out.preview == "\n".join([f"line {i}" for i in range(30)])
+    assert captured["generate"][0][0] == "builder"
+
+
+@pytest.mark.unit
+def test_short_content_preview_equals_content() -> None:
+    deps, _ = _build_deps(content="line 1\nline 2")
+    out = run_brief("shape", deps=deps)
+    assert out.preview == "line 1\nline 2"
+
+
+@pytest.mark.unit
+def test_agent_name_lowercased_and_stripped() -> None:
+    deps, captured = _build_deps(content="x")
+    out = run_brief("  Shape  ", deps=deps)
+    assert out.agent == "shape"
+    assert captured["generate"][0][0] == "shape"
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_unknown_agent_returns_error_envelope() -> None:
+    deps, captured = _build_deps()
+    out = run_brief("rogue", deps=deps)
+    assert out.error.startswith("invalid agent")
+    assert captured["generate"] == []  # never reached the generator
+
+
+@pytest.mark.unit
+def test_empty_agent_string_is_invalid() -> None:
+    deps, _ = _build_deps()
+    out = run_brief("", deps=deps)
+    assert "invalid agent" in out.error
+
+
+@pytest.mark.parametrize("agent", ["builder", "shape", "growth", "consultant"])
+@pytest.mark.unit
+def test_each_documented_agent_is_accepted(agent: str) -> None:
+    deps, _ = _build_deps(content="x")
+    out = run_brief(agent, deps=deps)
+    assert out.error == ""
+    assert out.agent == agent
+
+
+# ---------------------------------------------------------------------------
+# Failure path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_generate_failure_yields_error_envelope() -> None:
+    deps, _ = _build_deps(raises=True)
+    out = run_brief("builder", deps=deps)
+    assert out.error.startswith("RuntimeError:")
+    assert out.content == ""
+
+
+# ---------------------------------------------------------------------------
+# Envelope projection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_envelope_carries_all_fields() -> None:
+    out = BriefOutput(
+        agent="builder",
+        content="full content",
+        path="/p",
+        preview="preview",
+    )
+    env = brief_output_to_envelope(out)
+    assert env == {
+        "agent": "builder",
+        "content": "full content",
+        "path": "/p",
+        "preview": "preview",
+        "error": "",
+    }
+
+
+@pytest.mark.unit
+def test_envelope_carries_error_field() -> None:
+    out = BriefOutput(agent="x", error="invalid agent: 'x'. Must be ...")
+    env = brief_output_to_envelope(out)
+    assert env["error"].startswith("invalid agent")
+    assert env["content"] == ""


### PR DESCRIPTION
## Summary

Pre-Phase-3a, \`kairix brief\` was CLI-only — agents had to shell out via subprocess to read their own briefing. This PR wraps \`generate_briefing\` in a use case returning a uniform \`BriefOutput\` dataclass and adds \`tool_brief\` to the MCP server. Both surfaces share the same business logic.

## What changes

- **New** \`kairix/use_cases/brief.py\` — \`run_brief()\` returns \`BriefOutput(agent, content, path, preview, error)\`
- **Refactored** \`kairix/agents/briefing/cli.py\` — thin adapter calling \`run_brief\` then formatting for stdout
- **New** \`tool_brief\` in \`kairix/agents/mcp/server.py\` + registration in \`build_server\`
- **F7 baseline** \`_brief_defaults.py\` added (same precedent as Phase 1/2 \`_*_defaults.py\` files)

## Tests

- \`tests/use_cases/test_brief.py\` — 13 unit tests via \`BriefDeps\`
- \`tests/contracts/test_cli_mcp_parity_brief.py\` — 6 contract tests pinning thin-adapter shape

## Test plan

- [x] 2974 tests passing locally (unit + bdd + contract)
- [x] mypy --strict clean
- [x] ruff lint + format clean
- [x] Architecture fitness functions clean
- [ ] CI green
- [ ] Standard squash-merge (no \`--admin\`)

Phase 3a of #168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)