### PR TITLE
test(F6): convert detector/generate/backends/onboard to typed *Deps (4 of 12)

### DIFF
--- a/.architecture/baseline/no-test-only-kwargs-files.txt
+++ b/.architecture/baseline/no-test-only-kwargs-files.txt
@@ -1,4 +1,0 @@
-kairix/knowledge/contradict/detector.py
-kairix/knowledge/summaries/generate.py
-kairix/platform/llm/backends.py
-kairix/platform/onboard/check.py

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -216,7 +216,7 @@
         "filename": "tests/summaries/test_generate.py",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 28
+        "line_number": 29
       }
     ],
     "tests/test_secrets.py": [
@@ -236,5 +236,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-10T05:05:30Z"
+  "generated_at": "2026-05-10T13:56:06Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -216,7 +216,7 @@
         "filename": "tests/summaries/test_generate.py",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 29
+        "line_number": 30
       }
     ],
     "tests/test_secrets.py": [
@@ -236,5 +236,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-10T13:56:06Z"
+  "generated_at": "2026-05-10T14:57:46Z"
 }

--- a/kairix/knowledge/contradict/detector.py
+++ b/kairix/knowledge/contradict/detector.py
@@ -11,15 +11,16 @@ the document store via a Strategy-pattern pipeline:
      mismatch — and returns the winning category for each candidate.
   4. Results above ``threshold`` are returned, sorted by score.
 
-Never raises — failures return empty lists. Pass injectable scorer/
-extractor/search/LLM for testing without monkey-patching.
+Never raises — failures return empty lists. Pass a ``ContradictDetectorDeps``
+dataclass to substitute scorer / extractor / search at the boundary
+without monkey-patching.
 """
 
 from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from kairix.knowledge.contradict.extract import EntityDensityClaimExtractor
@@ -43,6 +44,32 @@ class ContradictionResult:
     claim: str = ""  # the extracted claim that drove the search/scoring
 
 
+def _default_search() -> Callable[..., Any]:
+    """Production search callable — bound to the canonical ``SearchPipeline``."""
+    from kairix.core.factory import build_search_pipeline
+
+    return build_search_pipeline().search
+
+
+@dataclass
+class ContradictDetectorDeps:
+    """Injectable dependencies for ``check_contradiction``.
+
+    Each field defaults to a production implementation; tests construct
+    ``ContradictDetectorDeps(search=fake_search, ...)`` with fakes
+    rather than threading per-helper ``*_fn=None`` substitution kwargs.
+
+    The scorer field is built lazily from the LLM passed to
+    ``check_contradiction`` because the production scorer needs the
+    LLM at construction time. Tests bypass that by setting ``scorer``
+    directly.
+    """
+
+    search: Callable[..., Any] = field(default_factory=_default_search)
+    scorer: CompositeContradictionScorer | None = None
+    extractor: Any = field(default_factory=EntityDensityClaimExtractor)
+
+
 def check_contradiction(
     content: str,
     llm: Any,
@@ -52,9 +79,7 @@ def check_contradiction(
     scope: Any = None,
     *,
     top_claims: int = 3,
-    search_fn: Callable[..., Any] | None = None,
-    scorer: CompositeContradictionScorer | None = None,
-    extractor: Any | None = None,
+    deps: ContradictDetectorDeps | None = None,
 ) -> list[ContradictionResult]:
     """
     Check whether *content* contradicts existing knowledge in the document store.
@@ -62,33 +87,26 @@ def check_contradiction(
     Args:
         content:    The new content to check (claim, note, decision, etc.).
         llm:        An LLM backend implementing ``chat(messages)`` — only used
-                    if scorer is None (the default scorer wraps the LLM).
+                    to build the default scorer when ``deps.scorer`` is None.
         top_k:      How many similar documents to compare against per claim.
         threshold:  Minimum contradiction score (0.0-1.0) to include. Default
                     0.45 — calibrated for the three-category composite which
                     individually scores more conservatively than the historic
                     single-prompt scorer.
         top_claims: How many high-signal claims to extract from content.
-        search_fn:  Injectable search function. Defaults to SearchPipeline.search.
-        scorer:     Injectable composite scorer. Defaults to all three categories
-                    (direct + overstatement + status_mismatch).
-        extractor:  Injectable claim extractor. Defaults to entity-density rank.
+        deps:       Injectable dependency bundle (search callable, scorer,
+                    extractor). Production callers leave ``None`` and the
+                    defaults wire to the real ``SearchPipeline``,
+                    composite scorer, and entity-density extractor.
 
     Returns:
         List of ContradictionResult, sorted by score descending. Empty list
         when no contradictions found or on any failure.
     """
-    if search_fn is None:
-        from kairix.core.factory import build_search_pipeline
-
-        _pipeline = build_search_pipeline()
-        search_fn = _pipeline.search
-
-    if scorer is None:
-        scorer = default_contradiction_scorer(llm)
-
-    if extractor is None:
-        extractor = EntityDensityClaimExtractor()
+    d = deps if deps is not None else ContradictDetectorDeps()
+    search = d.search
+    scorer = d.scorer if d.scorer is not None else default_contradiction_scorer(llm)
+    extractor = d.extractor
 
     claims = extractor.extract(content, top_n=top_claims) or [content[:500]]
 
@@ -105,7 +123,7 @@ def check_contradiction(
     seen_paths: dict[str, tuple[str, Any]] = {}
     for claim in claims:
         try:
-            sr = search_fn(query=claim[:500], **search_kwargs)
+            sr = search(query=claim[:500], **search_kwargs)
             for bundle in sr.results[:top_k]:
                 path = bundle.result.path
                 if path not in seen_paths:

--- a/kairix/knowledge/summaries/generate.py
+++ b/kairix/knowledge/summaries/generate.py
@@ -71,7 +71,7 @@ def _first_n_words(text: str, n: int) -> str:
     return " ".join(words[:n])
 
 
-def _default_chat(messages: list[dict], max_tokens: int) -> str:  # pragma: no cover — prod wrapper around kairix._azure
+def default_chat(messages: list[dict], max_tokens: int) -> str:  # pragma: no cover — prod wrapper around kairix._azure
     """Production chat callable — delegates to ``kairix._azure.chat_completion``.
 
     Wrapper exists so ``SummariesDeps.chat`` has a stable, typed default
@@ -91,7 +91,7 @@ class SummariesDeps:
     threading per-helper ``chat_fn=None`` substitution kwargs.
     """
 
-    chat: Callable[..., str] = field(default_factory=lambda: _default_chat)
+    chat: Callable[..., str] = field(default_factory=lambda: default_chat)
 
 
 def _call_chat(

--- a/kairix/knowledge/summaries/generate.py
+++ b/kairix/knowledge/summaries/generate.py
@@ -71,7 +71,7 @@ def _first_n_words(text: str, n: int) -> str:
     return " ".join(words[:n])
 
 
-def _default_chat(messages: list[dict], max_tokens: int) -> str:
+def _default_chat(messages: list[dict], max_tokens: int) -> str:  # pragma: no cover — prod wrapper around kairix._azure
     """Production chat callable — delegates to ``kairix._azure.chat_completion``.
 
     Wrapper exists so ``SummariesDeps.chat`` has a stable, typed default
@@ -110,8 +110,9 @@ def _call_chat(
     The api_key, endpoint, and deployment parameters are accepted for backwards
     compatibility but ignored — credentials are resolved by ``kairix._azure``.
     """
-    d = deps if deps is not None else SummariesDeps()
-    content = d.chat(messages, max_tokens=max_tokens)
+    if deps is None:  # pragma: no cover — production lazy default; tests pass deps=SummariesDeps(chat=fake)
+        deps = SummariesDeps()
+    content = deps.chat(messages, max_tokens=max_tokens)
     # Token usage is not available from the shared client; estimate from output length.
     tokens_est = estimate_tokens(content)
     return content, tokens_est
@@ -189,7 +190,8 @@ def generate_summaries(
     Sleeps sleep_ms milliseconds between each file call for rate limiting.
     batch_size controls how many files are processed before each sleep.
     """
-    d = deps if deps is not None else SummariesDeps()
+    if deps is None:  # pragma: no cover — production lazy default; tests pass deps=SummariesDeps(chat=fake)
+        deps = SummariesDeps()
     results: list[SummaryResult] = []
 
     for i, path in enumerate(paths):
@@ -207,13 +209,13 @@ def generate_summaries(
             now = datetime.now(timezone.utc).isoformat()
             tokens_total = 0
 
-            l0 = generate_l0(path, content, api_key, endpoint, deployment, deps=d)
+            l0 = generate_l0(path, content, api_key, endpoint, deployment, deps=deps)
             # Rough token estimate for L0 if usage not tracked here
             tokens_total += estimate_tokens(l0)
 
             l1: str | None = None
             if include_l1:
-                l1 = generate_l1(path, content, api_key, endpoint, deployment, deps=d)
+                l1 = generate_l1(path, content, api_key, endpoint, deployment, deps=deps)
                 tokens_total += estimate_tokens(l1)
 
             results.append(

--- a/kairix/knowledge/summaries/generate.py
+++ b/kairix/knowledge/summaries/generate.py
@@ -6,12 +6,17 @@ L1: structured overview (~500 tokens) — main topic, key points, status
 
 Both functions raise on API failure. The batch helper (generate_summaries)
 catches and logs failures per-file so callers always get partial results.
+
+Tests inject a fake chat callable through ``SummariesDeps`` rather than
+threading per-helper ``chat_fn=None`` substitution kwargs.
 """
+
+from __future__ import annotations
 
 import logging
 import time
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -66,13 +71,36 @@ def _first_n_words(text: str, n: int) -> str:
     return " ".join(words[:n])
 
 
+def _default_chat(messages: list[dict], max_tokens: int) -> str:
+    """Production chat callable — delegates to ``kairix._azure.chat_completion``.
+
+    Wrapper exists so ``SummariesDeps.chat`` has a stable, typed default
+    that doesn't import ``kairix._azure`` at module-import time.
+    """
+    from kairix._azure import chat_completion
+
+    return chat_completion(messages, max_tokens=max_tokens)
+
+
+@dataclass
+class SummariesDeps:
+    """Injectable dependencies for the summaries module.
+
+    Each field defaults to a production implementation; tests construct
+    ``SummariesDeps(chat=fake_chat)`` with a fake callable rather than
+    threading per-helper ``chat_fn=None`` substitution kwargs.
+    """
+
+    chat: Callable[..., str] = field(default_factory=lambda: _default_chat)
+
+
 def _call_chat(
     messages: list[dict],
     api_key: str,
     endpoint: str,
     deployment: str,
     max_tokens: int,
-    chat_fn: Callable[..., str] | None = None,
+    deps: SummariesDeps | None = None,
 ) -> tuple[str, int]:
     """
     Call Azure OpenAI chat completions via the shared SDK client.
@@ -82,12 +110,8 @@ def _call_chat(
     The api_key, endpoint, and deployment parameters are accepted for backwards
     compatibility but ignored — credentials are resolved by ``kairix._azure``.
     """
-    if chat_fn is None:
-        from kairix._azure import chat_completion
-
-        chat_fn = chat_completion
-
-    content = chat_fn(messages, max_tokens=max_tokens)
+    d = deps if deps is not None else SummariesDeps()
+    content = d.chat(messages, max_tokens=max_tokens)
     # Token usage is not available from the shared client; estimate from output length.
     tokens_est = estimate_tokens(content)
     return content, tokens_est
@@ -104,7 +128,8 @@ def generate_l0(
     api_key: str,
     endpoint: str,
     deployment: str = "gpt-4o-mini",
-    chat_fn: Callable[..., str] | None = None,
+    *,
+    deps: SummariesDeps | None = None,
 ) -> str:
     """
     Generate L0 abstract for a document.
@@ -117,7 +142,7 @@ def generate_l0(
         {"role": "system", "content": _L0_SYSTEM},
         {"role": "user", "content": f"Document path: {path}\n\n{truncated}"},
     ]
-    abstract, _ = _call_chat(messages, api_key, endpoint, deployment, max_tokens=150, chat_fn=chat_fn)
+    abstract, _ = _call_chat(messages, api_key, endpoint, deployment, max_tokens=150, deps=deps)
     return abstract
 
 
@@ -127,7 +152,8 @@ def generate_l1(
     api_key: str,
     endpoint: str,
     deployment: str = "gpt-4o-mini",
-    chat_fn: Callable[..., str] | None = None,
+    *,
+    deps: SummariesDeps | None = None,
 ) -> str:
     """
     Generate L1 structured overview for a document.
@@ -140,7 +166,7 @@ def generate_l1(
         {"role": "system", "content": _L1_SYSTEM},
         {"role": "user", "content": f"Document path: {path}\n\n{truncated}"},
     ]
-    overview, _ = _call_chat(messages, api_key, endpoint, deployment, max_tokens=600, chat_fn=chat_fn)
+    overview, _ = _call_chat(messages, api_key, endpoint, deployment, max_tokens=600, deps=deps)
     return overview
 
 
@@ -152,7 +178,8 @@ def generate_summaries(
     include_l1: bool = False,
     batch_size: int = 10,
     sleep_ms: int = 100,
-    chat_fn: Callable[..., str] | None = None,
+    *,
+    deps: SummariesDeps | None = None,
 ) -> list[SummaryResult]:
     """
     Batch generate summaries for a list of file paths.
@@ -162,6 +189,7 @@ def generate_summaries(
     Sleeps sleep_ms milliseconds between each file call for rate limiting.
     batch_size controls how many files are processed before each sleep.
     """
+    d = deps if deps is not None else SummariesDeps()
     results: list[SummaryResult] = []
 
     for i, path in enumerate(paths):
@@ -179,13 +207,13 @@ def generate_summaries(
             now = datetime.now(timezone.utc).isoformat()
             tokens_total = 0
 
-            l0 = generate_l0(path, content, api_key, endpoint, deployment, chat_fn=chat_fn)
+            l0 = generate_l0(path, content, api_key, endpoint, deployment, deps=d)
             # Rough token estimate for L0 if usage not tracked here
             tokens_total += estimate_tokens(l0)
 
             l1: str | None = None
             if include_l1:
-                l1 = generate_l1(path, content, api_key, endpoint, deployment, chat_fn=chat_fn)
+                l1 = generate_l1(path, content, api_key, endpoint, deployment, deps=d)
                 tokens_total += estimate_tokens(l1)
 
             results.append(

--- a/kairix/platform/llm/backends.py
+++ b/kairix/platform/llm/backends.py
@@ -2,12 +2,45 @@
 Concrete LLMBackend implementations.
 
 AzureOpenAIBackend — thin wrapper over kairix._azure.
+
+Tests substitute the chat/embed callables through ``LLMBackendDeps`` rather
+than passing per-method ``*_fn=None`` substitution kwargs.
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass, field
 from typing import Any
+
+
+def _default_chat(messages: list[dict[str, Any]], max_tokens: int = 800) -> str:
+    """Production chat callable — delegates to ``kairix._azure.chat_completion``."""
+    from kairix._azure import chat_completion
+
+    result: str = chat_completion(messages, max_tokens=max_tokens)
+    return result
+
+
+def _default_embed(text: str) -> list[float]:
+    """Production embed callable — delegates to ``kairix._azure.embed_text``."""
+    from kairix._azure import embed_text
+
+    result: list[float] = embed_text(text)
+    return result
+
+
+@dataclass
+class LLMBackendDeps:
+    """Injectable dependencies for ``AzureOpenAIBackend``.
+
+    Each field defaults to the production Azure callable; tests construct
+    ``LLMBackendDeps(chat=fake_chat, embed=fake_embed)`` rather than passing
+    ``chat_fn=`` / ``embed_fn=`` kwargs to the backend's constructor.
+    """
+
+    chat: Callable[..., str] = field(default_factory=lambda: _default_chat)
+    embed: Callable[[str], list[float]] = field(default_factory=lambda: _default_embed)
 
 
 class AzureOpenAIBackend:
@@ -25,29 +58,18 @@ class AzureOpenAIBackend:
     # Adapter pattern: satisfies LLMBackend protocol by delegating to _azure module
     """
 
-    def __init__(
-        self,
-        chat_fn: Callable[..., str] | None = None,
-        embed_fn: Callable[..., list[float]] | None = None,
-    ) -> None:
-        """Construct with optional injectable callables for testing."""
-        self._chat_fn = chat_fn
-        self._embed_fn = embed_fn
+    def __init__(self, deps: LLMBackendDeps | None = None) -> None:
+        """Construct with optional injectable dependencies for testing.
+
+        Production callers leave ``deps`` ``None`` and the defaults wire
+        to ``kairix._azure``; tests pass ``LLMBackendDeps(chat=...)``.
+        """
+        self._deps = deps if deps is not None else LLMBackendDeps()
 
     def chat(self, messages: list[dict[str, Any]], max_tokens: int = 800) -> str:
         """Chat completion via Azure OpenAI (gpt-4o-mini by default)."""
-        if self._chat_fn is not None:
-            return self._chat_fn(messages, max_tokens=max_tokens)
-        from kairix._azure import chat_completion
-
-        result: str = chat_completion(messages, max_tokens=max_tokens)
-        return result
+        return self._deps.chat(messages, max_tokens=max_tokens)
 
     def embed(self, text: str) -> list[float]:
         """Text embedding via Azure OpenAI (text-embedding-3-large)."""
-        if self._embed_fn is not None:
-            return self._embed_fn(text)
-        from kairix._azure import embed_text
-
-        result: list[float] = embed_text(text)
-        return result
+        return self._deps.embed(text)

--- a/kairix/platform/onboard/check.py
+++ b/kairix/platform/onboard/check.py
@@ -40,20 +40,41 @@ class CheckResult:
     fix: str | None = field(default=None)
 
 
+def _default_is_docker() -> bool:
+    """Production ``is_docker`` — defers to ``kairix.paths._is_docker``."""
+    from kairix.paths import _is_docker as _impl
+
+    return _impl()
+
+
+@dataclass
+class OnboardChecksDeps:
+    """Injectable dependencies for the onboard health checks.
+
+    Each field defaults to a production implementation; tests construct
+    ``OnboardChecksDeps(which=fake_which, is_docker=lambda: True)``
+    rather than threading per-check ``*_fn=None`` substitution kwargs
+    through the public health-check signatures.
+    """
+
+    which: Callable[[str], str | None] = field(default_factory=lambda: shutil.which)
+    is_docker: Callable[[], bool] = field(default_factory=lambda: _default_is_docker)
+
+
 # ---------------------------------------------------------------------------
 # Individual checks
 # ---------------------------------------------------------------------------
 
 
-def check_kairix_on_path(which_fn: Callable[[str], str | None] | None = None) -> CheckResult:
+def check_kairix_on_path(deps: OnboardChecksDeps | None = None) -> CheckResult:
     """kairix is findable via PATH.
 
-    ``which_fn`` is a DI seam (defaults to ``shutil.which``); tests pass
-    a callable returning the desired result so PATH doesn't need mutating.
+    ``deps.which`` is the DI seam (defaults to ``shutil.which``); tests
+    pass a ``OnboardChecksDeps`` with a callable returning the desired
+    result so the live PATH never needs mutating.
     """
-    if which_fn is None:
-        which_fn = shutil.which
-    path = which_fn("kairix")
+    d = deps if deps is not None else OnboardChecksDeps()
+    path = d.which("kairix")
     if path is None:
         return CheckResult(
             name="kairix_on_path",
@@ -68,31 +89,23 @@ def check_kairix_on_path(which_fn: Callable[[str], str | None] | None = None) ->
     return CheckResult(name="kairix_on_path", ok=True, detail=f"kairix found at {path}")
 
 
-def check_wrapper_installed(
-    is_docker_fn: Callable[[], bool] | None = None,
-    which_fn: Callable[[str], str | None] | None = None,
-) -> CheckResult:
+def check_wrapper_installed(deps: OnboardChecksDeps | None = None) -> CheckResult:
     """The kairix symlink points to a shell wrapper, not the raw Python binary.
 
-    ``is_docker_fn`` and ``which_fn`` are DI seams; production callers leave
-    them ``None`` and the implementation defaults to the kairix paths helper
+    ``deps.is_docker`` and ``deps.which`` are the DI seams; production
+    callers leave ``deps=None`` and defaults wire to ``kairix.paths._is_docker``
     and ``shutil.which``.
     """
-    if is_docker_fn is None:
-        from kairix.paths import _is_docker as _default_is_docker
+    d = deps if deps is not None else OnboardChecksDeps()
 
-        is_docker_fn = _default_is_docker
-    if which_fn is None:
-        which_fn = shutil.which
-
-    if is_docker_fn():
+    if d.is_docker():
         return CheckResult(
             name="wrapper_installed",
             ok=True,
             detail="Running in Docker — wrapper check skipped (pip install in image)",
         )
 
-    path = which_fn("kairix")
+    path = d.which("kairix")
     if path is None:
         return CheckResult(
             name="wrapper_installed",

--- a/tests/bdd/steps/onboard_steps.py
+++ b/tests/bdd/steps/onboard_steps.py
@@ -1,8 +1,8 @@
 """Step definitions for onboard_check.feature.
 
 Drives ``check_kairix_on_path`` and ``check_secrets_loaded`` through their
-public DI seams (``which_fn`` and ``env`` kwargs) — no monkeypatch on
-``os.environ`` or ``shutil.which``.
+public DI seams (``OnboardChecksDeps`` and ``env`` kwarg) — no monkeypatch
+on ``os.environ`` or ``shutil.which``.
 """
 
 import sqlite3
@@ -12,6 +12,7 @@ from pytest_bdd import given, then, when
 
 from kairix.platform.onboard.check import (
     CheckResult,
+    OnboardChecksDeps,
     check_kairix_on_path,
     check_secrets_loaded,
 )
@@ -28,13 +29,13 @@ def kairix_with_credentials():
         "KAIRIX_LLM_ENDPOINT": "https://test.openai.azure.com/",
     }
     # Pretend `kairix` is installed at /usr/local/bin/kairix for the on-path check.
-    _state["which_fn"] = lambda name: f"/usr/local/bin/{name}" if name == "kairix" else None
+    _state["which"] = lambda name: f"/usr/local/bin/{name}" if name == "kairix" else None
 
 
 @given("kairix is installed without API credentials")
 def kairix_without_credentials():
     _state["env"] = {}  # no KAIRIX_LLM_* keys, no KAIRIX_SECRETS_FILE
-    _state["which_fn"] = lambda name: f"/usr/local/bin/{name}" if name == "kairix" else None
+    _state["which"] = lambda name: f"/usr/local/bin/{name}" if name == "kairix" else None
 
 
 @given("documents are indexed")
@@ -65,7 +66,8 @@ def documents_indexed(tmp_path):
 @when("I run onboard check")
 def run_onboard_check(tmp_path):
     env = _state.get("env", {})
-    which_fn = _state.get("which_fn", lambda _name: None)
+    which = _state.get("which", lambda _name: None)
+    deps = OnboardChecksDeps(which=which)
 
     doc_root_setting = env.get("KAIRIX_DOCUMENT_ROOT", "")
     if doc_root_setting:
@@ -78,7 +80,7 @@ def run_onboard_check(tmp_path):
         doc_root_fix = "Set KAIRIX_DOCUMENT_ROOT or create ~/kairix-vault/"
 
     _state["check_results"] = {
-        "kairix_on_path": check_kairix_on_path(which_fn=which_fn),
+        "kairix_on_path": check_kairix_on_path(deps=deps),
         "secrets_loaded": check_secrets_loaded(env=env),
         "document_root_configured": CheckResult(
             name="document_root_configured",

--- a/tests/contradict/test_detector.py
+++ b/tests/contradict/test_detector.py
@@ -15,6 +15,7 @@ from typing import Any
 import pytest
 
 from kairix.knowledge.contradict.detector import (
+    ContradictDetectorDeps,
     ContradictionResult,
     check_contradiction,
 )
@@ -68,6 +69,16 @@ def _llm_response(score: float, reason: str = "test reason") -> str:
     return json.dumps({"score": score, "reason": reason})
 
 
+def _deps_with_search(search: Any, scorer: Any | None = None) -> ContradictDetectorDeps:
+    """Build a ContradictDetectorDeps using the given search/scorer.
+
+    The default extractor is left in place; ``scorer`` is optional so callers
+    that want the production composite scorer (built lazily from llm) can
+    pass ``None``.
+    """
+    return ContradictDetectorDeps(search=search, scorer=scorer)
+
+
 # ---------------------------------------------------------------------------
 # check_contradiction — exercises parse_llm_score's response-parsing branches
 # through the public surface. Each malformed/edge-case LLM response is fed
@@ -94,7 +105,7 @@ def test_unparseable_llm_response_yields_no_contradiction(raw_response: str) -> 
     parse_llm_score's failure branches through the public surface."""
     llm = FakeLLMBackend(chat_response=raw_response)
     bundles = [_make_search_result("doc.md", "candidate")]
-    results = check_contradiction("claim", llm=llm, threshold=0.5, search_fn=_fake_search(bundles))
+    results = check_contradiction("claim", llm=llm, threshold=0.5, deps=_deps_with_search(_fake_search(bundles)))
     assert results == []
 
 
@@ -103,21 +114,38 @@ def test_score_above_one_is_clamped_to_one() -> None:
     """parse_llm_score clamps to [0.0, 1.0]. Observed via the resulting score."""
     llm = FakeLLMBackend(chat_response='{"score": 1.5, "reason": "extreme"}')
     bundles = [_make_search_result("doc.md", "candidate")]
-    results = check_contradiction("claim", llm=llm, threshold=0.0, search_fn=_fake_search(bundles))
+    results = check_contradiction("claim", llm=llm, threshold=0.0, deps=_deps_with_search(_fake_search(bundles)))
     assert len(results) == 1
     assert results[0].score == pytest.approx(1.0)
 
 
 @pytest.mark.unit
 def test_score_below_zero_is_clamped_to_zero() -> None:
-    """Negative scores clamp to 0.0; below threshold → no result."""
+    """Negative scores clamp to 0.0; threshold=0.5 drops them entirely."""
     llm = FakeLLMBackend(chat_response='{"score": -0.3, "reason": "negative"}')
     bundles = [_make_search_result("doc.md", "candidate")]
-    # threshold=0 admits 0.0; the result should be present with score=0.
-    results = check_contradiction("claim", llm=llm, threshold=0.0, search_fn=_fake_search(bundles))
-    # Score below threshold>0 would drop the result — this just asserts the clamp.
-    if results:
-        assert results[0].score == pytest.approx(0.0)
+    # Use a non-zero threshold so the clamp can be observed: clamped 0.0
+    # is below 0.5, so the candidate must be dropped. (Sabotage-prove:
+    # if the clamp returned -0.3 unchanged, it would still be < 0.5
+    # so this assertion alone wouldn't catch the bug — see the partner
+    # test below.)
+    results = check_contradiction("claim", llm=llm, threshold=0.5, deps=_deps_with_search(_fake_search(bundles)))
+    assert results == []
+
+
+@pytest.mark.unit
+def test_score_below_zero_clamp_admits_at_threshold_zero() -> None:
+    """Negative scores clamp to 0.0; with threshold=0.0 the result IS admitted at score=0.0.
+
+    Partner to the above test — if the clamp didn't fire (i.e. -0.3 leaked
+    through), the result would still be admitted but with score=-0.3,
+    which this assertion catches.
+    """
+    llm = FakeLLMBackend(chat_response='{"score": -0.3, "reason": "negative"}')
+    bundles = [_make_search_result("doc.md", "candidate")]
+    results = check_contradiction("claim", llm=llm, threshold=0.0, deps=_deps_with_search(_fake_search(bundles)))
+    assert len(results) == 1
+    assert results[0].score == pytest.approx(0.0)
 
 
 @pytest.mark.unit
@@ -127,7 +155,7 @@ def test_json_with_preamble_parses_correctly() -> None:
         chat_response='Here is my assessment: {"score": 0.7, "reason": "contradicts existing record"}',
     )
     bundles = [_make_search_result("doc.md", "candidate")]
-    results = check_contradiction("claim", llm=llm, threshold=0.5, search_fn=_fake_search(bundles))
+    results = check_contradiction("claim", llm=llm, threshold=0.5, deps=_deps_with_search(_fake_search(bundles)))
     assert len(results) == 1
     assert results[0].score == pytest.approx(0.7)
     assert "contradicts" in results[0].reason.lower()
@@ -142,7 +170,11 @@ def test_json_with_preamble_parses_correctly() -> None:
 def test_check_contradiction_returns_empty_on_search_failure() -> None:
     """Returns [] when hybrid search raises an exception."""
     llm = FakeLLMBackend()
-    results = check_contradiction("some claim", llm=llm, search_fn=_failing_search(RuntimeError("no db")))
+    results = check_contradiction(
+        "some claim",
+        llm=llm,
+        deps=_deps_with_search(_failing_search(RuntimeError("no db"))),
+    )
     assert results == []
 
 
@@ -152,7 +184,7 @@ def test_check_contradiction_returns_empty_when_no_results_above_threshold() -> 
     llm = FakeLLMBackend(chat_response=_llm_response(0.2))  # well below default threshold 0.6
 
     bundles = [_make_search_result("a/doc.md", "some content")]
-    results = check_contradiction("new claim", llm=llm, search_fn=_fake_search(bundles))
+    results = check_contradiction("new claim", llm=llm, deps=_deps_with_search(_fake_search(bundles)))
     assert results == []
 
 
@@ -166,7 +198,7 @@ def test_check_contradiction_returns_result_above_threshold() -> None:
         "The project launched in Q3.",
         llm=llm,
         threshold=0.6,
-        search_fn=_fake_search(bundles),
+        deps=_deps_with_search(_fake_search(bundles)),
     )
     assert len(results) == 1
     r = results[0]
@@ -195,8 +227,7 @@ def test_check_contradiction_respects_top_k() -> None:
         llm=llm,
         top_k=3,
         threshold=0.0,
-        search_fn=_fake_search(bundles),
-        scorer=scorer,
+        deps=ContradictDetectorDeps(search=_fake_search(bundles), scorer=scorer),
     )
     # Only 3 LLM calls should have been made (3 unique candidates x 1 scorer)
     assert len(llm.chat_calls) == 3
@@ -215,7 +246,7 @@ def test_check_contradiction_sorts_by_score_descending() -> None:
     )
 
     bundles = [_make_search_result(f"doc{i}.md", "content") for i in range(3)]
-    results = check_contradiction("claim", llm=llm, threshold=0.0, search_fn=_fake_search(bundles))
+    results = check_contradiction("claim", llm=llm, threshold=0.0, deps=_deps_with_search(_fake_search(bundles)))
     scores = [r.score for r in results]
     assert scores == sorted(scores, reverse=True)
     assert scores[0] == pytest.approx(0.9)
@@ -262,8 +293,7 @@ def test_check_contradiction_handles_llm_exception() -> None:
         "claim",
         llm=llm,
         threshold=0.5,
-        search_fn=_fake_search(bundles),
-        scorer=scorer,
+        deps=ContradictDetectorDeps(search=_fake_search(bundles), scorer=scorer),
     )
     assert len(results) == 1
     assert results[0].doc_path == "ok.md"
@@ -273,7 +303,7 @@ def test_check_contradiction_handles_llm_exception() -> None:
 def test_check_contradiction_no_search_results() -> None:
     """Returns [] when search returns no results."""
     llm = FakeLLMBackend()
-    results = check_contradiction("claim", llm=llm, search_fn=_fake_search([]))
+    results = check_contradiction("claim", llm=llm, deps=_deps_with_search(_fake_search([])))
     assert results == []
     assert len(llm.chat_calls) == 0
 
@@ -300,5 +330,5 @@ def test_check_contradiction_snippet_truncated_to_300_chars() -> None:
 
     long_content = "X" * 1000
     bundles = [_make_search_result("doc.md", long_content)]
-    results = check_contradiction("claim", llm=llm, threshold=0.0, search_fn=_fake_search(bundles))
+    results = check_contradiction("claim", llm=llm, threshold=0.0, deps=_deps_with_search(_fake_search(bundles)))
     assert len(results[0].snippet) <= 300

--- a/tests/llm/test_backends.py
+++ b/tests/llm/test_backends.py
@@ -1,7 +1,7 @@
 """
 Tests for kairix.platform.llm — LLM backend abstraction (P1-2).
 
-Uses injected callables via AzureOpenAIBackend constructor — no monkey-patching needed.
+Uses ``LLMBackendDeps`` for dependency injection — no monkey-patching needed.
 """
 
 from __future__ import annotations
@@ -9,6 +9,7 @@ from __future__ import annotations
 import pytest
 
 from kairix.platform.llm import AzureOpenAIBackend, get_default_backend
+from kairix.platform.llm.backends import LLMBackendDeps
 from kairix.platform.llm.protocol import LLMBackend
 from tests.fakes import FakeLLMBackend
 
@@ -42,7 +43,7 @@ def test_azure_backend_chat_delegates_to_injected_fn() -> None:
         calls.append((messages, max_tokens))
         return "Hi there"
 
-    backend = AzureOpenAIBackend(chat_fn=fake_chat)
+    backend = AzureOpenAIBackend(deps=LLMBackendDeps(chat=fake_chat))
     messages = [{"role": "user", "content": "Hello"}]
     result = backend.chat(messages, max_tokens=100)
 
@@ -59,7 +60,7 @@ def test_azure_backend_chat_default_max_tokens() -> None:
         calls.append(max_tokens)
         return "ok"
 
-    backend = AzureOpenAIBackend(chat_fn=fake_chat)
+    backend = AzureOpenAIBackend(deps=LLMBackendDeps(chat=fake_chat))
     backend.chat([{"role": "user", "content": "test"}])
 
     assert calls[0] == 800
@@ -68,21 +69,21 @@ def test_azure_backend_chat_default_max_tokens() -> None:
 @pytest.mark.unit
 def test_azure_backend_embed_delegates_to_injected_fn() -> None:
     expected = [0.1, 0.2, 0.3]
-    backend = AzureOpenAIBackend(embed_fn=lambda text: expected)
+    backend = AzureOpenAIBackend(deps=LLMBackendDeps(embed=lambda text: expected))
     result = backend.embed("some text")
     assert result == expected
 
 
 @pytest.mark.unit
 def test_azure_backend_chat_returns_empty_string_on_failure() -> None:
-    backend = AzureOpenAIBackend(chat_fn=lambda msgs, max_tokens=800: "")
+    backend = AzureOpenAIBackend(deps=LLMBackendDeps(chat=lambda msgs, max_tokens=800: ""))
     result = backend.chat([{"role": "user", "content": "test"}])
     assert result == ""
 
 
 @pytest.mark.unit
 def test_azure_backend_embed_returns_empty_list_on_failure() -> None:
-    backend = AzureOpenAIBackend(embed_fn=lambda text: [])
+    backend = AzureOpenAIBackend(deps=LLMBackendDeps(embed=lambda text: []))
     result = backend.embed("text")
     assert result == []
 
@@ -99,7 +100,7 @@ def _do_summarise(text: str, llm: LLMBackend) -> str:
 
 @pytest.mark.unit
 def test_caller_accepts_protocol_type() -> None:
-    backend = AzureOpenAIBackend(chat_fn=lambda msgs, max_tokens=800: "Summary.")
+    backend = AzureOpenAIBackend(deps=LLMBackendDeps(chat=lambda msgs, max_tokens=800: "Summary."))
     result = _do_summarise("long document", backend)
     assert result == "Summary."
 

--- a/tests/onboard/test_check.py
+++ b/tests/onboard/test_check.py
@@ -10,6 +10,7 @@ import pytest
 
 from kairix.platform.onboard.check import (
     CheckResult,
+    OnboardChecksDeps,
     check_document_root_configured,
     check_neo4j_reachable,
     check_secrets_loaded,
@@ -49,7 +50,7 @@ class _FakeNeo4jClient:
 @pytest.mark.unit
 def test_wrapper_check_skipped_in_docker() -> None:
     """In Docker, wrapper_installed check returns ok=True without probing the binary."""
-    result = check_wrapper_installed(is_docker_fn=lambda: True)
+    result = check_wrapper_installed(deps=OnboardChecksDeps(is_docker=lambda: True))
     assert result.ok is True
     assert "Docker" in result.detail
 

--- a/tests/summaries/test_generate.py
+++ b/tests/summaries/test_generate.py
@@ -163,23 +163,19 @@ def test_generate_l1_uses_first_2000_words():
 
 
 @pytest.mark.unit
-def test_generate_summaries_with_l1():
+def test_generate_summaries_with_l1(tmp_path):
     """generate_summaries with include_l1=True produces both L0 and L1 per file."""
-    import tempfile
-    from pathlib import Path as _P
+    p = tmp_path / "doc.md"
+    p.write_text("Hello world content about testing.")
 
-    with tempfile.TemporaryDirectory() as td:
-        p = _P(td) / "doc.md"
-        p.write_text("Hello world content about testing.")
-
-        result = generate_summaries(
-            [str(p)],
-            api_key="k",
-            endpoint="https://ep",
-            include_l1=True,
-            sleep_ms=0,
-            deps=SummariesDeps(chat=lambda msgs, max_tokens=150: "L0/L1 stub."),
-        )
+    result = generate_summaries(
+        [str(p)],
+        api_key="k",
+        endpoint="https://ep",
+        include_l1=True,
+        sleep_ms=0,
+        deps=SummariesDeps(chat=lambda msgs, max_tokens=150: "L0/L1 stub."),
+    )
 
     assert len(result) == 1
     assert result[0].l0 == "L0/L1 stub."

--- a/tests/summaries/test_generate.py
+++ b/tests/summaries/test_generate.py
@@ -1,12 +1,13 @@
 """
 Tests for kairix.knowledge.summaries.generate
 
-Uses chat_fn parameter for dependency injection — no monkey-patching needed.
+Uses ``SummariesDeps(chat=...)`` for dependency injection — no monkey-patching needed.
 """
 
 import pytest
 
 from kairix.knowledge.summaries.generate import (
+    SummariesDeps,
     _first_n_words,
     generate_l0,
     generate_summaries,
@@ -27,7 +28,7 @@ def test_generate_l0_returns_string():
         content="Some content about Azure Key Vault.",
         api_key="test-key",
         endpoint="https://test.openai.azure.com",
-        chat_fn=lambda msgs, max_tokens=150: expected,
+        deps=SummariesDeps(chat=lambda msgs, max_tokens=150: expected),
     )
 
     assert result == expected
@@ -50,10 +51,10 @@ def test_generate_l0_uses_first_800_words():
         content=long_content,
         api_key="k",
         endpoint="https://ep",
-        chat_fn=capture_chat,
+        deps=SummariesDeps(chat=capture_chat),
     )
 
-    assert captured_messages, "chat_fn was not called"
+    assert captured_messages, "chat callable was not invoked"
     user_msg = captured_messages[0][1]["content"]
     # Should contain word_799 but NOT word_800
     assert "word_799" in user_msg
@@ -83,7 +84,7 @@ def test_first_n_words_empty():
 
 
 # ---------------------------------------------------------------------------
-# generate_summaries (integration-level mock)
+# generate_summaries (integration-level via injected fake chat)
 # ---------------------------------------------------------------------------
 
 
@@ -98,8 +99,14 @@ def test_generate_summaries_returns_list(tmp_path):
         [str(tmp_path / "a.md"), str(tmp_path / "b.md")],
         api_key="k",
         endpoint="https://ep",
-        chat_fn=lambda msgs, max_tokens=150: "Summary text.",
+        sleep_ms=0,  # keep the test fast — sleep path is exercised elsewhere
+        deps=SummariesDeps(chat=lambda msgs, max_tokens=150: "Summary text."),
     )
 
     assert isinstance(result, list)
     assert len(result) == 2
+    # Sabotage-prove: assert the chat-injected content actually flowed through.
+    # If deps wasn't honoured, the production _default_chat would have been
+    # invoked and raised on missing Azure credentials — so this also locks
+    # in that we never reach the production callable in the test path.
+    assert all(r.l0 == "Summary text." for r in result)

--- a/tests/summaries/test_generate.py
+++ b/tests/summaries/test_generate.py
@@ -110,3 +110,17 @@ def test_generate_summaries_returns_list(tmp_path):
     # invoked and raised on missing Azure credentials — so this also locks
     # in that we never reach the production callable in the test path.
     assert all(r.l0 == "Summary text." for r in result)
+
+
+@pytest.mark.unit
+def test_summaries_deps_default_factory_returns_default_chat():
+    """SummariesDeps() (no kwargs) wires .chat to default_chat via default_factory.
+
+    Sabotage-prove: identity check, not just callable. Swapping the lambda
+    body to `lambda: lambda *a, **k: ""` would silently pass a `callable()`
+    check; identity to `default_chat` makes substitution impossible.
+    """
+    from kairix.knowledge.summaries.generate import default_chat
+
+    deps = SummariesDeps()
+    assert deps.chat is default_chat

--- a/tests/summaries/test_generate.py
+++ b/tests/summaries/test_generate.py
@@ -10,6 +10,7 @@ from kairix.knowledge.summaries.generate import (
     SummariesDeps,
     _first_n_words,
     generate_l0,
+    generate_l1,
     generate_summaries,
 )
 
@@ -124,3 +125,93 @@ def test_summaries_deps_default_factory_returns_default_chat():
 
     deps = SummariesDeps()
     assert deps.chat is default_chat
+
+
+@pytest.mark.unit
+def test_generate_l1_returns_string():
+    """generate_l1 returns the structured overview from the chat callable."""
+    expected = "Topic: testing.\nKey points: alpha, beta.\nStatus: stable."
+    overview = generate_l1(
+        path="docs/test.md",
+        content="Hello world content.",
+        api_key="k",
+        endpoint="https://ep",
+        deps=SummariesDeps(chat=lambda msgs, max_tokens=600: expected),
+    )
+    assert overview == expected
+
+
+@pytest.mark.unit
+def test_generate_l1_uses_first_2000_words():
+    """generate_l1 truncates content to the first 2000 words before sending."""
+    long_content = "word " * 5000
+    captured: dict = {}
+
+    def capture_chat(messages: list[dict], max_tokens: int = 600) -> str:
+        captured["msg"] = messages[1]["content"]
+        return "ok"
+
+    generate_l1(
+        path="docs/long.md",
+        content=long_content,
+        api_key="k",
+        endpoint="https://ep",
+        deps=SummariesDeps(chat=capture_chat),
+    )
+    word_count = captured["msg"].count("word")
+    assert word_count <= 2010  # 2000 + a few from the prompt boilerplate
+
+
+@pytest.mark.unit
+def test_generate_summaries_with_l1():
+    """generate_summaries with include_l1=True produces both L0 and L1 per file."""
+    import tempfile
+    from pathlib import Path as _P
+
+    with tempfile.TemporaryDirectory() as td:
+        p = _P(td) / "doc.md"
+        p.write_text("Hello world content about testing.")
+
+        result = generate_summaries(
+            [str(p)],
+            api_key="k",
+            endpoint="https://ep",
+            include_l1=True,
+            sleep_ms=0,
+            deps=SummariesDeps(chat=lambda msgs, max_tokens=150: "L0/L1 stub."),
+        )
+
+    assert len(result) == 1
+    assert result[0].l0 == "L0/L1 stub."
+    assert result[0].l1 == "L0/L1 stub."  # same fake returns same content
+
+
+@pytest.mark.unit
+def test_generate_summaries_skips_missing_file(caplog):
+    """Missing files are warned and skipped — never raise."""
+    result = generate_summaries(
+        ["/nonexistent/path.md"],
+        api_key="k",
+        endpoint="https://ep",
+        sleep_ms=0,
+        deps=SummariesDeps(chat=lambda msgs, max_tokens=150: "ignored"),
+    )
+    assert result == []
+
+
+@pytest.mark.unit
+def test_generate_summaries_logs_per_file_failure(caplog, tmp_path):
+    """Per-file failure: chat raises → logged, skipped, never propagated."""
+    (tmp_path / "boom.md").write_text("content")
+
+    def boom(msgs: list[dict], max_tokens: int = 150) -> str:
+        raise RuntimeError("simulated chat failure")
+
+    result = generate_summaries(
+        [str(tmp_path / "boom.md")],
+        api_key="k",
+        endpoint="https://ep",
+        sleep_ms=0,
+        deps=SummariesDeps(chat=boom),
+    )
+    assert result == []


### PR DESCRIPTION
## Summary

Resolves the F6 (`*_fn=None` test-only kwargs in production) violation in 4 of the 12 files tracked by issue #199, using the canonical `BenchmarkDeps` pattern (#195) — a typed dataclass with `field(default_factory=...)` for production wiring instead of `Optional[Callable]` + `__post_init__` self-resolution.

### Files

- `kairix/knowledge/contradict/detector.py` — `search_fn` / `scorer` / `extractor` collapse into `ContradictDetectorDeps(search=, scorer=, extractor=)`.
- `kairix/knowledge/summaries/generate.py` — `chat_fn` on `_call_chat` / `generate_l0` / `generate_l1` / `generate_summaries` collapses into `SummariesDeps(chat=...)`. A module-level `_default_chat` wraps `kairix._azure.chat_completion` so the dataclass has a stable typed default.
- `kairix/platform/llm/backends.py` — `AzureOpenAIBackend(chat_fn=, embed_fn=)` collapses into `AzureOpenAIBackend(deps=LLMBackendDeps(chat=, embed=))`.
- `kairix/platform/onboard/check.py` — `check_kairix_on_path(which_fn=)` and `check_wrapper_installed(is_docker_fn=, which_fn=)` collapse into `OnboardChecksDeps(which=, is_docker=)`.

All four files removed from `.architecture/baseline/no-test-only-kwargs-files.txt` (baseline 12 → 8).

### Tests updated

- `tests/contradict/test_detector.py` — every `check_contradiction(..., search_fn=...)` call now passes `deps=ContradictDetectorDeps(search=...)`. Added a sabotage-prove partner test for the score-clamp behaviour (the original `if results: assert` formulation passed in both directions; the new pair fails if the clamp leaks).
- `tests/summaries/test_generate.py` — every `generate_*(..., chat_fn=...)` call now passes `deps=SummariesDeps(chat=...)`. Sabotage-prove assertion added that the injected chat content actually flows through.
- `tests/llm/test_backends.py` — every `AzureOpenAIBackend(chat_fn=..., embed_fn=...)` call now passes `deps=LLMBackendDeps(...)`.
- `tests/onboard/test_check.py` — `check_wrapper_installed(is_docker_fn=...)` becomes `check_wrapper_installed(deps=OnboardChecksDeps(is_docker=...))`.
- `tests/bdd/steps/onboard_steps.py` — `which_fn` state key renamed to `which`; the step constructs `OnboardChecksDeps(which=...)` once and passes it to `check_kairix_on_path`.

## Test plan

- [x] `pytest tests/contradict/ tests/summaries/ tests/llm/ tests/onboard/` — 80 passed
- [x] `pytest tests/bdd/ -k onboard` — 2 passed (BDD parity verified)
- [x] `mypy --strict` clean on all four target files (no `assert deps.x is not None` ladders introduced — `default_factory` everywhere except the lazily-built `ContradictDetectorDeps.scorer`, which is intentionally None until the LLM is bound at call time)
- [x] `bash scripts/safe-commit.sh` green (3184 tests, all arch fitness gates including F6, secrets, confidential)
- [x] `pre-commit run --all-files` green
- [x] F6 baseline drops 12 → 8 verified by running `python3 scripts/checks/check_no_test_only_kwargs.py`

Part of #199. Sibling agents own the remaining 8 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)