### PR TITLE
feat(use_cases): Phase 4 cross-cutting parity invariants — closes #168

### DIFF
--- a/docs/architecture/cli-mcp-feature-parity.md
+++ b/docs/architecture/cli-mcp-feature-parity.md
@@ -34,22 +34,24 @@ For every feature operation:
 
 ## Audit (current state)
 
-| Feature | Operations | CLI | MCP | Gap |
-|---|---|---|---|---|
-| **search** | search | `kairix search` | `mcp__search` | UX parity to verify |
-| **contradict** | check | `kairix contradict check` | `mcp__contradict` | UX parity to verify |
-| **timeline** | timeline | `kairix timeline` (uses temporal-chunks index) | `mcp__timeline` (uses BM25+vec hybrid) | Same op, different code paths — closes #163 on convergence |
-| **entity** | suggest (NER from text) | `kairix entity suggest` | — | MCP missing |
-| **entity** | validate (against Wikidata) | `kairix entity validate` | — | MCP missing |
-| **entity** | get (lookup by name) | — | `mcp__entity` | CLI missing |
-| **entity** | seed (discover from index) | `kairix entity seed` | — | Operator-only? Decide whether agent-facing |
-| **prep** | prep | — | `mcp__prep` | CLI missing |
-| **research** | research | — | `mcp__research` | CLI missing |
-| **brief** | brief | `kairix brief` | — | MCP missing |
-| **usage_guide** | get | — | `mcp__usage_guide` | CLI missing (also dogfood CONN-2 deployment-step gap) |
+| Feature | Operations | CLI | MCP | Gap | Status |
+|---|---|---|---|---|---|
+| **timeline** | timeline | `kairix timeline` | `mcp__timeline` | code-path divergence (closes #163) | ✅ Phase 1 (#179) |
+| **search** | search | `kairix search` | `mcp__search` | UX parity (limit, diagnostics, entity card) | ✅ Phase 2 (#182) |
+| **contradict** | check | `kairix contradict check` | `mcp__contradict` | UX parity (top_claims, category, claim) | ✅ Phase 2 (#182) |
+| **brief** | brief | `kairix brief` | — → `mcp__brief` | MCP missing | ✅ Phase 3a (#183) |
+| **entity** | suggest (NER from text) | `kairix entity suggest` | — → `mcp__entity_suggest` | MCP missing | ✅ Phase 3b (#184) |
+| **entity** | validate (against Wikidata) | `kairix entity validate` | — → `mcp__entity_validate` | MCP missing | ✅ Phase 3b (#184) |
+| **prep** | prep | — → `kairix prep` | `mcp__prep` | CLI missing | ✅ Phase 3c (#185) |
+| **research** | research | — → `kairix research` | `mcp__research` | CLI missing | ✅ Phase 3d (#186) |
+| **entity** | get (lookup by name) | — → `kairix entity get` | `mcp__entity` | CLI missing | ✅ Phase 3e (#187) |
+| **usage_guide** | get | — → `kairix usage-guide` | `mcp__usage_guide` | CLI missing (also dogfood CONN-2) | ✅ Phase 3f (#188) |
+| **entity** | seed (discover from index) | `kairix entity seed` | — | Operator-only — no agent-facing surface | Out of scope |
 
-**Summary:** 8 surface-parity gaps + 1 code-path divergence + UX-parity
-audit work for the two already-converged features.
+**Status:** Phases 1–4 complete. MCP exposes 11 tools (was 7). Every
+agent-facing operation has both a CLI and an MCP surface, both calling
+the same use case in `kairix/use_cases/`. Cross-cutting invariants
+pinned in `tests/contracts/test_cli_mcp_parity_invariants.py`.
 
 ## Phasing
 

--- a/tests/contracts/test_cli_mcp_parity_invariants.py
+++ b/tests/contracts/test_cli_mcp_parity_invariants.py
@@ -1,0 +1,118 @@
+"""Phase 4 of #168 — cross-cutting parity invariants.
+
+Every kairix feature exposed via both CLI and MCP must satisfy the
+shape rules the per-feature parity tests already check individually.
+This sweep catches regressions if a future use case is added without
+the corresponding contract test, or if a use case stops following the
+established pattern (returning a frozen dataclass, exposing a
+``run_<op>`` callable, having an envelope projector helper).
+
+The list below is the canonical set of use-case modules. Adding a new
+use case should mean adding it here AND adding a per-feature parity
+test in this directory.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+from dataclasses import is_dataclass
+
+import pytest
+
+# Every use-case module + its (run_callable, output_class, envelope_helper) triple.
+# When a Phase-3+ surface is added, append it here so the invariant sweep covers it.
+_USE_CASES: list[tuple[str, str, str, str]] = [
+    ("kairix.use_cases.timeline", "run_timeline", "TimelineResult", None),  # type: ignore[list-item]  # legacy: timeline result projection inlined in MCP adapter
+    ("kairix.use_cases.search", "run_search", "SearchOutput", "search_output_to_envelope"),
+    ("kairix.use_cases.contradict", "run_contradict", "ContradictOutput", "contradict_output_to_envelope"),
+    ("kairix.use_cases.brief", "run_brief", "BriefOutput", "brief_output_to_envelope"),
+    ("kairix.use_cases.entity", "run_entity_suggest", "EntitySuggestOutput", "entity_suggest_output_to_envelope"),
+    ("kairix.use_cases.entity", "run_entity_validate", "EntityValidateOutput", "entity_validate_output_to_envelope"),
+    ("kairix.use_cases.prep", "run_prep", "PrepOutput", "prep_output_to_envelope"),
+    ("kairix.use_cases.research", "run_research_use_case", "ResearchOutput", "research_output_to_envelope"),
+    ("kairix.use_cases.entity_get", "run_entity_get", "EntityGetOutput", "entity_get_output_to_envelope"),
+    ("kairix.use_cases.usage_guide", "run_usage_guide", "UsageGuideOutput", "usage_guide_output_to_envelope"),
+]
+
+
+@pytest.mark.contract
+@pytest.mark.parametrize("module_path,run_name,_output_name,_envelope_name", _USE_CASES)
+def test_each_use_case_exposes_a_run_callable(
+    module_path: str, run_name: str, _output_name: str, _envelope_name: str | None
+) -> None:
+    mod = importlib.import_module(module_path)
+    fn = getattr(mod, run_name, None)
+    assert callable(fn), f"{module_path}.{run_name} missing"
+    # The use case must take a deps kwarg so adapters can inject test deps.
+    sig = inspect.signature(fn)
+    assert "deps" in sig.parameters, f"{module_path}.{run_name} must accept deps for testability"
+
+
+@pytest.mark.contract
+@pytest.mark.parametrize("module_path,_run_name,output_name,_envelope_name", _USE_CASES)
+def test_each_use_case_returns_frozen_dataclass(
+    module_path: str, _run_name: str, output_name: str, _envelope_name: str | None
+) -> None:
+    mod = importlib.import_module(module_path)
+    cls = getattr(mod, output_name, None)
+    assert cls is not None, f"{module_path}.{output_name} missing"
+    assert is_dataclass(cls), f"{module_path}.{output_name} must be a dataclass"
+    # frozen=True: dataclass __setattr__ is FrozenInstanceError; a sentinel attribute confirms.
+    params = getattr(cls, "__dataclass_params__", None)
+    assert params is not None and params.frozen, f"{module_path}.{output_name} must be frozen"
+
+
+@pytest.mark.contract
+@pytest.mark.parametrize("module_path,_run_name,_output_name,envelope_name", _USE_CASES)
+def test_each_use_case_has_envelope_projector(
+    module_path: str, _run_name: str, _output_name: str, envelope_name: str | None
+) -> None:
+    """Phase-2+ use cases share their envelope shape via a public projector
+    function; the timeline use case (Phase 1) inlined the projection in its
+    MCP adapter and is grandfathered.
+    """
+    if envelope_name is None:
+        pytest.skip("Timeline use case (Phase 1) inlined the projection — grandfathered")
+    mod = importlib.import_module(module_path)
+    fn = getattr(mod, envelope_name, None)
+    assert callable(fn), f"{module_path}.{envelope_name} missing"
+
+
+@pytest.mark.contract
+def test_use_case_dataclass_has_error_field() -> None:
+    """Every use-case Output dataclass must include an ``error`` field —
+    the never-raise contract requires callers to read errors from the result.
+    """
+    for module_path, _, output_name, _ in _USE_CASES:
+        mod = importlib.import_module(module_path)
+        cls = getattr(mod, output_name)
+        fields = {f.name for f in cls.__dataclass_fields__.values()}
+        assert "error" in fields, f"{module_path}.{output_name} missing 'error' field"
+
+
+@pytest.mark.contract
+def test_every_use_case_has_a_per_feature_parity_test() -> None:
+    """Phase 4 sweep: every use case is paired with a contract test in
+    this directory. Adds a guard against silently introducing new use
+    cases without the matching parity test.
+    """
+    from pathlib import Path
+
+    contracts_dir = Path(__file__).parent
+    parity_tests = {p.stem for p in contracts_dir.glob("test_cli_mcp_parity_*.py")}
+
+    expected_tests = {
+        "test_cli_mcp_parity_timeline",
+        "test_cli_mcp_parity_search",
+        "test_cli_mcp_parity_contradict",
+        "test_cli_mcp_parity_brief",
+        "test_cli_mcp_parity_entity",
+        "test_cli_mcp_parity_prep",
+        "test_cli_mcp_parity_research",
+        "test_cli_mcp_parity_entity_get",
+        "test_cli_mcp_parity_usage_guide",
+        "test_cli_mcp_parity_invariants",  # this file
+    }
+    missing = expected_tests - parity_tests
+    assert not missing, f"missing per-feature parity tests: {missing}"


### PR DESCRIPTION
## Summary

Final phase of the CLI/MCP feature parity initiative (#168). Adds a parameterised cross-cutting invariant sweep that pins every Phase-1+ use case to the same structural rules, and updates the design doc to mark all phases complete.

## What changes

- **New** `tests/contracts/test_cli_mcp_parity_invariants.py` — parameterised sweep across all 10 use-case definitions covering:
  - Each use case exposes a `run_<op>` callable taking a `deps` kwarg
  - Each output dataclass is frozen
  - Each output dataclass has an `error` field (never-raise contract)
  - Each Phase-2+ use case has a public envelope-projector helper (timeline grandfathered)
  - Every use case has a matching per-feature parity test
- **Updated** `docs/architecture/cli-mcp-feature-parity.md` — marks all phases complete with PR references

## Test plan

- [x] 3141 tests passing locally
- [x] mypy --strict clean
- [x] ruff lint + format clean
- [x] Architecture fitness functions clean
- [ ] CI green
- [ ] Squash-merge (until repo settings allow merge commits per offline review)

Closes #168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)