### PR TITLE
test(embed): drive recall_check failure paths through DI; remove 7 pragmas (#194)

### DIFF
--- a/kairix/core/embed/recall_check.py
+++ b/kairix/core/embed/recall_check.py
@@ -19,9 +19,13 @@ no indexed documents (no corpus to sample from).
 To force a re-sample after major corpus changes, delete the canary
 cache file or pass ``rebuild_canaries=True`` to ``check()``.
 
-The ``RecallChecker`` class is the only seam: tests inject a ``FakeEmbedProvider``
-and a ``FakeVectorSearcher`` via the constructor; production callers build
-``RecallChecker()`` which constructs production defaults lazily on first use.
+The ``RecallChecker`` class is the only seam: tests inject a
+``FakeEmbedProvider`` and a ``FakeVectorSearcher`` via the constructor;
+production callers build ``RecallChecker()`` which constructs production
+defaults lazily on first use. For unit-coverage of the credentials /
+provider-construction failure paths, tests inject a ``creds_resolver``
+and ``provider_factory`` via the constructor (``FakeCredentials`` from
+``tests/fakes.py`` is the canonical creds stand-in).
 """
 
 from __future__ import annotations
@@ -39,6 +43,7 @@ import numpy as np
 from kairix.core.embed.schema import EMBED_VECTOR_DIMS as EMBED_DIMS
 
 if TYPE_CHECKING:
+    from kairix.credentials import Credentials, GraphCredentials
     from kairix.platform.llm.embed_provider import EmbedProvider
 
 logger = logging.getLogger(__name__)
@@ -187,45 +192,84 @@ def save_canary_cache(
     logger.info("recall-canaries: cached %d queries to %s", len(queries), cache_path)
 
 
+def _default_creds_resolver() -> Credentials | GraphCredentials | None:
+    """Production credentials resolver — looks up the embed creds.
+
+    Returns whatever ``get_credentials("embed")`` returns; on failure
+    (raising) returns ``None`` so the recall check degrades to a skip
+    instead of crashing.
+    """
+    try:
+        from kairix.credentials import get_credentials
+
+        return get_credentials("embed")
+    except Exception:
+        return None
+
+
+def _default_provider_factory(creds: Credentials) -> EmbedProvider:
+    """Production EmbedProvider factory — wraps ``get_embed_provider``.
+
+    Accepts the resolved credentials (unused by ``get_embed_provider`` but
+    exposed for symmetry with test injection).
+    """
+    del creds  # production helper resolves its own credentials internally
+    from kairix.platform.llm.embed_provider import get_embed_provider
+
+    return get_embed_provider()
+
+
+def _resolve_provider_and_model(
+    creds_resolver: Callable[[], Credentials | GraphCredentials | None],
+    provider_factory: Callable[[Credentials], EmbedProvider],
+    model: str | None,
+) -> tuple[EmbedProvider | None, str | None]:
+    """Resolve an EmbedProvider + model from injected dependencies.
+
+    Returns ``(None, None)`` when credentials are missing / unusable, the
+    resolver itself raises, or the factory raises — callers treat this as
+    a skip-the-query signal. The recall gate is an alarm system; it must
+    degrade silently rather than take down the embed pipeline.
+    """
+    from kairix.credentials import Credentials
+
+    try:
+        creds = creds_resolver()
+    except Exception as e:
+        logger.warning("Recall embed: creds_resolver raised %s — skipping", e)
+        return None, None
+
+    if not isinstance(creds, Credentials) or not creds.api_key or not creds.endpoint:
+        logger.warning("Embed credentials not set — skipping recall check")
+        return None, None
+
+    chosen_model = model if model is not None else (creds.model or "text-embedding-3-large")
+
+    try:
+        provider = provider_factory(creds)
+    except Exception as e:
+        logger.warning("Recall embed failed: provider_factory raised %s", e)
+        return None, None
+    return provider, chosen_model
+
+
 def _embed_query(
     query: str,
     *,
-    provider: EmbedProvider | None = None,
-    model: str | None = None,
+    provider: EmbedProvider,
+    model: str = "text-embedding-3-large",
 ) -> np.ndarray | None:
-    """Embed a single query string via the configured EmbedProvider.
+    """Embed a single query string via the supplied EmbedProvider.
 
-    Returns a unit-normalised float32 numpy array, or None when credentials
-    are missing or the provider call fails. The provider's openai SDK client
-    handles retry, rate-limiting, and backoff internally.
+    Returns a unit-normalised float32 numpy array, or ``None`` when the
+    provider call fails or returns no vectors. The provider's openai SDK
+    client handles retry, rate-limiting, and backoff internally.
+
+    This helper is intentionally pure — credentials resolution and provider
+    construction live in ``_resolve_provider_and_model`` (called by
+    ``RecallChecker._embed``) so the embed-batch call path can be tested
+    with a ``FakeEmbedProvider`` without exercising the credentials seam.
     """
-    if provider is None:
-        try:
-            from kairix.credentials import Credentials, get_credentials
-            from kairix.platform.llm.embed_provider import get_embed_provider
-
-            creds = get_credentials("embed")
-        except Exception:
-            logger.warning("Embed credentials not set — skipping recall check")
-            return None
-
-        # Reachable only with valid Azure embed credentials; deferred to
-        # FakeCredentials in credentials-DI.
-        if not isinstance(creds, Credentials) or not creds.api_key or not creds.endpoint:  # pragma: no cover
-            logger.warning("Embed credentials not set — skipping recall check")
-            return None
-
-        if model is None:  # pragma: no cover — same path as above; needs FakeCredentials
-            model = creds.model or "text-embedding-3-large"
-
-        try:  # pragma: no cover — same path as above; needs FakeCredentials
-            provider = get_embed_provider()
-        except Exception as e:  # pragma: no cover
-            logger.warning("Recall embed failed: get_embed_provider raised %s", e)
-            return None
-    elif model is None:
-        model = "text-embedding-3-large"
-
     try:
         vectors = provider.embed_batch([query], model=model, dims=EMBED_DIMS)
         if not vectors:
@@ -240,19 +284,28 @@ def _embed_query(
         return None
 
 
-class _UsearchVectorSearcher:  # pragma: no cover
-    """Production VectorSearcher — pragma'd whole.
+def _default_index_resolver() -> Any:
+    """Production index resolver — wraps ``get_vector_index`` so tests can inject a fake."""
+    from kairix.core.search.vec_index import get_vector_index
 
-    Tests inject ``FakeVectorSearcher`` via ``RecallChecker(vector_searcher=...)``.
-    The real usearch index lookup is exercised by integration coverage with a
-    populated usearch index, not by the unit suite.
+    return get_vector_index()
+
+
+class UsearchVectorSearcher:
+    """Production VectorSearcher wrapping the usearch index.
+
+    Tests construct it with ``index_resolver=`` to drive every branch
+    (index missing, search returns hits, search raises). Production callers
+    leave ``index_resolver=None`` and the default
+    (``kairix.core.search.vec_index.get_vector_index``) is used.
     """
+
+    def __init__(self, index_resolver: Callable[[], Any] | None = None) -> None:
+        self._index_resolver = index_resolver if index_resolver is not None else _default_index_resolver
 
     def search_vectors(self, vector: np.ndarray, *, limit: int) -> list[str]:
         try:
-            from kairix.core.search.vec_index import get_vector_index
-
-            index = get_vector_index()
+            index = self._index_resolver()
             if index is None:
                 logger.warning("usearch index not available for recall check")
                 return []
@@ -266,17 +319,27 @@ class _UsearchVectorSearcher:  # pragma: no cover
 class RecallChecker:
     """Embed-and-vector-search recall quality gate.
 
-    Constructor takes the two protocol implementations exercised by the gate:
+    Constructor takes the two protocol implementations exercised by the gate
+    plus injection seams for the credentials / provider lookup:
 
       - ``embed_provider``: any ``EmbedProvider`` (production: Azure/OpenAI;
-        tests: ``FakeEmbedProvider``).
+        tests: ``FakeEmbedProvider``). When ``None``, ``creds_resolver`` and
+        ``provider_factory`` are used to construct one on first ``_embed`` call.
       - ``vector_searcher``: any ``VectorSearcher`` (production:
-        ``_UsearchVectorSearcher`` wrapping the usearch index; tests:
+        ``UsearchVectorSearcher`` wrapping the usearch index; tests:
         ``FakeVectorSearcher`` from ``tests/fakes.py``).
+      - ``creds_resolver``: returns a ``Credentials`` or ``None``. Default
+        delegates to ``kairix.credentials.get_credentials("embed")`` and
+        treats any exception as "no credentials" (returns ``None``).
+      - ``provider_factory``: builds an ``EmbedProvider`` from resolved
+        ``Credentials``. Default delegates to
+        ``kairix.platform.llm.embed_provider.get_embed_provider``.
 
-    Both are optional — when ``None`` the production defaults are
-    constructed lazily so a bare ``RecallChecker()`` runs against the real
-    Azure/usearch surface.
+    All four are optional — production callers leave them all None and the
+    real Azure / usearch surface is used. Tests inject ``FakeEmbedProvider``
+    + ``FakeVectorSearcher`` to drive the happy paths, and inject
+    ``FakeCredentials`` (via ``creds_resolver``) to exercise the
+    credentials-resolution failure paths without touching real secrets.
     """
 
     def __init__(
@@ -284,19 +347,39 @@ class RecallChecker:
         *,
         embed_provider: EmbedProvider | None = None,
         vector_searcher: VectorSearcher | None = None,
+        creds_resolver: Callable[[], Credentials | GraphCredentials | None] | None = None,
+        provider_factory: Callable[[Credentials], EmbedProvider] | None = None,
     ) -> None:
         self._embed_provider = embed_provider
         self._vector_searcher = vector_searcher
+        self._creds_resolver = creds_resolver if creds_resolver is not None else _default_creds_resolver
+        self._provider_factory = provider_factory if provider_factory is not None else _default_provider_factory
+        # Cached resolved model so we only resolve credentials once per checker.
+        self._resolved_model: str | None = None
 
     def _embed(self, query: str) -> np.ndarray | None:
-        return _embed_query(query, provider=self._embed_provider)
+        provider = self._embed_provider
+        model: str
+        if provider is None:
+            resolved_provider, resolved_model = _resolve_provider_and_model(
+                self._creds_resolver,
+                self._provider_factory,
+                self._resolved_model,
+            )
+            if resolved_provider is None or resolved_model is None:
+                return None
+            self._embed_provider = resolved_provider
+            self._resolved_model = resolved_model
+            provider = resolved_provider
+            model = resolved_model
+        else:
+            model = self._resolved_model or "text-embedding-3-large"
+        return _embed_query(query, provider=provider, model=model)
 
     def _search(self, vector: np.ndarray, limit: int) -> list[str]:
         searcher = self._vector_searcher
-        # Lazy default is production-only — tests inject FakeVectorSearcher via
-        # the constructor, so this construction never fires in the unit suite.
-        if searcher is None:  # pragma: no cover
-            searcher = _UsearchVectorSearcher()
+        if searcher is None:
+            searcher = UsearchVectorSearcher()
             self._vector_searcher = searcher
         return searcher.search_vectors(vector, limit=limit)
 
@@ -323,16 +406,16 @@ class RecallChecker:
         """
         close_db = False
         if db is None:
-            try:
-                from kairix.core.db import get_db_path, open_db
+            from kairix.core.db import get_db_path, open_db
 
-                db = open_db(Path(get_db_path()))
-                close_db = True
-            # ``get_db_path`` returns a path even when missing and ``open_db``
-            # auto-creates parent dirs; this guard is defensive for unwritable
-            # parents (e.g. read-only fs).
-            except FileNotFoundError:  # pragma: no cover
-                db = None
+            # ``get_db_path`` returns a path (existing or default-creation
+            # location) and ``open_db`` auto-creates parent dirs and the
+            # SQLite file via ``sqlite3.connect``, so neither raises
+            # ``FileNotFoundError``. Other exceptions (e.g. permission
+            # errors) are surfaced — they indicate broken environment
+            # config that the gate cannot work around.
+            db = open_db(Path(get_db_path()))
+            close_db = True
 
         if recall_queries is not None:
             queries = recall_queries

--- a/tests/embed/test_recall_check_alarm_paths.py
+++ b/tests/embed/test_recall_check_alarm_paths.py
@@ -1,0 +1,431 @@
+"""Coverage tests for the alarm-system failure paths in recall_check.
+
+The ``recall_check`` module is the post-embed quality gate. Its happy
+paths are covered by ``test_recall_check.py`` and
+``test_recall_check_contracts.py``; this file targets the failure paths
+that used to be ``# pragma: no cover``-marked because no test could
+reach them through the public surface:
+
+  - credentials missing / empty / wrong type → query is skipped
+  - ``provider_factory`` raises → query is skipped
+  - usearch index missing / search raises → empty results, no crash
+  - lazy production defaults fire on first call when no overrides given
+
+Every test drives behaviour through the public ``RecallChecker.check``
+or the ``UsearchVectorSearcher`` constructor — no internal-name
+imports of helper functions, no ``@patch``, no ``monkeypatch.setenv``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from kairix.core.embed.recall_check import RecallChecker, UsearchVectorSearcher
+from tests.fakes import FakeCredentials, FakeEmbedProvider, FakeVectorSearcher
+
+# ---------------------------------------------------------------------------
+# Credentials-resolution failure paths — driven via ``creds_resolver`` /
+# ``provider_factory`` constructor injection. Every query that fails to
+# resolve a usable provider must surface as ``skipped=True`` in the
+# returned detail, NOT as a crash.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_check_skips_when_creds_resolver_returns_none() -> None:
+    """``creds_resolver`` returning ``None`` → no provider can be built → query is skipped."""
+
+    def _no_creds() -> None:
+        return None
+
+    checker = RecallChecker(
+        # No embed_provider — forces the lazy resolution path.
+        vector_searcher=FakeVectorSearcher(paths=["docs/whatever.md"]),
+        creds_resolver=_no_creds,
+    )
+    result = checker.check(recall_queries=[("R1", "any", "x")])
+
+    assert result["total"] == 0
+    assert result["passed"] == 0
+    assert result["score"] == pytest.approx(0.0)
+    assert result["detail"][0]["skipped"] is True
+
+
+@pytest.mark.unit
+def test_check_skips_when_creds_resolver_returns_non_credentials_type() -> None:
+    """``creds_resolver`` returning something other than ``Credentials``
+    (e.g. ``GraphCredentials``) is treated as no-creds → query is skipped.
+
+    This protects against config wiring that accidentally points the embed
+    gate at the graph creds — without this guard the gate would crash with
+    AttributeError on ``creds.api_key`` later.
+    """
+    from kairix.credentials import GraphCredentials
+
+    def _wrong_kind() -> GraphCredentials:
+        return GraphCredentials(uri="bolt://x", user="u", password="p")
+
+    checker = RecallChecker(
+        vector_searcher=FakeVectorSearcher(),
+        creds_resolver=_wrong_kind,
+    )
+    result = checker.check(recall_queries=[("R1", "any", "x")])
+
+    assert result["detail"][0]["skipped"] is True
+    assert result["total"] == 0
+
+
+@pytest.mark.unit
+def test_check_skips_when_credentials_have_empty_api_key() -> None:
+    """A ``Credentials`` whose ``api_key`` is empty is unusable → skip the query.
+
+    Empty strings can leak through env-var resolution (``KAIRIX_*=""``); the
+    gate must short-circuit on the credentials check itself, BEFORE the
+    provider factory runs. Verified by injecting a factory that would
+    succeed if called — the test passes only because the factory is never
+    reached for empty-api-key creds.
+    """
+    factory_calls: list[object] = []
+    checker = RecallChecker(
+        vector_searcher=FakeVectorSearcher(),
+        creds_resolver=lambda: FakeCredentials(api_key=""),
+        provider_factory=lambda c: factory_calls.append(c) or FakeEmbedProvider(),  # type: ignore[func-returns-value, arg-type, return-value]  # one-shot capture-and-return
+    )
+    result = checker.check(recall_queries=[("R1", "any", "x")])
+
+    assert result["detail"][0]["skipped"] is True
+    # Critical: the factory must NOT have been called for empty-api-key creds.
+    assert factory_calls == []
+
+
+@pytest.mark.unit
+def test_check_skips_when_credentials_have_empty_endpoint() -> None:
+    """A ``Credentials`` whose ``endpoint`` is empty is unusable → skip the query.
+
+    Verified that the credentials check runs BEFORE the provider factory:
+    we inject a factory that would succeed and assert it was never called.
+    """
+    factory_calls: list[object] = []
+    checker = RecallChecker(
+        vector_searcher=FakeVectorSearcher(),
+        creds_resolver=lambda: FakeCredentials(endpoint=""),
+        provider_factory=lambda c: factory_calls.append(c) or FakeEmbedProvider(),  # type: ignore[func-returns-value, arg-type, return-value]  # one-shot capture-and-return
+    )
+    result = checker.check(recall_queries=[("R1", "any", "x")])
+
+    assert result["detail"][0]["skipped"] is True
+    assert factory_calls == []
+
+
+@pytest.mark.unit
+def test_check_skips_when_provider_factory_raises() -> None:
+    """``provider_factory`` raising (e.g. SDK init failure) → skip the query, do not propagate."""
+    creds_calls: list[int] = []
+
+    def _creds() -> object:
+        creds_calls.append(1)
+        return FakeCredentials()
+
+    def _exploding_factory(creds: object) -> object:
+        raise RuntimeError("openai SDK init failed")
+
+    checker = RecallChecker(
+        vector_searcher=FakeVectorSearcher(),
+        creds_resolver=_creds,
+        provider_factory=_exploding_factory,
+    )
+    result = checker.check(recall_queries=[("R1", "any", "x")])
+
+    assert result["detail"][0]["skipped"] is True
+    assert result["total"] == 0
+    # creds_resolver was called exactly once before the factory exploded.
+    assert len(creds_calls) == 1
+
+
+@pytest.mark.unit
+def test_check_uses_provider_factory_when_credentials_resolve_successfully() -> None:
+    """Happy lazy-resolution path: creds resolve → factory returns a provider →
+    the resolved provider is reused on subsequent calls (no re-resolution per query).
+    """
+    factory_calls: list[object] = []
+    factory_provider = FakeEmbedProvider(vector=[1.0, 0.0, 0.0])
+
+    def _factory(creds: object) -> object:
+        factory_calls.append(creds)
+        return factory_provider
+
+    fake_searcher = FakeVectorSearcher(paths=["docs/architecture.md"])
+    checker = RecallChecker(
+        vector_searcher=fake_searcher,
+        creds_resolver=lambda: FakeCredentials(),
+        provider_factory=_factory,
+    )
+    result = checker.check(
+        recall_queries=[
+            ("R1", "q1", "architecture"),
+            ("R2", "q2", "architecture"),
+        ]
+    )
+
+    # Both queries hit (gold fragment "architecture" is in the returned path).
+    assert result["passed"] == 2
+    assert result["total"] == 2
+    # The factory was called exactly once across two queries — provider is cached.
+    assert len(factory_calls) == 1
+    # And the provider itself saw both queries.
+    assert len(factory_provider.calls) == 2
+
+
+@pytest.mark.unit
+def test_check_uses_credentials_model_when_no_explicit_model() -> None:
+    """When the resolved Credentials carry a ``model``, the recall gate
+    passes that model name through to ``provider.embed_batch`` rather than
+    falling back to the hardcoded default.
+    """
+    factory_provider = FakeEmbedProvider(vector=[1.0, 0.0, 0.0])
+
+    checker = RecallChecker(
+        vector_searcher=FakeVectorSearcher(paths=["docs/x.md"]),
+        creds_resolver=lambda: FakeCredentials(model="custom-embed-model-v9"),
+        provider_factory=lambda _creds: factory_provider,
+    )
+    checker.check(recall_queries=[("R1", "q", "x")])
+
+    assert len(factory_provider.calls) == 1
+    assert factory_provider.calls[0]["model"] == "custom-embed-model-v9"
+
+
+@pytest.mark.unit
+def test_check_falls_back_to_default_model_when_credentials_have_empty_model() -> None:
+    """``creds.model`` is the empty string → the gate falls back to
+    ``text-embedding-3-large`` (the documented default).
+    """
+    factory_provider = FakeEmbedProvider(vector=[1.0, 0.0, 0.0])
+
+    checker = RecallChecker(
+        vector_searcher=FakeVectorSearcher(paths=["docs/x.md"]),
+        creds_resolver=lambda: FakeCredentials(model=""),
+        provider_factory=lambda _creds: factory_provider,
+    )
+    checker.check(recall_queries=[("R1", "q", "x")])
+
+    assert factory_provider.calls[0]["model"] == "text-embedding-3-large"
+
+
+# ---------------------------------------------------------------------------
+# UsearchVectorSearcher — drive every branch via the ``index_resolver``
+# constructor seam. No ``# pragma: no cover``; the production wrapper is
+# now testable.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_usearch_searcher_returns_empty_list_when_index_resolver_returns_none(caplog: pytest.LogCaptureFixture) -> None:
+    """A missing usearch index (``get_vector_index() is None``) → empty list,
+    NOT an exception. The wrapper logs the dedicated "index not available"
+    warning rather than the generic "search failed" — this distinguishes
+    the early-return branch from the catch-all error path.
+    """
+    import logging
+
+    caplog.set_level(logging.WARNING, logger="kairix.core.embed.recall_check")
+    searcher = UsearchVectorSearcher(index_resolver=lambda: None)
+    result = searcher.search_vectors(np.array([0.1, 0.2, 0.3], dtype=np.float32), limit=5)
+    assert result == []
+    # Dedicated "index missing" warning fired — NOT the generic catch-all path.
+    messages = [rec.getMessage() for rec in caplog.records]
+    assert any("usearch index not available" in m for m in messages), (
+        f"expected 'index not available' warning; got {messages}"
+    )
+    assert not any("recall search failed" in m for m in messages), (
+        f"early-return branch should not log generic 'search failed'; got {messages}"
+    )
+
+
+@pytest.mark.unit
+def test_usearch_searcher_returns_paths_from_index_search_results() -> None:
+    """The wrapper extracts the ``path`` field from each search hit and
+    returns them in order.
+    """
+
+    class _StubIndex:
+        def __init__(self) -> None:
+            self.search_calls: list[tuple[Any, int]] = []
+
+        def search(self, vector: Any, *, k: int) -> list[dict[str, str]]:
+            self.search_calls.append((vector, k))
+            return [
+                {"path": "docs/a.md", "score": 0.9},
+                {"path": "docs/b.md", "score": 0.8},
+            ]
+
+    index = _StubIndex()
+    searcher = UsearchVectorSearcher(index_resolver=lambda: index)
+    vector = np.array([0.0, 1.0, 0.0], dtype=np.float32)
+    result = searcher.search_vectors(vector, limit=2)
+
+    assert result == ["docs/a.md", "docs/b.md"]
+    # The wrapper passed through the vector and limit verbatim.
+    assert len(index.search_calls) == 1
+    np.testing.assert_array_equal(index.search_calls[0][0], vector)
+    assert index.search_calls[0][1] == 2
+
+
+@pytest.mark.unit
+def test_usearch_searcher_returns_empty_list_when_index_search_raises() -> None:
+    """``index.search`` raising → wrapper returns ``[]``, does not propagate.
+
+    The recall gate must be a soft alarm — production faults inside the
+    vector index must not take down the embed pipeline.
+    """
+
+    class _ExplodingIndex:
+        def search(self, vector: Any, *, k: int) -> list[dict[str, str]]:
+            raise RuntimeError("usearch index corrupt")
+
+    searcher = UsearchVectorSearcher(index_resolver=lambda: _ExplodingIndex())
+    result = searcher.search_vectors(np.array([0.1, 0.2], dtype=np.float32), limit=3)
+    assert result == []
+
+
+@pytest.mark.unit
+def test_usearch_searcher_returns_empty_list_when_index_resolver_raises() -> None:
+    """``index_resolver`` itself raising (e.g. import-time crash) → ``[]``.
+
+    The wrapper's outer try/except must cover the resolver lookup, not just
+    the search call. Without this, a deferred-import error would crash the
+    recall gate instead of degrading.
+    """
+
+    def _exploding_resolver() -> Any:
+        raise ImportError("usearch wheel missing")
+
+    searcher = UsearchVectorSearcher(index_resolver=_exploding_resolver)
+    result = searcher.search_vectors(np.array([0.1, 0.2], dtype=np.float32), limit=3)
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Lazy default constructions — RecallChecker._search builds a default
+# UsearchVectorSearcher once when no vector_searcher was injected; the
+# default credentials resolver returns None on exception.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_recall_checker_lazily_constructs_default_vector_searcher_when_none_injected() -> None:
+    """``RecallChecker(vector_searcher=None)`` builds a default
+    ``UsearchVectorSearcher`` on first ``_search`` call.
+
+    Observable contract: with no vector_searcher injected and a working
+    embed provider, ``check()`` runs to completion (no crash) and reports
+    the queries as non-skipped (the default usearch wrapper degrades to
+    ``[]`` when the index is missing, which is a miss, not a skip).
+    """
+    checker = RecallChecker(embed_provider=FakeEmbedProvider(vector=[1.0, 0.0, 0.0]))
+
+    result = checker.check(
+        recall_queries=[
+            ("R1", "q1", "no-match"),
+            ("R2", "q2", "also-no-match"),
+        ]
+    )
+
+    # Both queries reached the search step (non-skipped), and both missed —
+    # the default ``UsearchVectorSearcher`` was constructed and used.
+    assert result["total"] == 2
+    assert result["passed"] == 0
+    for entry in result["detail"]:
+        assert entry["skipped"] is False
+        assert entry["hit"] is False
+        # The default searcher returned an empty list (no usearch index in unit env).
+        assert entry["returned"] == []
+
+
+@pytest.mark.unit
+def test_check_skips_when_creds_resolver_itself_raises() -> None:
+    """A ``creds_resolver`` that raises (e.g. Key Vault unreachable) is
+    caught by the recall gate and surfaces as a skipped query.
+
+    This is the alarm-system contract: the gate must NEVER take down the
+    embed pipeline. A failing creds lookup degrades to "no recall this
+    cycle", not an unhandled exception.
+    """
+
+    def _raising_resolver() -> object:
+        raise RuntimeError("Azure Key Vault unreachable")
+
+    checker = RecallChecker(
+        vector_searcher=FakeVectorSearcher(),
+        creds_resolver=_raising_resolver,
+    )
+
+    result = checker.check(recall_queries=[("R1", "any", "x")])
+
+    assert result["detail"][0]["skipped"] is True
+    assert result["total"] == 0
+
+
+@pytest.mark.unit
+def test_production_default_creds_resolver_swallows_exceptions() -> None:
+    """``_default_creds_resolver`` (production default) returns ``None``
+    rather than propagating when ``get_credentials`` raises.
+
+    Driven via the public RecallChecker surface: instantiate a checker with
+    NO ``creds_resolver`` override; the default is in play. We then verify
+    the contract by ensuring the gate skips every query when there are no
+    real credentials configured (the test environment doesn't carry valid
+    Azure secrets, so ``get_credentials`` raises OSError or returns
+    something unusable).
+    """
+    # No embed_provider → forces lazy resolution via _default_creds_resolver.
+    # No creds_resolver / provider_factory overrides → exercises production defaults.
+    checker = RecallChecker(vector_searcher=FakeVectorSearcher())
+    result = checker.check(recall_queries=[("R1", "any", "x")])
+
+    # The default resolver caught the secrets-store failure and returned None,
+    # so the gate skipped the query rather than crashing.
+    assert result["detail"][0]["skipped"] is True
+    assert result["total"] == 0
+
+
+@pytest.mark.unit
+def test_production_default_provider_factory_runs_when_creds_resolve(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The production default ``provider_factory`` is invoked when creds
+    resolve to a valid Credentials but no ``provider_factory`` override
+    is supplied.
+
+    The unit test environment doesn't carry Azure / OpenAI credentials, so
+    the default factory's ``get_embed_provider()`` call raises OSError
+    (missing env vars). The gate catches the exception, logs the
+    "provider_factory raised" warning, and skips the query.
+
+    This pins the wiring: a working creds_resolver + the production
+    factory default DOES reach the SDK construction code.
+    """
+    import logging
+
+    caplog.set_level(logging.WARNING, logger="kairix.core.embed.recall_check")
+
+    # Inject valid-looking FakeCredentials so the resolver short-circuit
+    # doesn't fire; no provider_factory override → production default runs.
+    checker = RecallChecker(
+        vector_searcher=FakeVectorSearcher(),
+        creds_resolver=lambda: FakeCredentials(),
+    )
+    result = checker.check(recall_queries=[("R1", "any", "x")])
+
+    # Query was skipped — the factory raised and the gate degraded gracefully.
+    assert result["detail"][0]["skipped"] is True
+    # The "provider_factory raised" warning was logged; this proves the
+    # production default factory was reached and exercised, not the
+    # missing-credentials short-circuit.
+    messages = [rec.getMessage() for rec in caplog.records]
+    assert any("provider_factory raised" in m for m in messages), (
+        f"expected production default factory to be reached and raise; got {messages}"
+    )

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -549,6 +549,30 @@ class FakeVectorSearcher:
         return list(self._paths[:limit])
 
 
+def FakeCredentials(  # noqa: N802 — factory function returning real Credentials; named like a class for call-site clarity
+    *,
+    api_key: str = "fake-api-key",
+    endpoint: str = "https://fake.openai.azure.com",
+    model: str = "text-embedding-3-large",
+    dims: int = 1536,
+) -> Any:
+    """Construct a real ``kairix.credentials.Credentials`` from explicit args.
+
+    The canonical replacement for "monkey-patch ``get_credentials``" in tests.
+    Tests inject ``creds_resolver=lambda: FakeCredentials(...)`` (or
+    ``lambda: None``, or ``lambda: FakeCredentials(api_key="")`` to drive
+    the missing-credentials skip path) into ``RecallChecker`` rather than
+    mutating module-level state.
+
+    Returns a real ``Credentials`` instance — the production code's
+    ``isinstance(creds, Credentials)`` check passes, so tests exercise the
+    same control flow production runs.
+    """
+    from kairix.credentials import Credentials
+
+    return Credentials(api_key=api_key, endpoint=endpoint, model=model, dims=dims)
+
+
 class FakeFusion:
     """Pass-through fusion: concatenates BM25 and vector results.
 


### PR DESCRIPTION
## Summary

Closes #194 (Phase 2c: Coverage backfill — `kairix/core/embed/recall_check.py`).

Drives every `# pragma: no cover` in the alarm-system file to zero by injecting `creds_resolver` and `provider_factory` into `RecallChecker`, making `UsearchVectorSearcher` injectable, and deleting one dead branch.

### Production refactor

- `RecallChecker.__init__` now takes optional `creds_resolver` and `provider_factory` callables (typed, default to production-only resolvers; not `*_fn=None` so F6 is happy). Tests inject `FakeCredentials` via the resolver to drive every credentials-failure branch.
- `_embed_query` is now pure — it always takes a non-None provider. Lazy credentials resolution + provider construction live in `_resolve_provider_and_model`, which catches every failure mode (resolver raises, non-Credentials returned, empty `api_key`/`endpoint`, factory raises) and returns `None, None` so the recall query is skipped, never propagated.
- `_UsearchVectorSearcher` → `UsearchVectorSearcher` (made public; F5 wouldn't allow tests to import a `_`-prefixed class). Now takes an injectable `index_resolver` so tests drive index-missing / hits-returned / search-raises / resolver-raises through the constructor without an actual usearch index.
- Deleted dead `FileNotFoundError` guard at line 334. `open_db` / `get_db_path` never raise FNF (open_db auto-creates parent dirs; sqlite3.connect creates the file). The docstring already called it out as defensive-only.

### New tests

`tests/embed/test_recall_check_alarm_paths.py` (16 tests, all `@pytest.mark.unit`):

- creds_resolver returns `None` / non-`Credentials` (e.g. `GraphCredentials`) / `Credentials` with empty api_key / empty endpoint → query is skipped
- creds_resolver itself raises → caught, query is skipped
- provider_factory raises → caught, query is skipped
- provider_factory called only once across multiple queries (provider is cached)
- creds.model is propagated to `embed_batch`; empty model falls back to `text-embedding-3-large`
- `UsearchVectorSearcher`: index resolver returns None / valid index / index.search raises / resolver raises — all branches covered, with log-message assertions distinguishing the dedicated "index not available" branch from the catch-all error path
- `RecallChecker` lazily constructs a default `UsearchVectorSearcher` when no `vector_searcher` is injected
- production default `_default_creds_resolver` swallows exceptions
- production default `_default_provider_factory` is reached when creds resolve

### Sabotage-proven

For each new test that pins a failure path, I mutated the production branch (removed the `or not creds.endpoint` check, removed the `try/except` around `provider_factory`, removed the `if index is None` early-return, removed the lazy default in `_search`) and confirmed the tests fail before restoring.

### Fakes

Added `FakeCredentials` to `tests/fakes.py` — factory function that returns a real `kairix.credentials.Credentials` with sensible defaults so `isinstance(creds, Credentials)` passes in production code paths. Tests pass `creds_resolver=lambda: FakeCredentials(api_key="")` to drive empty-creds branches.

## Pragma delta

| Line | Reason | Resolution |
|------|--------|------------|
| 214 | Credentials check uncovered | Tested via `creds_resolver=lambda: FakeCredentials(api_key="")` etc. |
| 218 | model fallback uncovered | Tested via `FakeCredentials(model="")` |
| 221 | get_embed_provider call uncovered | Tested via injected `provider_factory` |
| 223 | get_embed_provider exception uncovered | Tested via raising factory |
| 243 | Whole class pragma | Class is now public + injectable; all branches tested |
| 298 | Lazy vector_searcher default | Tested via `RecallChecker(embed_provider=...)` with no `vector_searcher` |
| 334 | Dead FileNotFoundError | Deleted — confirmed dead by docstring + `open_db` source |

All 7 pragmas removed. Net new pragmas: 0.

## Test plan

- [x] `python3 -m pytest tests/embed/test_recall_check_alarm_paths.py` (16 tests, all pass)
- [x] `python3 -m pytest tests/ -m "unit or contract or bdd"` (2915 pass, was 2900)
- [x] `python3 -m pytest tests/integration/test_recall_gate_pipeline.py` (3 pass)
- [x] `bash scripts/safe-commit.sh` green (ruff, mypy strict, tests, F1-F6+F8+F10-F13, secrets, confidential)
- [x] `pre-commit run --all-files` green (CI parity)
- [ ] CI on the PR (Stage 2 reports F7 ≥ 90% on `recall_check.py`)

## Notes

- Local coverage measurement is blocked on Python 3.14 + numpy + coverage.py double-import (machine has 3.14, CI uses 3.12). Coverage delta will surface in Codecov on the PR.
- `_default_provider_factory` is exercised end-to-end via the public `RecallChecker()` surface — no private-name imports in tests (F5 clean).

## Defects discovered while writing tests

None — the failure paths handle their cases correctly when reached. The bug was that they were uncovered, not that they were broken. The DI refactor is what made them reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)