### PR TITLE
fix(use_cases): class-prefix soft-error messages — closes #165

### DIFF
--- a/kairix/use_cases/brief.py
+++ b/kairix/use_cases/brief.py
@@ -73,7 +73,7 @@ def run_brief(
     if normalised not in _VALID_AGENTS:
         return BriefOutput(
             agent=agent,
-            error=f"invalid agent: {agent!r}. Must be one of: {sorted(_VALID_AGENTS)}",
+            error=f"InvalidAgent: {agent!r}. Must be one of: {sorted(_VALID_AGENTS)}",
         )
 
     d = deps or BriefDeps()

--- a/kairix/use_cases/entity_get.py
+++ b/kairix/use_cases/entity_get.py
@@ -33,9 +33,10 @@ class EntityGetOutput:
             populated.
         vault_path: On-disk path to the entity's markdown file in the
             vault. Empty when the entity has no associated file.
-        error: Empty on success; ``"Entity not found: <name>"`` when
+        error: Empty on success; ``"EntityNotFound: <name>"`` when
             the lookup returned no rows; structured ``"<Class>: <msg>"``
-            on top-level failure.
+            on top-level failure (#165: every error string is
+            class-prefixed so agents can switch on the prefix).
     """
 
     id: str = ""
@@ -76,7 +77,7 @@ def run_entity_get(
         return EntityGetOutput(name=name, error=f"{type(exc).__name__}: {exc}")
 
     if card is None:
-        return EntityGetOutput(name=name, error=f"Entity not found: {name}")
+        return EntityGetOutput(name=name, error=f"EntityNotFound: {name}")
 
     return EntityGetOutput(
         id=str(card.get("id", "") or ""),

--- a/kairix/use_cases/usage_guide.py
+++ b/kairix/use_cases/usage_guide.py
@@ -111,7 +111,7 @@ def run_usage_guide(
         if not resolved.exists():
             return UsageGuideOutput(
                 topic=topic,
-                error="Usage guide not found. Run: kairix onboard guide --document-root <path>",
+                error="UsageGuideNotFound: run 'kairix onboard guide --document-root <path>' to install it",
             )
 
         full_text = resolved.read_text(encoding="utf-8")

--- a/tests/agents/usage_guide/test_cli.py
+++ b/tests/agents/usage_guide/test_cli.py
@@ -53,7 +53,7 @@ def test_format_text_with_topic_adds_heading() -> None:
 
 
 def test_format_text_short_circuits_on_error() -> None:
-    out = UsageGuideOutput(error="Usage guide not found.")
+    out = UsageGuideOutput(error="UsageGuideNotFound: missing")
     assert format_text(out).startswith("error:")
 
 

--- a/tests/bdd/features/mcp_agent_entity.feature
+++ b/tests/bdd/features/mcp_agent_entity.feature
@@ -14,7 +14,7 @@ Feature: MCP agent entity lookup
   Scenario: Unknown entity returns structured not-found
     Given Neo4j has no entity named "Nonexistent Corp"
     When the agent calls tool_entity with name "Nonexistent Corp"
-    Then the entity response error contains "not found"
+    Then the entity response error contains "EntityNotFound"
 
   Scenario: Entity lookup never raises
     When the agent calls tool_entity with name ""

--- a/tests/briefing/test_cli.py
+++ b/tests/briefing/test_cli.py
@@ -70,7 +70,7 @@ def test_format_output_print_full_returns_complete_content() -> None:
 
 
 def test_format_output_empty_content_returns_empty_string() -> None:
-    out = BriefOutput(agent="x", content="", error="invalid agent")
+    out = BriefOutput(agent="x", content="", error="InvalidAgent: 'x'")
     assert format_output(out, print_full=False) == ""
 
 
@@ -102,7 +102,7 @@ def test_main_invalid_agent_exits_nonzero() -> None:
     exit_code, _stdout, stderr = _run(["rogue"], _build_deps())
     assert exit_code == 1
     assert "Error generating briefing" in stderr
-    assert "invalid agent" in stderr
+    assert "InvalidAgent" in stderr
 
 
 def test_main_happy_path_prints_path_and_preview() -> None:

--- a/tests/knowledge/entities/test_cli.py
+++ b/tests/knowledge/entities/test_cli.py
@@ -336,7 +336,7 @@ def test_format_get_output_renders_unknown_for_empty_fields() -> None:
 
 
 def test_format_get_output_short_circuits_on_error() -> None:
-    out = EntityGetOutput(name="X", error="Entity not found: X")
+    out = EntityGetOutput(name="X", error="EntityNotFound: X")
     assert format_get_output(out).startswith("error:")
 
 
@@ -362,7 +362,7 @@ def test_cmd_get_returns_one_on_not_found() -> None:
     deps = EntityGetDeps(fetch_fn=lambda name: None)
     rc, stdout, _ = _capture(lambda: cmd_get(args, deps=deps))
     assert rc == 1
-    assert "Entity not found" in stdout
+    assert "EntityNotFound" in stdout
 
 
 def test_cmd_get_json_format_emits_envelope() -> None:

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -74,7 +74,7 @@ def test_tool_entity_neo4j_not_found_returns_error() -> None:
     result = tool_entity(name="Unknown Entity", neo4j_client=fake)
 
     assert result["id"] == ""
-    assert "not found" in result["error"].lower()
+    assert result["error"].startswith("EntityNotFound:")
 
 
 @pytest.mark.unit
@@ -213,7 +213,7 @@ def test_tool_usage_guide_returns_error_when_explicit_guide_path_missing(tmp_pat
     missing = tmp_path / "no-such-guide.md"
     result = tool_usage_guide(topic="anything", guide_path=missing)
     assert result["content"] == ""
-    assert "Usage guide not found" in result["error"]
+    assert result["error"].startswith("UsageGuideNotFound:")
     assert result["topic"] == "anything"
 
 

--- a/tests/mcp/test_tool_brief.py
+++ b/tests/mcp/test_tool_brief.py
@@ -37,7 +37,7 @@ def test_tool_brief_happy_path_returns_envelope_dict() -> None:
 def test_tool_brief_invalid_agent_returns_error_envelope() -> None:
     deps = BriefDeps()
     result = tool_brief(agent="rogue", deps=deps)
-    assert result["error"].startswith("invalid agent")
+    assert result["error"].startswith("InvalidAgent")
     assert result["content"] == ""
 
 

--- a/tests/use_cases/test_brief.py
+++ b/tests/use_cases/test_brief.py
@@ -81,7 +81,7 @@ def test_agent_name_lowercased_and_stripped() -> None:
 def test_unknown_agent_returns_error_envelope() -> None:
     deps, captured = _build_deps()
     out = run_brief("rogue", deps=deps)
-    assert out.error.startswith("invalid agent")
+    assert out.error.startswith("InvalidAgent")
     assert captured["generate"] == []  # never reached the generator
 
 
@@ -89,7 +89,7 @@ def test_unknown_agent_returns_error_envelope() -> None:
 def test_empty_agent_string_is_invalid() -> None:
     deps, _ = _build_deps()
     out = run_brief("", deps=deps)
-    assert "invalid agent" in out.error
+    assert "InvalidAgent" in out.error
 
 
 @pytest.mark.parametrize("agent", ["builder", "shape", "growth", "consultant"])
@@ -139,7 +139,7 @@ def test_envelope_carries_all_fields() -> None:
 
 @pytest.mark.unit
 def test_envelope_carries_error_field() -> None:
-    out = BriefOutput(agent="x", error="invalid agent: 'x'. Must be ...")
+    out = BriefOutput(agent="x", error="InvalidAgent: 'x'. Must be ...")
     env = brief_output_to_envelope(out)
-    assert env["error"].startswith("invalid agent")
+    assert env["error"].startswith("InvalidAgent")
     assert env["content"] == ""

--- a/tests/use_cases/test_entity_get.py
+++ b/tests/use_cases/test_entity_get.py
@@ -44,7 +44,7 @@ def test_card_present_projects_into_output() -> None:
 
 def test_card_none_returns_not_found_error() -> None:
     out = run_entity_get("Bogus", deps=_build_deps(card=None))
-    assert out.error == "Entity not found: Bogus"
+    assert out.error == "EntityNotFound: Bogus"
     assert out.id == ""
     # Name preserved from the caller for the operator's error message.
     assert out.name == "Bogus"

--- a/tests/use_cases/test_usage_guide.py
+++ b/tests/use_cases/test_usage_guide.py
@@ -104,7 +104,7 @@ def test_topic_filter_returns_section(tmp_path: Path) -> None:
 def test_missing_guide_file_returns_operator_actionable_error(tmp_path: Path) -> None:
     deps = UsageGuideDeps(resolve_guide_fn=lambda p: tmp_path / "no-such.md")
     out = run_usage_guide(deps=deps)
-    assert "Usage guide not found" in out.error
+    assert out.error.startswith("UsageGuideNotFound:")
     assert "kairix onboard guide" in out.error
     assert out.content == ""
 


### PR DESCRIPTION
## Summary

Per Sprint-19 spec, MCP error envelopes should carry a class-prefixed error string so agents can switch on the exception class without brittle string matching.

## What changes

Hard errors (use case unhandled exceptions) already follow the spec shape `{type(exc).__name__}: {exc}`. This change brings the soft-error paths in line:

| Use case | Before | After |
|---|---|---|
| `run_entity_get` | `Entity not found: <name>` | `EntityNotFound: <name>` |
| `run_brief` | `invalid agent: <name>...` | `InvalidAgent: <name>...` |
| `run_usage_guide` | `Usage guide not found...` | `UsageGuideNotFound: ...` |

Tests updated to assert on the new prefixes (`.startswith` pattern so agents can do the same).

## Test plan

- [x] 3141 tests passing locally
- [x] mypy --strict, ruff, arch fitness all clean
- [ ] CI green

Closes #165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)