### PR TITLE
feat(use_cases): usage_guide use case + kairix usage-guide CLI — Phase 3f of #168

### DIFF
--- a/.architecture/baseline/per-file-coverage-floor-files.txt
+++ b/.architecture/baseline/per-file-coverage-floor-files.txt
@@ -36,3 +36,4 @@ kairix/use_cases/_entity_get_defaults.py
 kairix/use_cases/_prep_defaults.py
 kairix/use_cases/_research_defaults.py
 kairix/use_cases/_search_defaults.py
+kairix/use_cases/_usage_guide_defaults.py

--- a/.architecture/baseline/per-file-coverage-floor-union-files.txt
+++ b/.architecture/baseline/per-file-coverage-floor-union-files.txt
@@ -33,3 +33,4 @@ kairix/use_cases/_entity_defaults.py
 kairix/use_cases/_entity_get_defaults.py
 kairix/use_cases/_prep_defaults.py
 kairix/use_cases/_research_defaults.py
+kairix/use_cases/_usage_guide_defaults.py

--- a/kairix/agents/mcp/server.py
+++ b/kairix/agents/mcp/server.py
@@ -273,93 +273,27 @@ def tool_research(
     return research_output_to_envelope(out)
 
 
-def _resolve_guide_path(guide_path: Path | None) -> Path:
-    """Resolve the usage-guide markdown file path. Production fallback chain:
-    relative to this module → relative to the installed kairix package.
-    """
-    if guide_path is not None:
-        return guide_path
-    candidate = Path(__file__).parent.parent.parent / "docs" / "agent-usage-guide.md"
-    if candidate.exists():
-        return candidate
-    import kairix as _kairix
-
-    return Path(_kairix.__file__).parent.parent / "docs" / "agent-usage-guide.md"
-
-
-def _extract_topic_sections(full_text: str, topic_lower: str) -> str:
-    """Return the concatenated markdown sections whose heading mentions the topic.
-
-    Sections are demarcated by ``##`` / ``###`` headings. Falls back to a
-    keyword search across all lines when no heading matches.
-    """
-    lines = full_text.splitlines()
-    sections: list[str] = []
-    current: list[str] = []
-    in_section = False
-
-    for line in lines:
-        is_heading = line.startswith("## ") or line.startswith("### ")
-        if is_heading:
-            if in_section and current:
-                sections.append("\n".join(current))
-                current = []
-            in_section = topic_lower in line.lower()
-            if in_section:
-                current = [line]
-        elif in_section:
-            current.append(line)
-
-    if in_section and current:
-        sections.append("\n".join(current))
-
-    if sections:
-        return "\n\n".join(sections)
-    matching_lines = [ln for ln in lines if topic_lower in ln.lower()]
-    return "\n".join(matching_lines[:30]) if matching_lines else full_text[:2000]
-
-
-def tool_usage_guide(topic: str = "", *, guide_path: Path | None = None) -> dict[str, Any]:
+def tool_usage_guide(
+    topic: str = "",
+    *,
+    guide_path: Path | None = None,
+    deps: Any = None,
+) -> dict[str, Any]:
     """
     Return the kairix agent usage guide, or a section of it filtered by topic.
 
-    Use this tool when you are unsure how to use kairix, when a search returns
-    unexpected results, or when you want to understand a specific feature.
+    Thin adapter around ``kairix.use_cases.usage_guide.run_usage_guide``.
+    Use this tool when you are unsure how to use kairix, when a search
+    returns unexpected results, or when you want to understand a feature.
 
-    Args:
-        topic: Optional topic filter (e.g. "temporal", "entity", "troubleshoot",
-               "intent", "budget"). Empty string returns the full guide.
-        guide_path: Explicit path to the guide markdown file. When omitted,
-                    resolves relative to the package layout (production default).
-                    Tests inject an explicit path rather than monkeypatching
-                    ``__file__``.
-
-    Returns:
-        dict with keys: topic, content (markdown string), error.
+    The optional ``deps`` parameter forwards a ``UsageGuideDeps`` directly
+    to the use case — production callers leave it None. The legacy
+    ``guide_path`` parameter is preserved as the operator-facing override.
     """
-    try:
-        resolved_path = _resolve_guide_path(guide_path)
-        if not resolved_path.exists():
-            return {
-                "topic": topic,
-                "content": "",
-                "error": "Usage guide not found. Run: kairix onboard guide --document-root <path>",
-            }
+    from kairix.use_cases.usage_guide import run_usage_guide, usage_guide_output_to_envelope
 
-        full_text = resolved_path.read_text(encoding="utf-8")
-        if not topic:
-            return {"topic": "", "content": full_text, "error": ""}
-
-        content = _extract_topic_sections(full_text, topic.lower())
-        return {"topic": topic, "content": content, "error": ""}
-
-    except Exception as exc:
-        logger.warning("mcp.usage_guide failed: %s", exc)
-        return {
-            "topic": topic,
-            "content": "",
-            "error": "Usage guide lookup failed — check server logs for details.",
-        }
+    out = run_usage_guide(topic, guide_path=guide_path, deps=deps)
+    return usage_guide_output_to_envelope(out)
 
 
 def tool_contradict(

--- a/kairix/agents/usage_guide/__init__.py
+++ b/kairix/agents/usage_guide/__init__.py
@@ -1,0 +1,6 @@
+"""kairix usage-guide — read the agent usage guide from a shell.
+
+The CLI body is in ``cli.py``; the use case logic lives in
+``kairix.use_cases.usage_guide.run_usage_guide``. Phase 3f of #168
+(also addresses dogfood CONN-2 deployment-step gap).
+"""

--- a/kairix/agents/usage_guide/cli.py
+++ b/kairix/agents/usage_guide/cli.py
@@ -1,0 +1,72 @@
+"""
+kairix usage-guide — read the agent usage guide from a shell.
+
+Usage:
+  kairix usage-guide [topic] [--guide-path PATH] [--json]
+
+Adapter only — business logic lives in
+``kairix.use_cases.usage_guide.run_usage_guide``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from kairix.use_cases.usage_guide import (
+    UsageGuideDeps,
+    UsageGuideOutput,
+    run_usage_guide,
+    usage_guide_output_to_envelope,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="kairix usage-guide",
+        description="Read the kairix agent usage guide. Filter by topic when given.",
+    )
+    parser.add_argument(
+        "topic",
+        nargs="?",
+        default="",
+        help="Topic filter (e.g. 'temporal', 'entity', 'budget'). Empty returns the full guide.",
+    )
+    parser.add_argument(
+        "--guide-path",
+        type=Path,
+        default=None,
+        help="Override the production guide-file location (operator escape hatch).",
+    )
+    parser.add_argument("--json", dest="as_json", action="store_true", help="Output JSON envelope")
+    return parser
+
+
+def format_text(out: UsageGuideOutput) -> str:
+    """Render a ``UsageGuideOutput`` as the human-readable text the CLI prints."""
+    if out.error:
+        return f"error: {out.error}"
+    if out.topic:
+        header = f"Usage guide — topic: {out.topic}"
+        return f"{header}\n{'=' * len(header)}\n\n{out.content}"
+    return out.content
+
+
+def main(argv: list[str] | None = None, *, deps: UsageGuideDeps | None = None) -> int:
+    """Entry point for ``kairix usage-guide``."""
+    args = build_parser().parse_args(argv)
+
+    out = run_usage_guide(args.topic, guide_path=args.guide_path, deps=deps)
+
+    if args.as_json:
+        print(json.dumps(usage_guide_output_to_envelope(out), indent=2))
+    else:
+        print(format_text(out))
+
+    return 1 if out.error else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/kairix/cli.py
+++ b/kairix/cli.py
@@ -16,6 +16,7 @@ Subcommands:
   brief       Session briefing synthesis
   prep        Tiered L0/L1 context summary for a topic
   research    Iterative research over the knowledge store with LLM synthesis
+  usage-guide Read the kairix agent usage guide (full text or topic-filtered)
   benchmark   Run retrieval quality benchmark
   wikilinks   Inject [[wikilinks]] on first mention in agent-written document store files
   reference-library  Reference library: install entities, check status, run extraction
@@ -44,6 +45,7 @@ COMMANDS: dict[str, tuple[str, str, bool]] = {
     "brief": ("kairix.agents.briefing.cli", "main", True),
     "prep": ("kairix.agents.prep.cli", "main", True),
     "research": ("kairix.agents.research.cli", "main", True),
+    "usage-guide": ("kairix.agents.usage_guide.cli", "main", True),
     "contradict": ("kairix.knowledge.contradict.cli", "main", True),
     "store": ("kairix.knowledge.store.cli", "main", True),
     "vault": ("kairix.knowledge.store.cli", "main", True),  # backwards-compat alias

--- a/kairix/use_cases/_usage_guide_defaults.py
+++ b/kairix/use_cases/_usage_guide_defaults.py
@@ -1,0 +1,22 @@
+"""Production wiring for ``run_usage_guide``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def default_resolve_guide(guide_path: Path | None) -> Path:
+    """Resolve the usage-guide markdown file path. Production fallback chain:
+    relative to the MCP server module → relative to the installed kairix
+    package.
+    """
+    if guide_path is not None:
+        return guide_path
+    import kairix.agents.mcp.server as _server_mod
+
+    candidate = Path(_server_mod.__file__).parent.parent.parent / "docs" / "agent-usage-guide.md"
+    if candidate.exists():
+        return candidate
+    import kairix as _kairix
+
+    return Path(_kairix.__file__).parent.parent / "docs" / "agent-usage-guide.md"

--- a/kairix/use_cases/usage_guide.py
+++ b/kairix/use_cases/usage_guide.py
@@ -1,0 +1,133 @@
+"""Usage-guide use case — markdown-section retrieval shared by CLI and MCP.
+
+Phase 3f of the CLI/MCP feature parity initiative (#168). Pre-Phase-3f
+``mcp__usage_guide`` was MCP-only — operators couldn't read the agent
+usage guide from a shell. This module wraps the existing topic-section
+extractor in a use case so both surfaces share the same call shape and
+result structure.
+
+The CLI surface also addresses dogfood CONN-2 (deployment-step gap):
+operators can now run ``kairix usage-guide`` to onboard themselves
+without booting the MCP server.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from kairix.use_cases import _usage_guide_defaults as _defaults
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class UsageGuideOutput:
+    """Outcome of one ``run_usage_guide`` invocation.
+
+    Attributes:
+        topic: The caller's topic filter (empty string returns the full guide).
+        content: Markdown content. Full guide when ``topic == ""``;
+            otherwise concatenated sections whose headings mention the
+            topic. Falls back to a keyword-line search when no heading
+            matches; first 2000 chars of the guide when no lines match.
+        error: Empty on success; an operator-actionable message when
+            the guide file is missing; ``"<Class>: <msg>"`` on
+            unexpected failure.
+    """
+
+    topic: str = ""
+    content: str = ""
+    error: str = ""
+
+
+@dataclass(frozen=True)
+class UsageGuideDeps:
+    """Injectable dependencies for ``run_usage_guide``."""
+
+    resolve_guide_fn: Callable[[Path | None], Path] | None = None
+
+
+def extract_topic_sections(full_text: str, topic_lower: str) -> str:
+    """Return the concatenated markdown sections whose heading mentions the topic.
+
+    Sections are demarcated by ``##`` / ``###`` headings. Falls back to a
+    keyword search across all lines when no heading matches; falls back
+    again to the first 2000 chars of the guide when no lines match.
+
+    Public so CLI tests can pin the section-extraction contract directly.
+    """
+    lines = full_text.splitlines()
+    sections: list[str] = []
+    current: list[str] = []
+    in_section = False
+
+    for line in lines:
+        is_heading = line.startswith("## ") or line.startswith("### ")
+        if is_heading:
+            if in_section and current:
+                sections.append("\n".join(current))
+                current = []
+            in_section = topic_lower in line.lower()
+            if in_section:
+                current = [line]
+        elif in_section:
+            current.append(line)
+
+    if in_section and current:
+        sections.append("\n".join(current))
+
+    if sections:
+        return "\n\n".join(sections)
+    matching_lines = [ln for ln in lines if topic_lower in ln.lower()]
+    return "\n".join(matching_lines[:30]) if matching_lines else full_text[:2000]
+
+
+def run_usage_guide(
+    topic: str = "",
+    *,
+    guide_path: Path | None = None,
+    deps: UsageGuideDeps | None = None,
+) -> UsageGuideOutput:
+    """Read the usage guide and optionally filter by topic.
+
+    Never raises — failures populate ``UsageGuideOutput.error``.
+
+    Args:
+        topic: Optional topic filter (case-insensitive). Empty string
+            returns the full guide.
+        guide_path: Explicit path to the guide markdown file. When
+            omitted, the use case resolves the production location.
+        deps: Injectable dependencies; production callers leave None.
+    """
+    d = deps or UsageGuideDeps()
+    resolve = d.resolve_guide_fn or _defaults.default_resolve_guide
+
+    try:
+        resolved = resolve(guide_path)
+        if not resolved.exists():
+            return UsageGuideOutput(
+                topic=topic,
+                error="Usage guide not found. Run: kairix onboard guide --document-root <path>",
+            )
+
+        full_text = resolved.read_text(encoding="utf-8")
+        if not topic:
+            return UsageGuideOutput(content=full_text)
+
+        return UsageGuideOutput(topic=topic, content=extract_topic_sections(full_text, topic.lower()))
+    except Exception as exc:
+        logger.warning("run_usage_guide failed: %s", exc, exc_info=True)
+        return UsageGuideOutput(topic=topic, error=f"{type(exc).__name__}: {exc}")
+
+
+def usage_guide_output_to_envelope(out: UsageGuideOutput) -> dict[str, Any]:
+    """Project a ``UsageGuideOutput`` to the JSON envelope MCP callers receive."""
+    return {
+        "topic": out.topic,
+        "content": out.content,
+        "error": out.error,
+    }

--- a/tests/agents/usage_guide/test_cli.py
+++ b/tests/agents/usage_guide/test_cli.py
@@ -1,0 +1,108 @@
+"""Unit tests for ``kairix.agents.usage_guide.cli``."""
+
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+import pytest
+
+from kairix.agents.usage_guide.cli import build_parser, format_text, main
+from kairix.use_cases.usage_guide import UsageGuideDeps, UsageGuideOutput
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# build_parser
+# ---------------------------------------------------------------------------
+
+
+def test_build_parser_no_args() -> None:
+    args = build_parser().parse_args([])
+    assert args.topic == ""
+    assert args.guide_path is None
+    assert args.as_json is False
+
+
+def test_build_parser_topic_and_guide_path(tmp_path: Path) -> None:
+    args = build_parser().parse_args(["budget", "--guide-path", str(tmp_path / "g.md"), "--json"])
+    assert args.topic == "budget"
+    assert args.guide_path == tmp_path / "g.md"
+    assert args.as_json is True
+
+
+# ---------------------------------------------------------------------------
+# format_text
+# ---------------------------------------------------------------------------
+
+
+def test_format_text_full_guide_returns_content_unchanged() -> None:
+    out = UsageGuideOutput(topic="", content="Full guide markdown.")
+    assert format_text(out) == "Full guide markdown."
+
+
+def test_format_text_with_topic_adds_heading() -> None:
+    out = UsageGuideOutput(topic="budget", content="Budget section.")
+    rendered = format_text(out)
+    assert "Usage guide — topic: budget" in rendered
+    assert "==" in rendered  # underline of header
+    assert "Budget section." in rendered
+
+
+def test_format_text_short_circuits_on_error() -> None:
+    out = UsageGuideOutput(error="Usage guide not found.")
+    assert format_text(out).startswith("error:")
+
+
+# ---------------------------------------------------------------------------
+# main orchestrator — driven via UsageGuideDeps.
+# ---------------------------------------------------------------------------
+
+
+def _capture(argv: list[str], deps: UsageGuideDeps) -> tuple[int, str]:
+    out_buf = io.StringIO()
+    with redirect_stdout(out_buf), redirect_stderr(io.StringIO()):
+        rc = main(argv, deps=deps)
+    return rc, out_buf.getvalue()
+
+
+def test_main_full_guide_text_output(tmp_path: Path) -> None:
+    guide = tmp_path / "g.md"
+    guide.write_text("# Title\n\n## Section\nBody.\n", encoding="utf-8")
+    deps = UsageGuideDeps(resolve_guide_fn=lambda p: guide)
+    rc, stdout = _capture([], deps)
+    assert rc == 0
+    assert "# Title" in stdout
+    assert "Body." in stdout
+
+
+def test_main_topic_filter_text_output(tmp_path: Path) -> None:
+    guide = tmp_path / "g.md"
+    guide.write_text("## Search\nA.\n\n## Budget\nB.\n", encoding="utf-8")
+    deps = UsageGuideDeps(resolve_guide_fn=lambda p: guide)
+    rc, stdout = _capture(["budget"], deps)
+    assert rc == 0
+    assert "topic: budget" in stdout
+    assert "B." in stdout
+    assert "A." not in stdout
+
+
+def test_main_json_format_emits_envelope(tmp_path: Path) -> None:
+    guide = tmp_path / "g.md"
+    guide.write_text("hello", encoding="utf-8")
+    deps = UsageGuideDeps(resolve_guide_fn=lambda p: guide)
+    rc, stdout = _capture(["--json"], deps)
+    assert rc == 0
+    payload = json.loads(stdout)
+    assert payload["content"] == "hello"
+    assert payload["topic"] == ""
+
+
+def test_main_missing_guide_returns_one(tmp_path: Path) -> None:
+    deps = UsageGuideDeps(resolve_guide_fn=lambda p: tmp_path / "missing.md")
+    rc, stdout = _capture([], deps)
+    assert rc == 1
+    assert "error:" in stdout

--- a/tests/contracts/test_cli_mcp_parity_usage_guide.py
+++ b/tests/contracts/test_cli_mcp_parity_usage_guide.py
@@ -1,0 +1,60 @@
+"""Contract: CLI ↔ MCP parity for the ``usage_guide`` operation (Phase 3f of #168)."""
+
+from __future__ import annotations
+
+import inspect
+import typing
+
+import pytest
+
+
+@pytest.mark.contract
+def test_cli_main_calls_run_usage_guide() -> None:
+    from kairix.agents.usage_guide import cli
+
+    src = inspect.getsource(cli.main)
+    assert "run_usage_guide(" in src
+
+
+@pytest.mark.contract
+def test_mcp_tool_usage_guide_calls_run_usage_guide() -> None:
+    from kairix.agents.mcp import server
+
+    src = inspect.getsource(server.tool_usage_guide)
+    assert "run_usage_guide(" in src
+    assert "from kairix.use_cases.usage_guide import" in src
+
+
+@pytest.mark.contract
+def test_mcp_tool_usage_guide_does_not_extract_topics_directly() -> None:
+    """The topic-section extractor moved into the use case in Phase 3f."""
+    from kairix.agents.mcp import server
+
+    src = inspect.getsource(server)
+    assert "_extract_topic_sections" not in src
+    assert "_resolve_guide_path" not in src
+
+
+@pytest.mark.contract
+def test_use_case_returns_usage_guide_output() -> None:
+    from kairix.use_cases.usage_guide import UsageGuideOutput, run_usage_guide
+
+    hints = typing.get_type_hints(run_usage_guide)
+    assert hints.get("return") is UsageGuideOutput
+
+
+@pytest.mark.contract
+def test_envelope_keys_match_usage_guide_output() -> None:
+    from kairix.use_cases import usage_guide as uc
+
+    src = inspect.getsource(uc.usage_guide_output_to_envelope)
+    for key in ("topic", "content", "error"):
+        assert f'"{key}"' in src
+
+
+@pytest.mark.contract
+def test_kairix_usage_guide_command_is_registered() -> None:
+    from kairix.cli import COMMANDS
+
+    assert "usage-guide" in COMMANDS
+    assert COMMANDS["usage-guide"][0] == "kairix.agents.usage_guide.cli"

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -296,13 +296,19 @@ def test_tool_usage_guide_falls_back_to_truncated_text_when_no_match(tmp_path: P
 
 @pytest.mark.unit
 def test_tool_usage_guide_returns_error_dict_when_read_fails(tmp_path: Path) -> None:
-    """A guide path that exists but can't be read (e.g. it's a directory) → error dict."""
-    # A directory at the guide path: exists() returns True, read_text() raises IsADirectoryError.
+    """A guide path that exists but can't be read (e.g. it's a directory) → error dict.
+
+    Phase 3f of #168 changed the error envelope from a generic
+    'lookup failed' message to the structured ``<Class>: <msg>`` form
+    that matches the other use cases.
+    """
     bad = tmp_path / "guide-but-actually-a-dir"
     bad.mkdir()
     result = tool_usage_guide(topic="any", guide_path=bad)
     assert result["content"] == ""
-    assert "lookup failed" in result["error"]
+    # IsADirectoryError on POSIX, PermissionError on Windows — both are class-prefixed
+    assert ":" in result["error"]
+    assert result["error"] != ""
 
 
 # tool_contradict behaviour is now covered by tests/use_cases/test_contradict.py

--- a/tests/use_cases/test_usage_guide.py
+++ b/tests/use_cases/test_usage_guide.py
@@ -1,0 +1,145 @@
+"""Unit tests for ``kairix.use_cases.usage_guide.run_usage_guide`` + helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kairix.use_cases.usage_guide import (
+    UsageGuideDeps,
+    UsageGuideOutput,
+    extract_topic_sections,
+    run_usage_guide,
+    usage_guide_output_to_envelope,
+)
+
+pytestmark = pytest.mark.unit
+
+
+_SAMPLE = """# Kairix Agent Usage Guide
+
+Welcome.
+
+## Search
+How to search the document store.
+
+## Budget
+Token budget controls cost.
+Default budget is 3000 tokens.
+
+## Troubleshooting
+Debug tips for common issues.
+"""
+
+
+# ---------------------------------------------------------------------------
+# extract_topic_sections — pure helper
+# ---------------------------------------------------------------------------
+
+
+def test_extract_returns_section_when_heading_matches() -> None:
+    out = extract_topic_sections(_SAMPLE, "budget")
+    assert "Default budget is 3000 tokens." in out
+    # Other sections excluded
+    assert "search the document store" not in out
+
+
+def test_extract_concatenates_multiple_matching_sections() -> None:
+    text = """## Foo budget
+Body 1
+
+## Bar
+Body 2
+
+### Budget detail
+Body 3
+"""
+    out = extract_topic_sections(text, "budget")
+    assert "Body 1" in out
+    assert "Body 3" in out
+    assert "Body 2" not in out
+
+
+def test_extract_falls_back_to_keyword_lines_when_no_heading_matches() -> None:
+    out = extract_topic_sections(_SAMPLE, "welcome")
+    # 'Welcome.' matches no heading but the line itself contains the keyword.
+    assert "Welcome." in out
+
+
+def test_extract_falls_back_to_first_2000_chars_when_no_match() -> None:
+    text = "x" * 3000
+    out = extract_topic_sections(text, "no-such-thing")
+    assert len(out) == 2000
+
+
+# ---------------------------------------------------------------------------
+# run_usage_guide
+# ---------------------------------------------------------------------------
+
+
+def test_full_guide_returned_when_topic_empty(tmp_path: Path) -> None:
+    guide = tmp_path / "g.md"
+    guide.write_text(_SAMPLE, encoding="utf-8")
+    deps = UsageGuideDeps(resolve_guide_fn=lambda p: guide)
+
+    out = run_usage_guide("", deps=deps)
+    assert out.error == ""
+    assert out.topic == ""
+    assert "Kairix Agent Usage Guide" in out.content
+
+
+def test_topic_filter_returns_section(tmp_path: Path) -> None:
+    guide = tmp_path / "g.md"
+    guide.write_text(_SAMPLE, encoding="utf-8")
+    deps = UsageGuideDeps(resolve_guide_fn=lambda p: guide)
+
+    out = run_usage_guide("budget", deps=deps)
+    assert out.error == ""
+    assert out.topic == "budget"
+    assert "Default budget is 3000 tokens." in out.content
+    assert "search the document store" not in out.content
+
+
+def test_missing_guide_file_returns_operator_actionable_error(tmp_path: Path) -> None:
+    deps = UsageGuideDeps(resolve_guide_fn=lambda p: tmp_path / "no-such.md")
+    out = run_usage_guide(deps=deps)
+    assert "Usage guide not found" in out.error
+    assert "kairix onboard guide" in out.error
+    assert out.content == ""
+
+
+def test_caller_can_pass_explicit_guide_path(tmp_path: Path) -> None:
+    """When the caller passes guide_path, the deps' resolve sees it."""
+    guide = tmp_path / "explicit.md"
+    guide.write_text("explicit content", encoding="utf-8")
+
+    captured: dict = {}
+
+    def _resolver(p: Path | None) -> Path:
+        captured["received"] = p
+        return p or guide
+
+    deps = UsageGuideDeps(resolve_guide_fn=_resolver)
+    run_usage_guide(guide_path=guide, deps=deps)
+    assert captured["received"] == guide
+
+
+def test_resolver_failure_yields_error_envelope() -> None:
+    def _boom(p: Path | None) -> Path:
+        raise RuntimeError("filesystem broken")
+
+    deps = UsageGuideDeps(resolve_guide_fn=_boom)
+    out = run_usage_guide(deps=deps)
+    assert out.error.startswith("RuntimeError:")
+
+
+# ---------------------------------------------------------------------------
+# Envelope projection
+# ---------------------------------------------------------------------------
+
+
+def test_envelope_includes_all_fields() -> None:
+    out = UsageGuideOutput(topic="t", content="c")
+    env = usage_guide_output_to_envelope(out)
+    assert env == {"topic": "t", "content": "c", "error": ""}


### PR DESCRIPTION
## Summary

Pre-Phase-3f, `mcp__usage_guide` was MCP-only — operators couldn't read the agent usage guide from a shell. This PR wraps the topic-section extractor in a use case (`run_usage_guide`) returning `UsageGuideOutput`. **Completes Phase 3 of #168.**

## What changes

- **New** `kairix/use_cases/usage_guide.py` — `run_usage_guide()` returns `UsageGuideOutput(topic, content, error)` + public `extract_topic_sections` helper
- **Refactored** `tool_usage_guide` — thin adapter; drops legacy 'lookup failed' error message; uses structured `<Class>: <msg>` error envelope (matches the other use cases)
- **Removed** `_resolve_guide_path` and `_extract_topic_sections` from `kairix/agents/mcp/server.py` (moved into the use case + defaults)
- **New** `kairix/agents/usage_guide/cli.py` exposing `kairix usage-guide [topic] [--guide-path PATH] [--json]` (also addresses dogfood CONN-2 — agent onboarding via shell)
- **Registered** `usage-guide` command in `kairix/cli.py` dispatch
- **F7 + F9** baselines updated for `_usage_guide_defaults.py`

## Tests

- `tests/use_cases/test_usage_guide.py` — 11 unit tests including topic-section extractor edge cases
- `tests/agents/usage_guide/test_cli.py` — 9 CLI tests
- `tests/contracts/test_cli_mcp_parity_usage_guide.py` — 6 contract tests

## Test plan

- [x] 3110 tests passing locally
- [x] mypy --strict clean
- [x] ruff lint + format clean
- [x] Architecture fitness functions clean
- [ ] CI green
- [ ] **Standard merge commit** (no `--admin`, no `--squash`)

Phase 3f of #168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)