### PR TITLE
feat(use_cases): entity_get use case + kairix entity get CLI — Phase 3e of #168

### DIFF
--- a/.architecture/baseline/per-file-coverage-floor-files.txt
+++ b/.architecture/baseline/per-file-coverage-floor-files.txt
@@ -32,6 +32,7 @@ kairix/secrets.py
 kairix/use_cases/_brief_defaults.py
 kairix/use_cases/_contradict_defaults.py
 kairix/use_cases/_entity_defaults.py
+kairix/use_cases/_entity_get_defaults.py
 kairix/use_cases/_prep_defaults.py
 kairix/use_cases/_research_defaults.py
 kairix/use_cases/_search_defaults.py

--- a/.architecture/baseline/per-file-coverage-floor-union-files.txt
+++ b/.architecture/baseline/per-file-coverage-floor-union-files.txt
@@ -30,5 +30,6 @@ kairix/quality/eval/cli.py
 kairix/secrets.py
 kairix/use_cases/_brief_defaults.py
 kairix/use_cases/_entity_defaults.py
+kairix/use_cases/_entity_get_defaults.py
 kairix/use_cases/_prep_defaults.py
 kairix/use_cases/_research_defaults.py

--- a/kairix/agents/mcp/server.py
+++ b/kairix/agents/mcp/server.py
@@ -150,29 +150,29 @@ def tool_search(
 def tool_entity(
     name: str,
     *,
+    deps: Any = None,
     neo4j_client: Any | None = None,
 ) -> dict[str, Any]:
     """Look up a specific person, company, or topic by name.
 
+    Thin adapter around ``kairix.use_cases.entity_get.run_entity_get``.
     This is a quick, direct lookup from the knowledge graph (Neo4j) —
     use it when you already know the name of what you're looking for.
 
-    Args:
-        neo4j_client: Injectable Neo4j client for testing.
-                      Defaults to the production client.
-    """
-    card = _fetch_entity_card(name, neo4j_client=neo4j_client)
-    if card is not None:
-        return {**card, "error": ""}
+    The optional ``deps`` parameter forwards an ``EntityGetDeps`` directly
+    to the use case — production callers leave it None.
 
-    return {
-        "id": "",
-        "name": name,
-        "type": "",
-        "summary": "",
-        "vault_path": "",
-        "error": f"Entity not found: {name}",
-    }
+    The legacy ``neo4j_client`` parameter is retained for back-compat;
+    when set, it overrides the default ``_fetch_entity_card`` helper's
+    Neo4j client. Prefer ``deps`` for new code.
+    """
+    from kairix.use_cases.entity_get import EntityGetDeps, entity_get_output_to_envelope, run_entity_get
+
+    if deps is None and neo4j_client is not None:
+        deps = EntityGetDeps(fetch_fn=lambda n: _fetch_entity_card(n, neo4j_client=neo4j_client))
+
+    out = run_entity_get(name, deps=deps)
+    return entity_get_output_to_envelope(out)
 
 
 def tool_prep(

--- a/kairix/knowledge/entities/cli.py
+++ b/kairix/knowledge/entities/cli.py
@@ -236,7 +236,54 @@ def build_parser() -> argparse.ArgumentParser:
     p_seed.add_argument("--dry-run", action="store_true", help="Show candidates without seeding")
     p_seed.set_defaults(func=cmd_seed)
 
+    # get subcommand — direct entity lookup by name (Phase 3e of #168)
+    p_get = sub.add_parser("get", help="Look up an entity by name")
+    p_get.add_argument("name", help="Entity name (case-insensitive)")
+    p_get.add_argument("--format", choices=["table", "json"], default="table")
+    p_get.set_defaults(func=cmd_get)
+
     return parser
+
+
+def cmd_get(
+    args: argparse.Namespace,
+    *,
+    deps: Any = None,
+) -> int:
+    """kairix entity get <name> — direct Neo4j entity-card lookup.
+
+    Thin adapter around ``kairix.use_cases.entity_get.run_entity_get``.
+    """
+    import json as _json
+
+    from kairix.use_cases.entity_get import run_entity_get
+
+    out = run_entity_get(args.name, deps=deps)
+
+    if args.format == "json":
+        from kairix.use_cases.entity_get import entity_get_output_to_envelope
+
+        print(_json.dumps(entity_get_output_to_envelope(out), indent=2))
+    else:
+        print(format_get_output(out))
+
+    return 1 if out.error else 0
+
+
+def format_get_output(out: Any) -> str:
+    """Render an EntityGetOutput as the operator-facing table view."""
+    if out.error:
+        return f"error: {out.error}"
+    lines: list[str] = [
+        f"Entity:     {out.name}",
+        f"Type:       {out.type or '(unknown)'}",
+        f"Neo4j id:   {out.id or '(none)'}",
+        f"Vault path: {out.vault_path or '(none)'}",
+    ]
+    if out.summary:
+        lines.append("")
+        lines.append(out.summary)
+    return "\n".join(lines)
 
 
 def main(argv: list[str] | None = None, *, db_path: Any = None, neo4j_client: Any = None) -> int:
@@ -254,4 +301,6 @@ def main(argv: list[str] | None = None, *, db_path: Any = None, neo4j_client: An
         return cmd_suggest(args)
     if args.command == "validate":
         return cmd_validate(args)
+    if args.command == "get":
+        return cmd_get(args)
     return 1  # pragma: no cover — unreachable; subparsers required=True

--- a/kairix/use_cases/_entity_get_defaults.py
+++ b/kairix/use_cases/_entity_get_defaults.py
@@ -1,0 +1,11 @@
+"""Production wiring for ``run_entity_get``."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def default_fetch_card(name: str, *, neo4j_client: Any | None = None) -> dict[str, Any] | None:
+    from kairix.agents.mcp.server import _fetch_entity_card
+
+    return _fetch_entity_card(name, neo4j_client=neo4j_client)

--- a/kairix/use_cases/entity_get.py
+++ b/kairix/use_cases/entity_get.py
@@ -1,0 +1,99 @@
+"""Entity get use case — direct entity-card lookup shared by CLI and MCP.
+
+Phase 3e of the CLI/MCP feature parity initiative (#168). Pre-Phase-3e
+``mcp__entity`` was MCP-only; the CLI had no way to look an entity up
+by name from the knowledge graph. This module wraps the existing
+``_fetch_entity_card`` helper in a use case so both surfaces share
+the same call shape and result structure.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from kairix.use_cases import _entity_get_defaults as _defaults
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class EntityGetOutput:
+    """Outcome of one ``run_entity_get`` invocation.
+
+    Attributes:
+        id: Neo4j node id (slugified). Empty when entity not found.
+        name: Canonical entity name. Equals the caller's name when the
+            entity was not found in Neo4j.
+        type: Neo4j label (``Person``, ``Organisation``, ``Project``, …).
+        summary: Human-readable summary built from type-specific fields
+            (role, org, tier, industry, …). Empty when no fields were
+            populated.
+        vault_path: On-disk path to the entity's markdown file in the
+            vault. Empty when the entity has no associated file.
+        error: Empty on success; ``"Entity not found: <name>"`` when
+            the lookup returned no rows; structured ``"<Class>: <msg>"``
+            on top-level failure.
+    """
+
+    id: str = ""
+    name: str = ""
+    type: str = ""
+    summary: str = ""
+    vault_path: str = ""
+    error: str = ""
+
+
+@dataclass(frozen=True)
+class EntityGetDeps:
+    """Injectable dependencies for ``run_entity_get``."""
+
+    fetch_fn: Callable[..., dict[str, Any] | None] | None = None
+
+
+def run_entity_get(
+    name: str,
+    *,
+    deps: EntityGetDeps | None = None,
+) -> EntityGetOutput:
+    """Look up an entity by name and return a structured result.
+
+    Never raises — failures populate ``EntityGetOutput.error``.
+
+    Args:
+        name: Entity name to look up (case-insensitive against canonical name + slug).
+        deps: Injectable dependencies; production callers leave None.
+    """
+    d = deps or EntityGetDeps()
+    fetch = d.fetch_fn or _defaults.default_fetch_card
+
+    try:
+        card = fetch(name)
+    except Exception as exc:
+        logger.warning("run_entity_get failed: %s", exc, exc_info=True)
+        return EntityGetOutput(name=name, error=f"{type(exc).__name__}: {exc}")
+
+    if card is None:
+        return EntityGetOutput(name=name, error=f"Entity not found: {name}")
+
+    return EntityGetOutput(
+        id=str(card.get("id", "") or ""),
+        name=str(card.get("name", "") or ""),
+        type=str(card.get("type", "") or ""),
+        summary=str(card.get("summary", "") or ""),
+        vault_path=str(card.get("vault_path", "") or ""),
+    )
+
+
+def entity_get_output_to_envelope(out: EntityGetOutput) -> dict[str, Any]:
+    """Project an ``EntityGetOutput`` to the JSON envelope MCP callers receive."""
+    return {
+        "id": out.id,
+        "name": out.name,
+        "type": out.type,
+        "summary": out.summary,
+        "vault_path": out.vault_path,
+        "error": out.error,
+    }

--- a/tests/contracts/test_cli_mcp_parity_entity_get.py
+++ b/tests/contracts/test_cli_mcp_parity_entity_get.py
@@ -1,0 +1,52 @@
+"""Contract: CLI ↔ MCP parity for the ``entity get`` operation (Phase 3e of #168)."""
+
+from __future__ import annotations
+
+import inspect
+import typing
+
+import pytest
+
+
+@pytest.mark.contract
+def test_cli_cmd_get_uses_run_entity_get() -> None:
+    from kairix.knowledge.entities import cli
+
+    src = inspect.getsource(cli.cmd_get)
+    assert "run_entity_get(" in src
+
+
+@pytest.mark.contract
+def test_mcp_tool_entity_uses_run_entity_get() -> None:
+    from kairix.agents.mcp import server
+
+    src = inspect.getsource(server.tool_entity)
+    assert "run_entity_get(" in src
+
+
+@pytest.mark.contract
+def test_use_case_returns_entity_get_output() -> None:
+    from kairix.use_cases.entity_get import EntityGetOutput, run_entity_get
+
+    hints = typing.get_type_hints(run_entity_get)
+    assert hints.get("return") is EntityGetOutput
+
+
+@pytest.mark.contract
+def test_envelope_keys_match_entity_get_output() -> None:
+    from kairix.use_cases import entity_get as uc
+
+    src = inspect.getsource(uc.entity_get_output_to_envelope)
+    for key in ("id", "name", "type", "summary", "vault_path", "error"):
+        assert f'"{key}"' in src
+
+
+@pytest.mark.contract
+def test_entity_get_subcommand_is_registered() -> None:
+    """The entity CLI's parser exposes a ``get`` subcommand."""
+    from kairix.knowledge.entities.cli import build_parser
+
+    parser = build_parser()
+    args = parser.parse_args(["get", "Acme"])
+    assert args.command == "get"
+    assert args.name == "Acme"

--- a/tests/knowledge/entities/test_cli.py
+++ b/tests/knowledge/entities/test_cli.py
@@ -18,8 +18,10 @@ from typing import Any
 import pytest
 
 from kairix.knowledge.entities.cli import (
+    cmd_get,
     cmd_suggest,
     cmd_validate,
+    format_get_output,
     format_suggest_output,
     format_validate_table,
 )
@@ -31,6 +33,7 @@ from kairix.use_cases.entity import (
     EntityValidateOutput,
     SuggestedEntityHit,
 )
+from kairix.use_cases.entity_get import EntityGetDeps, EntityGetOutput
 
 pytestmark = pytest.mark.unit
 
@@ -305,3 +308,76 @@ def test_cmd_validate_use_case_error_exits_one() -> None:
     rc, _stdout, stderr = _capture(lambda: cmd_validate(args, deps=deps))
     assert rc == 1
     assert "Validation failed" in stderr
+
+
+# ---------------------------------------------------------------------------
+# cmd_get — Phase 3e
+# ---------------------------------------------------------------------------
+
+
+def test_format_get_output_renders_entity_with_summary() -> None:
+    out = EntityGetOutput(
+        id="acme", name="Acme", type="Organisation", summary="supplier — Tier A", vault_path="/Acme.md"
+    )
+    text = format_get_output(out)
+    assert "Entity:     Acme" in text
+    assert "Type:       Organisation" in text
+    assert "Neo4j id:   acme" in text
+    assert "Vault path: /Acme.md" in text
+    assert "supplier — Tier A" in text
+
+
+def test_format_get_output_renders_unknown_for_empty_fields() -> None:
+    out = EntityGetOutput(name="X")
+    text = format_get_output(out)
+    assert "Type:       (unknown)" in text
+    assert "Neo4j id:   (none)" in text
+    assert "Vault path: (none)" in text
+
+
+def test_format_get_output_short_circuits_on_error() -> None:
+    out = EntityGetOutput(name="X", error="Entity not found: X")
+    assert format_get_output(out).startswith("error:")
+
+
+def test_cmd_get_table_format_returns_zero_on_match() -> None:
+    args = argparse.Namespace(name="Acme", format="table")
+    deps = EntityGetDeps(
+        fetch_fn=lambda name: {
+            "id": "acme",
+            "name": name,
+            "type": "Organisation",
+            "summary": "supplier",
+            "vault_path": "/Acme.md",
+        }
+    )
+    rc, stdout, _ = _capture(lambda: cmd_get(args, deps=deps))
+    assert rc == 0
+    assert "Acme" in stdout
+    assert "Organisation" in stdout
+
+
+def test_cmd_get_returns_one_on_not_found() -> None:
+    args = argparse.Namespace(name="Bogus", format="table")
+    deps = EntityGetDeps(fetch_fn=lambda name: None)
+    rc, stdout, _ = _capture(lambda: cmd_get(args, deps=deps))
+    assert rc == 1
+    assert "Entity not found" in stdout
+
+
+def test_cmd_get_json_format_emits_envelope() -> None:
+    args = argparse.Namespace(name="Acme", format="json")
+    deps = EntityGetDeps(
+        fetch_fn=lambda name: {
+            "id": "acme",
+            "name": name,
+            "type": "Organisation",
+            "summary": "s",
+            "vault_path": "/p",
+        }
+    )
+    rc, stdout, _ = _capture(lambda: cmd_get(args, deps=deps))
+    assert rc == 0
+    payload = json.loads(stdout)
+    assert payload["id"] == "acme"
+    assert payload["name"] == "Acme"

--- a/tests/use_cases/test_entity_get.py
+++ b/tests/use_cases/test_entity_get.py
@@ -1,0 +1,76 @@
+"""Unit tests for ``kairix.use_cases.entity_get.run_entity_get``."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from kairix.use_cases.entity_get import (
+    EntityGetDeps,
+    EntityGetOutput,
+    entity_get_output_to_envelope,
+    run_entity_get,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _build_deps(card: dict[str, Any] | None = None, raises: bool = False) -> EntityGetDeps:
+    def _fetch(name: str) -> dict[str, Any] | None:
+        if raises:
+            raise RuntimeError("Neo4j down")
+        return card
+
+    return EntityGetDeps(fetch_fn=_fetch)
+
+
+def test_card_present_projects_into_output() -> None:
+    card = {
+        "id": "acme",
+        "name": "Acme",
+        "type": "Organisation",
+        "summary": "supplier — Tier A",
+        "vault_path": "02-Areas/00-Clients/Acme/Acme.md",
+    }
+    out = run_entity_get("Acme", deps=_build_deps(card=card))
+    assert out.error == ""
+    assert out.id == "acme"
+    assert out.name == "Acme"
+    assert out.type == "Organisation"
+    assert out.summary == "supplier — Tier A"
+    assert out.vault_path == "02-Areas/00-Clients/Acme/Acme.md"
+
+
+def test_card_none_returns_not_found_error() -> None:
+    out = run_entity_get("Bogus", deps=_build_deps(card=None))
+    assert out.error == "Entity not found: Bogus"
+    assert out.id == ""
+    # Name preserved from the caller for the operator's error message.
+    assert out.name == "Bogus"
+
+
+def test_none_summary_renders_empty_string() -> None:
+    card = {"id": "x", "name": "X", "type": "Project", "summary": None, "vault_path": None}
+    out = run_entity_get("X", deps=_build_deps(card=card))
+    assert out.summary == ""
+    assert out.vault_path == ""
+
+
+def test_fetch_failure_yields_error_envelope() -> None:
+    out = run_entity_get("X", deps=_build_deps(raises=True))
+    assert out.error.startswith("RuntimeError:")
+    assert out.id == ""
+
+
+def test_envelope_includes_all_fields() -> None:
+    out = EntityGetOutput(id="a", name="A", type="Person", summary="role", vault_path="/p")
+    env = entity_get_output_to_envelope(out)
+    assert env == {
+        "id": "a",
+        "name": "A",
+        "type": "Person",
+        "summary": "role",
+        "vault_path": "/p",
+        "error": "",
+    }


### PR DESCRIPTION
## Summary

Pre-Phase-3e, `mcp__entity` was MCP-only — operators couldn't look up an entity card by name from a shell. This PR wraps `_fetch_entity_card` in a use case (`run_entity_get`) returning a uniform `EntityGetOutput` dataclass.

## What changes

- **New** `kairix/use_cases/entity_get.py` — `run_entity_get()` returns `EntityGetOutput(id, name, type, summary, vault_path, error)`
- **Refactored** `tool_entity` — thin adapter; `neo4j_client` legacy parameter retained for back-compat, new code uses `deps: EntityGetDeps`
- **New** `kairix entity get <name> [--format table|json]` subcommand
- **F7 + F9** baselines updated for `_entity_get_defaults.py`

## Tests

- `tests/use_cases/test_entity_get.py` — 5 unit tests
- `tests/contracts/test_cli_mcp_parity_entity_get.py` — 5 contract tests
- 6 new `cmd_get` adapter tests appended to `tests/knowledge/entities/test_cli.py`

## Test plan

- [x] 3085 tests passing locally
- [x] mypy --strict clean
- [x] ruff lint + format clean
- [x] Architecture fitness functions clean
- [ ] CI green
- [ ] Standard squash-merge (no `--admin`)

Phase 3e of #168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)