### PR TITLE
test(embed): backfill embed.py coverage + tighten partial-batch contract (#196)

### DIFF
--- a/kairix/core/embed/embed.py
+++ b/kairix/core/embed/embed.py
@@ -90,7 +90,7 @@ def chunk_text(
 # ── Azure API ─────────────────────────────────────────────────────────────────
 
 
-def _get_azure_config() -> tuple[str, str, str]:  # pragma: no cover
+def _get_azure_config() -> tuple[str, str, str]:  # pragma: no cover  # prod lazy default; deps injection
     """
     Read embed API config via ``get_credentials("embed")``. Supports Azure,
     OpenRouter, or any OpenAI-compatible endpoint.
@@ -144,7 +144,7 @@ def preflight_check(
     ``.data[0].embedding`` list. Production callers leave it as ``None`` so
     the real client is built lazily via ``make_openai_client``.
     """
-    if client is None:  # pragma: no cover
+    if client is None:  # pragma: no cover  # prod lazy default; tests inject client=fake
         from kairix.credentials import make_openai_client
 
         client = make_openai_client(api_key, endpoint, max_retries=2, timeout=30.0)
@@ -165,7 +165,7 @@ _embed_client = None
 _embed_client_key: tuple[str, str] = ("", "")
 
 
-def _get_embed_client(api_key: str, endpoint: str) -> Any:  # pragma: no cover
+def _get_embed_client(api_key: str, endpoint: str) -> Any:  # pragma: no cover  # prod-only module cache
     """Return a cached OpenAI client. Creates a new one if credentials change.
 
     Production-only — every test that exercises ``embed_batch`` injects a
@@ -214,7 +214,7 @@ def embed_batch(
     if not texts:
         return []
 
-    if client is None:  # pragma: no cover
+    if client is None:  # pragma: no cover  # prod lazy default; tests inject client=fake
         client = _get_embed_client(api_key, endpoint)
 
     try:
@@ -286,7 +286,7 @@ def batched(items: list[Any], size: int) -> Generator[list[Any], None, None]:
 # ── usearch index update ─────────────────────────────────────────────────────
 
 
-def _open_usearch_index() -> Any:  # pragma: no cover
+def _open_usearch_index() -> Any:  # pragma: no cover  # prod lazy default; deps injection
     """Open (or create) the usearch ANN index for the embed run.
 
     Production-only — every test that exercises ``run_embed`` injects an
@@ -483,7 +483,7 @@ def run_embed(
 
     Returns dict with: embedded, skipped, failed, duration_s, estimated_cost_usd
     """
-    if deps is None:  # pragma: no cover
+    if deps is None:  # pragma: no cover  # prod lazy default; tests pass deps=
         deps = EmbedDependencies()
 
     assert deps.get_document_root is not None

--- a/tests/embed/test_embed_contracts.py
+++ b/tests/embed/test_embed_contracts.py
@@ -184,3 +184,47 @@ def test_run_embed_does_not_overcount_when_embed_batch_returns_fewer_vectors_tha
         f"embedded={result['embedded']} but content_vectors has {staged_count} rows — "
         "partial-response chunks were miscounted"
     )
+
+
+# ---------------------------------------------------------------------------
+# Contract: unaccounted chunks (partial response) bubble out as ``failed`` —
+# they don't vanish into ``skipped``. Sabotage check: if the bookkeeping
+# treated the dropped chunk as skipped, this test would fail because the
+# documented contract is that anything that didn't get a vector but was in
+# the batch is a failure to be retried, not a deliberate skip.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_run_embed_partial_response_marks_unaccounted_chunks_as_failed() -> None:
+    """Partial-response chunks must surface in ``failed`` and ``failed_paths`` —
+    not get silently swallowed into ``skipped``. The caller relies on this
+    to retry / log / alert on partial-response chunks.
+    """
+    from kairix.core.embed.embed import run_embed
+
+    db = sqlite3.connect(":memory:")
+    _seed_documents(
+        db,
+        [
+            ("h1", "first body " * 5, "docs/a.md"),
+            ("h2", "second body " * 5, "docs/b.md"),
+            ("h3", "third body " * 5, "docs/c.md"),
+        ],
+    )
+
+    def _partial_embed_batch(texts, *_a, **_kw):
+        # Drop the last text on every call — backend returns N-1 vectors.
+        return [[0.1] * 1536 for _ in texts[:-1]]
+
+    deps = _build_run_embed_deps(embed_batch=_partial_embed_batch)
+    result = run_embed(db, batch_size=10, deps=deps)
+
+    # Exactly one chunk lacks a vector — it must surface as failed, not skipped.
+    assert result["failed"] == 1, f"expected failed=1 (the unaccounted chunk); got failed={result['failed']}"
+    # And the path of the unaccounted chunk must appear in failed_paths so
+    # callers can retry it. The dropped text is the last in the texts list,
+    # which corresponds to docs/c.md (last seeded).
+    assert "docs/c.md" in result["failed_paths"], (
+        f"unaccounted chunk's path missing from failed_paths={result['failed_paths']}"
+    )

--- a/tests/embed/test_embed_coverage.py
+++ b/tests/embed/test_embed_coverage.py
@@ -121,6 +121,23 @@ def test_chunk_text_empty_string() -> None:
     assert isinstance(result, list)
 
 
+@pytest.mark.unit
+def test_chunk_text_skips_whitespace_only_chunks() -> None:
+    """When a chunk window contains only whitespace, the chunker drops it
+    and continues — exercises the falsy-chunk branch in chunk_text.
+    """
+    # Text whose body has a long whitespace stretch in the middle so a
+    # mid-text chunk window strips down to "". Force chunk_size large enough
+    # that the iteration produces multiple windows.
+    text = "alpha " + " " * 800 + " beta"
+    chunks = chunk_text(text, chunk_size=300, overlap=0)
+    # Sanity: every kept chunk has non-empty stripped text.
+    assert all(c["text"].strip() for c in chunks)
+    # Seq numbers are still sequential (skipped chunks don't increment seq).
+    for i, c in enumerate(chunks):
+        assert c["seq"] == i
+
+
 # ---------------------------------------------------------------------------
 # preflight_check — driven through the ``client=`` injection seam.
 # ---------------------------------------------------------------------------
@@ -486,6 +503,59 @@ def test_run_embed_logs_chunk_date_populated_count_when_documents_have_dates(cap
     # Sabotage check: if extract_chunk_date were broken or the chunk_date assertion path
     # in run_embed were the warning branch, the populated message would not appear at all.
     assert "/" in populated_lines[0]  # "for N/M chunks" embeds a fraction
+
+
+@pytest.mark.unit
+def test_run_embed_marks_batch_failed_when_db_write_raises_sqlite_error(caplog) -> None:
+    """When the sqlite write inside ``_embed_and_store_batch`` raises
+    ``sqlite3.Error`` (e.g. closed connection, locked DB, schema drift),
+    every chunk in that batch surfaces as failed and the run continues.
+
+    Drives the ``except sqlite3.Error`` branch in _embed_and_store_batch
+    via a deps-injected ``embed_batch`` and a wrapper sqlite connection
+    whose commit raises. No monkeypatch — pure injection at the boundary.
+    """
+    import logging
+
+    db = sqlite3.connect(":memory:")
+    _seed_documents(db, [("h1", "doc body content " * 5, "docs/a.md")])
+
+    # Wrapper that raises sqlite3.Error on commit. ``with db:`` calls
+    # ``commit`` on success, so this fires the run_embed sqlite-error path.
+    class _CommitFailsConnection:
+        def __init__(self, inner: sqlite3.Connection) -> None:
+            self._inner = inner
+
+        def __enter__(self) -> Any:
+            return self._inner.__enter__()
+
+        def __exit__(self, exc_type, exc, tb) -> Any:
+            # Force commit to fail so _embed_and_store_batch hits its
+            # sqlite3.Error branch (covers the DB-write failure path).
+            raise sqlite3.OperationalError("simulated DB write failure")
+
+        def execute(self, *args: Any, **kwargs: Any) -> Any:
+            return self._inner.execute(*args, **kwargs)
+
+        def commit(self) -> None:
+            self._inner.commit()
+
+        def cursor(self) -> Any:
+            return self._inner.cursor()
+
+    deps = _build_run_embed_deps()
+
+    from kairix.core.embed.embed import run_embed
+
+    wrapped = _CommitFailsConnection(db)
+    with caplog.at_level(logging.ERROR):
+        result = run_embed(wrapped, batch_size=10, deps=deps)  # type: ignore[arg-type]  # wrapper proxies sqlite3.Connection surface that run_embed touches
+
+    # Every chunk in the failing batch should be marked failed.
+    assert result["embedded"] == 0
+    assert result["failed"] >= 1
+    error_lines = [r.message for r in caplog.records if "DB write for batch" in r.message]
+    assert error_lines, f"expected a 'DB write for batch' error log; got {[r.message for r in caplog.records]}"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Phase 2c coverage backfill for `kairix/core/embed/embed.py` (per #196 / #193).
Strips bare `# pragma: no cover` markers and either covers the line or re-adds a same-line F3 rationale.

- Cover the partial-response failure path: new contract test asserts unaccounted chunks (backend returns N-1 vectors) bubble out as `failed` (with their path) — not silently swallowed into `skipped`.
- Cover the DB-write failure path: new test drives `_embed_and_store_batch`'s `sqlite3.Error` branch by injecting a sqlite connection wrapper whose commit raises. No monkeypatch, no `@patch` — pure boundary injection.
- Cover the chunk-text whitespace-skip branch (line 81 falsy chunk drop).
- Re-add `# pragma: no cover` on 5 production-only lazy defaults (`_get_azure_config`, `_get_embed_client`, `_open_usearch_index`, the two `client is None` lazy branches, the `deps is None` branch in `run_embed`) with same-line F3 rationales — these literally only run in production because every test injects via `EmbedDependencies` / `client=` kwargs.

## Coverage delta

`embed.py`: 100% line + branch coverage on the testable surface (140 statements, 40 branches, all hit). With the rationale-pragmas in place, all 5 production-only lazy defaults are properly justified per F3.

## Defects discovered

None — the partial-response and checkpoint-error paths were already correctly handled. The new contract tests pin them down so future changes can't silently regress.

## Performance observations

- Partial-response slicing (`matched = batch[:len(vectors)]`, `unaccounted = list(batch[len(vectors):])`) runs every batch even on the success path. Fast (just slice + empty-list construction) — no perf concern.
- `vec_index.save()` on every 10th batch is a hot disk-flush during ingest. Already tuned (see `save_interval = 10`); not an alleged-cold-path-hot-in-practice case.
- No "rare" branches discovered to be hot in practice. No follow-up perf issue needed.

## Test plan

- [x] Sabotage-prove: replaced `return len(matched), unaccounted` with `return len(matched), []`; new partial-response test failed (caught the bookkeeping regression).
- [x] `safe-commit.sh` green: ruff lint + format, mypy strict, 3160 unit/bdd/contract tests, arch F1-F6 + F8 + F10-F13, secrets, confidential.
- [x] `pre-commit run --all-files` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)