### PR TITLE
fix(ci): pin docker-publish + publish-pypi actions to specific SHAs (closes #174)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,12 +28,12 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -53,7 +53,7 @@ jobs:
           fi
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           push: true

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -19,11 +19,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0  # setuptools-scm needs full history
 
-      - uses: hynek/build-and-inspect-python-package@v2
+      - uses: hynek/build-and-inspect-python-package@e6f4945c542cb46284a23bdb29121f4593636894 # v2
 
   publish:
     name: Publish to PyPI
@@ -33,19 +33,19 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: Packages
           path: dist/
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
 
   verify:
     name: Verify install
     needs: publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 


### PR DESCRIPTION
## Summary

5 SonarCloud hotspots (`githubactions:S7637`) flagged the `docker-publish.yml` and `publish-pypi.yml` workflows for using floating tag references. Supply-chain hardening: pin every external action to a specific SHA.

## What changes

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v4` | `@34e114876b… # v4.3.1` |
| `docker/setup-buildx-action` | `@v3` | `@b5ca514318… # v3.10.0` |
| `docker/login-action` | `@v3` | `@c94ce9fb46… # v3.7.0` |
| `docker/build-push-action` | `@v5` | `@ca052bb54a… # v5.4.0` |
| `hynek/build-and-inspect-python-package` | `@v2` | `@e6f4945c54… # v2` |
| `actions/download-artifact` | `@v4` | `@d3f86a106a… # v4.3.0` |
| `pypa/gh-action-pypi-publish` | `@release/v1` | `@6733eb7d74… # v1.14.0` |
| `actions/setup-python` | `@v5` | `@a26af69be9… # v5` |

SHAs taken from existing pinned references in `ci.yml` and `sonar-triage.yml` where available; otherwise the latest matching minor version.

## Test plan

- [x] Workflow files parse (verified via diff)
- [ ] CI green
- [ ] All 5 `githubactions:S7637` hotspots clear on the next Sonar scan
- [ ] Standard merge

Closes #174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)