### PR TITLE
feat(arch): F6 — convert briefing/research/config_loader to typed Deps (#199 4/12)

### DIFF
--- a/.architecture/baseline/no-test-only-kwargs-files.txt
+++ b/.architecture/baseline/no-test-only-kwargs-files.txt
@@ -1,7 +1,3 @@
-kairix/agents/briefing/pipeline.py
-kairix/agents/research/graph.py
-kairix/agents/research/nodes.py
-kairix/core/search/config_loader.py
 kairix/knowledge/contradict/detector.py
 kairix/knowledge/summaries/generate.py
 kairix/platform/llm/backends.py

--- a/kairix/agents/briefing/pipeline.py
+++ b/kairix/agents/briefing/pipeline.py
@@ -30,6 +30,36 @@ from kairix.text import estimate_tokens, truncate_to_tokens
 
 logger = logging.getLogger(__name__)
 
+
+def _default_synthesise() -> Callable[..., str]:
+    """Return the production synthesiser. Lazy import breaks the module cycle."""
+    from kairix.agents.briefing.synthesiser import synthesise
+
+    return synthesise
+
+
+def _default_write_briefing() -> Callable[..., Path]:
+    """Return the production writer. Lazy import breaks the module cycle."""
+    from kairix.agents.briefing.writer import write_briefing
+
+    return write_briefing
+
+
+@dataclass
+class BriefingDeps:
+    """Injectable dependencies for ``generate_briefing``.
+
+    Each field defaults to the production implementation via
+    ``default_factory`` — fields are typed as concrete callables so mypy
+    sees a real type at every call site (no ``assert deps.x is not None``
+    ladder). Tests construct ``BriefingDeps(synthesise_fn=fake, ...)`` to
+    swap individual collaborators.
+    """
+
+    synthesise_fn: Callable[..., str] = field(default_factory=_default_synthesise)
+    write_fn: Callable[..., Path] = field(default_factory=_default_write_briefing)
+
+
 # Token caps per source (approximate)
 _SOURCE_TOKEN_CAPS: dict[str, int] = {
     "memory_logs": 500,
@@ -96,8 +126,7 @@ def _trim_context(context: dict[str, str]) -> dict[str, str]:
 def generate_briefing(
     agent: str,
     *,
-    synthesise_fn: Callable[..., str] | None = None,
-    write_fn: Callable[..., Path] | None = None,
+    deps: BriefingDeps | None = None,
     sources: dict[str, Callable] | None = None,
     output_dir: Path | None = None,
 ) -> str:
@@ -110,20 +139,21 @@ def generate_briefing(
     8:   Write to file
 
     Args:
-        agent:         Agent name (e.g. "builder", "shape").
-        synthesise_fn: Optional replacement for the LLM synthesis step.
-                       Signature: (agent, context, max_tokens=800) -> str.
-        write_fn:      Optional replacement for the file writer step.
-                       Signature: (agent, content, sources_count, token_estimate) -> Path.
+        agent:      Agent name (e.g. "builder", "shape").
+        deps:       Injectable dependencies (synthesise_fn, write_fn).
+                    Production callers leave None — the dataclass wires
+                    real implementations via ``default_factory``. Tests
+                    construct ``BriefingDeps(synthesise_fn=fake, ...)``.
+        sources:    Per-source callable overrides (key = source name).
+        output_dir: Optional output directory override (currently unused
+                    by this function; reserved for future).
 
     Returns:
         Full briefing content (with header). Never raises.
     """
-    from kairix.agents.briefing.synthesiser import synthesise as _default_synthesise
-    from kairix.agents.briefing.writer import write_briefing as _default_write
-
-    synthesise = synthesise_fn or _default_synthesise
-    write_briefing = write_fn or _default_write
+    d = deps or BriefingDeps()
+    synthesise = d.synthesise_fn
+    write_briefing = d.write_fn
 
     t_start = time.monotonic()
     logger.info("pipeline: generating briefing for agent %r", agent)
@@ -281,18 +311,15 @@ class BriefingPipeline:
     for each agent.
 
     Attributes:
-        sources:        Per-source callable overrides (key = source name).
-        synthesise_fn:  LLM synthesis callable. Signature:
-                        (agent, context, max_tokens=800) -> str.
-        write_fn:       File writer callable. Signature:
-                        (agent, content, sources_count, token_estimate) -> Path.
-        output_dir:     Optional output directory override (unused by
-                        generate_briefing today, reserved for future).
+        sources:    Per-source callable overrides (key = source name).
+        deps:       Injectable dependencies (synthesise_fn, write_fn).
+                    Defaults to production implementations.
+        output_dir: Optional output directory override (unused by
+                    generate_briefing today, reserved for future).
     """
 
     sources: dict[str, Callable] = field(default_factory=dict)
-    synthesise_fn: Callable[..., str] | None = None
-    write_fn: Callable[..., Path] | None = None
+    deps: BriefingDeps = field(default_factory=BriefingDeps)
     output_dir: Path | None = None
 
     def generate(self, agent: str) -> str:
@@ -309,8 +336,7 @@ class BriefingPipeline:
         """
         return generate_briefing(
             agent=agent,
-            synthesise_fn=self.synthesise_fn,
-            write_fn=self.write_fn,
+            deps=self.deps,
             sources=self.sources if self.sources else None,
             output_dir=self.output_dir,
         )

--- a/kairix/agents/research/graph.py
+++ b/kairix/agents/research/graph.py
@@ -7,9 +7,13 @@ finds a good answer or runs out of turns.
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
 from typing import Any
 
 from kairix.agents.research.nodes import (
+    ClassifyIntentDeps,
+    RetrieveDeps,
     classify_intent,
     evaluate_sufficiency,
     refine_query,
@@ -22,21 +26,65 @@ from kairix.agents.research.state import DEFAULT_MAX_TURNS, ResearcherState
 logger = logging.getLogger(__name__)
 
 
+def _default_classify() -> Callable[..., Any]:
+    """Lazy production import for intent classification."""
+    from kairix.core.search.intent import classify
+
+    return classify
+
+
+def _default_search() -> Callable[..., Any]:
+    """Lazy production import for the search pipeline.
+
+    Wraps ``build_search_pipeline().search`` in a closure so the pipeline
+    is constructed lazily (and cached implicitly through Python's import
+    machinery for the call shape we expose to the graph).
+    """
+
+    def _search(**kwargs: Any) -> Any:
+        from kairix.core.factory import build_search_pipeline
+
+        return build_search_pipeline().search(**kwargs)
+
+    return _search
+
+
+@dataclass
+class ResearchGraphDeps:
+    """Injectable dependencies for the research graph.
+
+    All fields are typed as concrete callables/objects (no ``Optional``) so
+    mypy sees a real type at every call site. Production callers leave deps
+    None — the dataclass wires real implementations via ``default_factory``.
+    Tests construct ``ResearchGraphDeps(search_fn=fake, ...)``.
+
+    Attributes:
+        search_fn:         Search callable. Signature: (query=, budget=) -> SearchResult.
+        classify_fn:       Intent classifier callable. Signature: (query) -> QueryIntent.
+        llm_backend:       LLM backend object exposing ``.chat(messages, max_tokens=)``.
+                           ``None`` means the nodes lazy-load the default backend.
+        confidence_parser: ConfidenceParser instance for evaluate_sufficiency.
+                           ``None`` means the node uses the default parser chain.
+    """
+
+    search_fn: Callable[..., Any] = field(default_factory=_default_search)
+    classify_fn: Callable[..., Any] = field(default_factory=_default_classify)
+    # llm_backend and confidence_parser are not test-only-callable kwargs —
+    # they are stateful objects (or absent) and live as plain object slots.
+    llm_backend: Any = None
+    confidence_parser: Any = None
+
+
 def build_researcher_graph(
     *,
-    search_fn: Any | None = None,
-    llm_backend: Any | None = None,
-    classify_fn: Any | None = None,
-    confidence_parser: Any | None = None,
+    deps: ResearchGraphDeps | None = None,
 ) -> Any:
     """Build the LangGraph state machine for iterative research.
 
     Args:
-        search_fn:         Injectable search function (passed to retrieve node).
-        llm_backend:       Injectable LLM backend (passed to evaluate/synthesise nodes).
-        classify_fn:       Injectable intent classifier (passed to classify_intent node).
-        confidence_parser: Injectable ConfidenceParser (passed to evaluate node).
-                           If None, evaluate_sufficiency uses default_confidence_parser_chain().
+        deps: Injectable dependencies (search, classify, llm_backend,
+              confidence_parser). Production callers leave None; tests
+              pass a ``ResearchGraphDeps`` with fakes.
 
     Returns a compiled graph ready to invoke with an initial state.
     """
@@ -44,21 +92,29 @@ def build_researcher_graph(
 
     from langgraph.graph import END, StateGraph
 
+    d = deps or ResearchGraphDeps()
+
     graph = StateGraph(ResearcherState)
 
-    # Add nodes — inject dependencies via partial where provided
-    _classify = partial(classify_intent, classify_fn=classify_fn) if classify_fn else classify_intent
-    _retrieve = partial(retrieve, search_fn=search_fn) if search_fn else retrieve
+    # Add nodes — inject dependencies via partial against typed Deps shapes.
+    _classify = partial(
+        classify_intent,
+        deps=ClassifyIntentDeps(classify_fn=d.classify_fn),
+    )
+    _retrieve = partial(
+        retrieve,
+        deps=RetrieveDeps(search_fn=d.search_fn),
+    )
 
     # evaluate gets both llm_backend and confidence_parser if either is set
     _eval_kwargs: dict[str, Any] = {}
-    if llm_backend is not None:
-        _eval_kwargs["llm_backend"] = llm_backend
-    if confidence_parser is not None:
-        _eval_kwargs["confidence_parser"] = confidence_parser
+    if d.llm_backend is not None:
+        _eval_kwargs["llm_backend"] = d.llm_backend
+    if d.confidence_parser is not None:
+        _eval_kwargs["confidence_parser"] = d.confidence_parser
     _eval = partial(evaluate_sufficiency, **_eval_kwargs) if _eval_kwargs else evaluate_sufficiency
 
-    _synth = partial(synthesise, llm_backend=llm_backend) if llm_backend else synthesise
+    _synth = partial(synthesise, llm_backend=d.llm_backend) if d.llm_backend else synthesise
 
     graph.add_node("classify_intent", _classify)
     graph.add_node("retrieve", _retrieve)
@@ -88,10 +144,7 @@ def run_research(
     query: str,
     max_turns: int = DEFAULT_MAX_TURNS,
     *,
-    search_fn: Any | None = None,
-    llm_backend: Any | None = None,
-    classify_fn: Any | None = None,
-    confidence_parser: Any | None = None,
+    deps: ResearchGraphDeps | None = None,
 ) -> dict[str, Any]:
     """Run a research query through the full iterative search pipeline.
 
@@ -99,24 +152,16 @@ def run_research(
     question, and refines the search if needed — up to max_turns rounds.
 
     Args:
-        query:             The question to research.
-        max_turns:         Maximum search rounds before giving up (default 4).
-        search_fn:         Injectable search function for testing.
-        llm_backend:       Injectable LLM backend for testing.
-        classify_fn:       Injectable intent classifier for testing.
-        confidence_parser: Injectable ConfidenceParser for testing.
+        query:     The question to research.
+        max_turns: Maximum search rounds before giving up (default 4).
+        deps:      Injectable dependencies; production callers leave None.
 
     Returns:
         dict with: query, synthesis, retrieved_chunks, entities_found,
         gaps, confidence, turns, error.
     """
     try:
-        compiled = build_researcher_graph(
-            search_fn=search_fn,
-            llm_backend=llm_backend,
-            classify_fn=classify_fn,
-            confidence_parser=confidence_parser,
-        )
+        compiled = build_researcher_graph(deps=deps)
 
         initial_state: ResearcherState = {
             "query": query,

--- a/kairix/agents/research/nodes.py
+++ b/kairix/agents/research/nodes.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import logging
 from collections.abc import Callable
+from dataclasses import dataclass, field
 from typing import Any
 
 from kairix.agents.research.state import (
@@ -22,33 +23,78 @@ from kairix.agents.research.state import (
 logger = logging.getLogger(__name__)
 
 
-def classify_intent(state: ResearcherState, *, classify_fn: Callable[..., Any] | None = None) -> dict[str, Any]:
+def _default_classify() -> Callable[..., Any]:
+    """Lazy production import for intent classification."""
+    from kairix.core.search.intent import classify
+
+    return classify
+
+
+def _default_search() -> Callable[..., Any]:
+    """Lazy production import for the search pipeline."""
+
+    def _search(**kwargs: Any) -> Any:
+        from kairix.core.factory import build_search_pipeline
+
+        return build_search_pipeline().search(**kwargs)
+
+    return _search
+
+
+@dataclass
+class ClassifyIntentDeps:
+    """Injectable dependencies for ``classify_intent``.
+
+    The single ``classify_fn`` field is typed as a concrete callable so
+    mypy sees a real type at every call site. Tests construct
+    ``ClassifyIntentDeps(classify_fn=fake)``; production callers leave
+    ``deps=None`` and the default factory wires the real classifier.
+    """
+
+    classify_fn: Callable[..., Any] = field(default_factory=_default_classify)
+
+
+@dataclass
+class RetrieveDeps:
+    """Injectable dependencies for ``retrieve``.
+
+    ``search_fn`` is typed as a concrete callable so mypy sees a real type
+    at every call site. Tests construct ``RetrieveDeps(search_fn=fake)``;
+    production callers leave ``deps=None`` and the default factory wires
+    the real search pipeline.
+    """
+
+    search_fn: Callable[..., Any] = field(default_factory=_default_search)
+
+
+def classify_intent(
+    state: ResearcherState,
+    *,
+    deps: ClassifyIntentDeps | None = None,
+) -> dict[str, Any]:
     """Work out what kind of question this is (entity lookup, date-based, etc.).
 
     Args:
-        classify_fn: Injectable intent classifier for testing.
-                     Defaults to ``kairix.core.search.intent.classify``.
+        deps: Injectable dependencies; production callers leave None.
+              Tests pass ``ClassifyIntentDeps(classify_fn=fake)``.
     """
+    d = deps or ClassifyIntentDeps()
     try:
-        if classify_fn is None:
-            from kairix.core.search.intent import classify
-
-            classify_fn = classify
-
-        intent = classify_fn(state["query"])
+        intent = d.classify_fn(state["query"])
         return {"intent": intent.value}
     except Exception as exc:
         logger.warning("research: classify_intent failed — %s", exc)
         return {"intent": "semantic"}
 
 
-def retrieve(state: ResearcherState, *, search_fn: Callable[..., Any] | None = None) -> dict[str, Any]:
+def retrieve(
+    state: ResearcherState,
+    *,
+    deps: RetrieveDeps | None = None,
+) -> dict[str, Any]:
     """Search the knowledge base for answers to the current query."""
-    if search_fn is None:
-        from kairix.core.factory import build_search_pipeline
-
-        _pipeline = build_search_pipeline()
-        search_fn = _pipeline.search
+    d = deps or RetrieveDeps()
+    search_fn = d.search_fn
 
     query = state.get("refined_query") or state["query"]
     turns = state.get("turns", 0)

--- a/kairix/core/search/config_loader.py
+++ b/kairix/core/search/config_loader.py
@@ -448,12 +448,26 @@ def _get_collection_overrides() -> dict[str, dict]:
     return {c.name: c.retrieval_overrides for c in collections_cfg.shared if c.retrieval_overrides}
 
 
+@dataclass
+class ResolveConfigDeps:
+    """Injectable dependencies for ``resolve_retrieval_config``.
+
+    Both fields are typed as concrete callables (no ``Optional``) so mypy
+    sees a real type at every call site. Production callers leave
+    ``deps=None`` — the dataclass wires the real loader and override lookup
+    via ``default_factory``. Tests construct
+    ``ResolveConfigDeps(config_fn=..., overrides_fn=...)``.
+    """
+
+    config_fn: Callable[[], RetrievalConfig] = field(default_factory=lambda: load_config)
+    overrides_fn: Callable[[], dict[str, dict]] = field(default_factory=lambda: _get_collection_overrides)
+
+
 def resolve_retrieval_config(
     collection: str | None = None,
     collections: list[str] | None = None,
     explicit_config: RetrievalConfig | None = None,
-    config_fn: Callable[[], RetrievalConfig] | None = None,
-    overrides_fn: Callable[[], dict[str, dict]] | None = None,
+    deps: ResolveConfigDeps | None = None,
 ) -> RetrievalConfig:
     """Resolve the retrieval config for a search request.
 
@@ -476,17 +490,17 @@ def resolve_retrieval_config(
         collections:     List of collection names; per-collection override
                          applies only when this list is length 1.
         explicit_config: Direct override; bypasses all other lookup.
-        config_fn:       Injection seam for the global config loader. Tests
-                         pass a no-arg callable returning a known RetrievalConfig.
-        overrides_fn:    Injection seam for per-collection overrides lookup.
-                         Tests pass a no-arg callable returning the override
-                         dict directly. Defaults to ``_get_collection_overrides``.
+        deps:            Injectable dependencies (config_fn, overrides_fn).
+                         Production callers leave None; tests pass a
+                         ``ResolveConfigDeps`` with fakes. The default
+                         factories wire the real loader and per-collection
+                         override lookup.
     """
     if explicit_config is not None:
         return explicit_config
 
-    _load = config_fn or load_config
-    global_cfg = _load()
+    d = deps or ResolveConfigDeps()
+    global_cfg = d.config_fn()
 
     # Determine target collection (only for single-collection searches)
     target = collection
@@ -497,8 +511,7 @@ def resolve_retrieval_config(
         return global_cfg
 
     # Per-collection YAML overrides
-    _overrides = overrides_fn or _get_collection_overrides
-    overrides = _overrides().get(target)
+    overrides = d.overrides_fn().get(target)
     if overrides:
         return _merge_retrieval_config(global_cfg, overrides)
 

--- a/tests/bdd/steps/search_collection_retrieval_overrides_steps.py
+++ b/tests/bdd/steps/search_collection_retrieval_overrides_steps.py
@@ -7,8 +7,8 @@ per-collection overrides in YAML, and the resolver merges them over the
 global config when the search is scoped to a single collection.
 
 These scenarios drive ``resolve_retrieval_config`` via its public injection
-seams (``config_fn``, ``overrides_fn``) — no monkeypatching, no inline
-stubs.
+seam (``deps=ResolveConfigDeps(config_fn, overrides_fn)``) — no
+monkeypatching, no inline stubs.
 """
 
 from __future__ import annotations
@@ -20,7 +20,7 @@ import pytest
 from pytest_bdd import given, parsers, then, when
 
 from kairix.core.search.config import RetrievalConfig
-from kairix.core.search.config_loader import resolve_retrieval_config
+from kairix.core.search.config_loader import ResolveConfigDeps, resolve_retrieval_config
 
 
 @dataclass
@@ -74,8 +74,10 @@ def _resolve_with_ctx(ctx: _OverridesCtx, *, collection: str | None, collections
     ctx.resolved = resolve_retrieval_config(
         collection=collection,
         collections=collections,
-        config_fn=lambda: global_cfg,
-        overrides_fn=lambda: ctx.overrides,
+        deps=ResolveConfigDeps(
+            config_fn=lambda: global_cfg,
+            overrides_fn=lambda: ctx.overrides,
+        ),
     )
 
 

--- a/tests/briefing/test_pipeline.py
+++ b/tests/briefing/test_pipeline.py
@@ -12,6 +12,7 @@ import pytest
 
 from kairix.agents.briefing.pipeline import (
     _TOTAL_CONTEXT_CAP,
+    BriefingDeps,
     BriefingPipeline,
     _trim_context,
     generate_briefing,
@@ -141,8 +142,10 @@ class TestGenerateBriefing:
         """Test that pipeline runs and returns a string."""
         result = generate_briefing(
             "builder",
-            synthesise_fn=_fake_synthesise,
-            write_fn=_make_fake_writer(tmp_path),
+            deps=BriefingDeps(
+                synthesise_fn=_fake_synthesise,
+                write_fn=_make_fake_writer(tmp_path),
+            ),
             sources=_all_content_sources(),
         )
 
@@ -154,8 +157,10 @@ class TestGenerateBriefing:
     def test_header_is_included(self, tmp_path):
         result = generate_briefing(
             "builder",
-            synthesise_fn=lambda agent, ctx, max_tokens=800: "## Pending\nNone.",
-            write_fn=_make_fake_writer(tmp_path),
+            deps=BriefingDeps(
+                synthesise_fn=lambda agent, ctx, max_tokens=800: "## Pending\nNone.",
+                write_fn=_make_fake_writer(tmp_path),
+            ),
             sources=_all_empty_sources(),
         )
 
@@ -170,8 +175,10 @@ class TestGenerateBriefing:
 
         result = generate_briefing(
             "builder",
-            synthesise_fn=_fake_synthesise,
-            write_fn=_make_fake_writer(tmp_path),
+            deps=BriefingDeps(
+                synthesise_fn=_fake_synthesise,
+                write_fn=_make_fake_writer(tmp_path),
+            ),
             sources=sources,
         )
 
@@ -182,8 +189,10 @@ class TestGenerateBriefing:
         """Synthesis API failure should return a partial/fallback briefing, not raise."""
         result = generate_briefing(
             "builder",
-            synthesise_fn=lambda agent, ctx, max_tokens=800: "synthesis unavailable",
-            write_fn=_make_fake_writer(tmp_path),
+            deps=BriefingDeps(
+                synthesise_fn=lambda agent, ctx, max_tokens=800: "synthesis unavailable",
+                write_fn=_make_fake_writer(tmp_path),
+            ),
             sources=_all_content_sources(),
         )
 
@@ -194,8 +203,10 @@ class TestGenerateBriefing:
     def test_output_file_is_written(self, tmp_path):
         generate_briefing(
             "builder",
-            synthesise_fn=_fake_synthesise,
-            write_fn=_make_fake_writer(tmp_path),
+            deps=BriefingDeps(
+                synthesise_fn=_fake_synthesise,
+                write_fn=_make_fake_writer(tmp_path),
+            ),
             sources=_all_content_sources(),
         )
 
@@ -212,8 +223,10 @@ class TestBriefingPipeline:
         """BriefingPipeline.generate delegates to generate_briefing."""
         pipeline = BriefingPipeline(
             sources=_all_content_sources(),
-            synthesise_fn=_fake_synthesise,
-            write_fn=_make_fake_writer(tmp_path),
+            deps=BriefingDeps(
+                synthesise_fn=_fake_synthesise,
+                write_fn=_make_fake_writer(tmp_path),
+            ),
         )
 
         result = pipeline.generate("builder")
@@ -226,8 +239,10 @@ class TestBriefingPipeline:
         """BriefingPipeline handles empty sources gracefully."""
         pipeline = BriefingPipeline(
             sources=_all_empty_sources(),
-            synthesise_fn=lambda agent, ctx, max_tokens=800: "## Pending\nNone.",
-            write_fn=_make_fake_writer(tmp_path),
+            deps=BriefingDeps(
+                synthesise_fn=lambda agent, ctx, max_tokens=800: "## Pending\nNone.",
+                write_fn=_make_fake_writer(tmp_path),
+            ),
         )
 
         result = pipeline.generate("shape")
@@ -240,8 +255,10 @@ class TestBriefingPipeline:
         """BriefingPipeline.generate writes the briefing file."""
         pipeline = BriefingPipeline(
             sources=_all_content_sources(),
-            synthesise_fn=_fake_synthesise,
-            write_fn=_make_fake_writer(tmp_path),
+            deps=BriefingDeps(
+                synthesise_fn=_fake_synthesise,
+                write_fn=_make_fake_writer(tmp_path),
+            ),
         )
 
         pipeline.generate("builder")

--- a/tests/research/test_graph.py
+++ b/tests/research/test_graph.py
@@ -26,7 +26,7 @@ def _mock_search_result(paths_snippets: list[tuple[str, str]]):
 @pytest.mark.unit
 def test_run_research_sufficient_first_pass() -> None:
     """Graph completes in one pass when results are sufficient."""
-    from kairix.agents.research.graph import run_research
+    from kairix.agents.research.graph import ResearchGraphDeps, run_research
 
     mock_backend = MagicMock()
     # evaluate_sufficiency returns high confidence
@@ -45,9 +45,11 @@ def test_run_research_sufficient_first_pass() -> None:
     result = run_research(
         "simple question",
         max_turns=4,
-        search_fn=lambda **kwargs: _mock_search_result([("doc.md", "content")]),
-        llm_backend=mock_backend,
-        classify_fn=lambda q: MagicMock(value="semantic"),
+        deps=ResearchGraphDeps(
+            search_fn=lambda **kwargs: _mock_search_result([("doc.md", "content")]),
+            classify_fn=lambda q: MagicMock(value="semantic"),
+            llm_backend=mock_backend,
+        ),
     )
 
     assert result["confidence"] >= 0.7
@@ -58,7 +60,7 @@ def test_run_research_sufficient_first_pass() -> None:
 @pytest.mark.unit
 def test_run_research_refines_then_succeeds() -> None:
     """Graph refines query and succeeds on second pass."""
-    from kairix.agents.research.graph import run_research
+    from kairix.agents.research.graph import ResearchGraphDeps, run_research
 
     mock_backend = MagicMock()
     mock_backend.chat.side_effect = [
@@ -94,9 +96,11 @@ def test_run_research_refines_then_succeeds() -> None:
     result = run_research(
         "complex question",
         max_turns=4,
-        search_fn=mock_search,
-        llm_backend=mock_backend,
-        classify_fn=lambda q: MagicMock(value="semantic"),
+        deps=ResearchGraphDeps(
+            search_fn=mock_search,
+            classify_fn=lambda q: MagicMock(value="semantic"),
+            llm_backend=mock_backend,
+        ),
     )
 
     assert result["turns"] == 1  # refined once
@@ -107,7 +111,7 @@ def test_run_research_refines_then_succeeds() -> None:
 @pytest.mark.unit
 def test_run_research_synthesises_best_effort_after_max_turns() -> None:
     """Graph synthesises a best-effort answer when max turns exhausted at low confidence."""
-    from kairix.agents.research.graph import run_research
+    from kairix.agents.research.graph import ResearchGraphDeps, run_research
 
     mock_backend = MagicMock()
     # Evaluation always returns low confidence; final call is synthesis
@@ -142,9 +146,11 @@ def test_run_research_synthesises_best_effort_after_max_turns() -> None:
     result = run_research(
         "hard question",
         max_turns=2,
-        search_fn=mock_search,
-        llm_backend=mock_backend,
-        classify_fn=lambda q: MagicMock(value="semantic"),
+        deps=ResearchGraphDeps(
+            search_fn=mock_search,
+            classify_fn=lambda q: MagicMock(value="semantic"),
+            llm_backend=mock_backend,
+        ),
     )
 
     assert result["synthesis"] != ""

--- a/tests/research/test_nodes.py
+++ b/tests/research/test_nodes.py
@@ -8,6 +8,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from kairix.agents.research.nodes import (
+    ClassifyIntentDeps,
+    RetrieveDeps,
     classify_intent,
     evaluate_sufficiency,
     refine_query,
@@ -42,7 +44,7 @@ class TestClassifyIntent:
     def test_sets_intent(self) -> None:
         result = classify_intent(
             _state(query="who is Jordan Blake"),
-            classify_fn=lambda q: MagicMock(value="entity"),
+            deps=ClassifyIntentDeps(classify_fn=lambda q: MagicMock(value="entity")),
         )
         assert result["intent"] == "entity"
 
@@ -51,7 +53,7 @@ class TestClassifyIntent:
         def _failing(q):
             raise RuntimeError("boom")
 
-        result = classify_intent(_state(), classify_fn=_failing)
+        result = classify_intent(_state(), deps=ClassifyIntentDeps(classify_fn=_failing))
         assert result["intent"] == "semantic"
 
 
@@ -75,7 +77,7 @@ class TestRetrieve:
     @pytest.mark.unit
     def test_calls_search(self) -> None:
         mock_search = MagicMock(return_value=_mock_search_result([("a.md", "hello")]))
-        result = retrieve(_state(), search_fn=mock_search)
+        result = retrieve(_state(), deps=RetrieveDeps(search_fn=mock_search))
         assert len(result["retrieved_chunks"]) == 1
         assert result["retrieved_chunks"][0]["path"] == "a.md"
 
@@ -83,20 +85,26 @@ class TestRetrieve:
     def test_accumulates_across_turns(self) -> None:
         existing = [{"path": "old.md", "snippet": "existing"}]
         mock_search = MagicMock(return_value=_mock_search_result([("new.md", "new")]))
-        result = retrieve(_state(retrieved_chunks=existing, turns=1), search_fn=mock_search)
+        result = retrieve(
+            _state(retrieved_chunks=existing, turns=1),
+            deps=RetrieveDeps(search_fn=mock_search),
+        )
         assert len(result["retrieved_chunks"]) == 2
 
     @pytest.mark.unit
     def test_deduplicates_by_path(self) -> None:
         existing = [{"path": "same.md", "snippet": "v1"}]
         mock_search = MagicMock(return_value=_mock_search_result([("same.md", "v2")]))
-        result = retrieve(_state(retrieved_chunks=existing), search_fn=mock_search)
+        result = retrieve(
+            _state(retrieved_chunks=existing),
+            deps=RetrieveDeps(search_fn=mock_search),
+        )
         assert len(result["retrieved_chunks"]) == 1
 
     @pytest.mark.unit
     def test_higher_budget_on_refinement(self) -> None:
         mock_search = MagicMock(return_value=_mock_search_result([]))
-        retrieve(_state(turns=2), search_fn=mock_search)
+        retrieve(_state(turns=2), deps=RetrieveDeps(search_fn=mock_search))
         mock_search.assert_called_once()
         assert mock_search.call_args.kwargs["budget"] == 5000
 

--- a/tests/search/test_collection_config.py
+++ b/tests/search/test_collection_config.py
@@ -6,6 +6,7 @@ import pytest
 
 from kairix.core.search.config import RetrievalConfig
 from kairix.core.search.config_loader import (
+    ResolveConfigDeps,
     _merge_retrieval_config,
     resolve_retrieval_config,
 )
@@ -124,8 +125,10 @@ class TestResolveRetrievalConfig:
         }
         result = resolve_retrieval_config(
             collections=["reference-library"],
-            config_fn=RetrievalConfig.defaults,
-            overrides_fn=lambda: baseline_overrides,
+            deps=ResolveConfigDeps(
+                config_fn=RetrievalConfig.defaults,
+                overrides_fn=lambda: baseline_overrides,
+            ),
         )
         assert result.fusion_strategy == "bm25_primary"
         assert result.vec_limit == 5
@@ -144,8 +147,10 @@ class TestResolveRetrievalConfig:
         global_cfg = RetrievalConfig.defaults()
         result = resolve_retrieval_config(
             collections=["reference-library"],
-            config_fn=lambda: global_cfg,
-            overrides_fn=lambda: {},
+            deps=ResolveConfigDeps(
+                config_fn=lambda: global_cfg,
+                overrides_fn=lambda: {},
+            ),
         )
         assert result is global_cfg
 
@@ -153,8 +158,10 @@ class TestResolveRetrievalConfig:
     def test_single_collection_with_yaml_config(self) -> None:
         result = resolve_retrieval_config(
             collections=["my-docs"],
-            config_fn=RetrievalConfig.defaults,
-            overrides_fn=lambda: {"my-docs": {"fusion_strategy": "rrf", "vec_limit": 30}},
+            deps=ResolveConfigDeps(
+                config_fn=RetrievalConfig.defaults,
+                overrides_fn=lambda: {"my-docs": {"fusion_strategy": "rrf", "vec_limit": 30}},
+            ),
         )
         assert result.fusion_strategy == "rrf"
         assert result.vec_limit == 30
@@ -162,13 +169,16 @@ class TestResolveRetrievalConfig:
     @pytest.mark.unit
     def test_multi_collection_uses_global(self) -> None:
         global_cfg = RetrievalConfig.defaults()
-        result = resolve_retrieval_config(collections=["a", "b"], config_fn=lambda: global_cfg)
+        result = resolve_retrieval_config(
+            collections=["a", "b"],
+            deps=ResolveConfigDeps(config_fn=lambda: global_cfg),
+        )
         assert result is global_cfg
 
     @pytest.mark.unit
     def test_no_collection_uses_global(self) -> None:
         global_cfg = RetrievalConfig.defaults()
-        result = resolve_retrieval_config(config_fn=lambda: global_cfg)
+        result = resolve_retrieval_config(deps=ResolveConfigDeps(config_fn=lambda: global_cfg))
         assert result is global_cfg
 
     @pytest.mark.unit
@@ -176,8 +186,10 @@ class TestResolveRetrievalConfig:
         global_cfg = RetrievalConfig.defaults()
         result = resolve_retrieval_config(
             collections=["unknown"],
-            config_fn=lambda: global_cfg,
-            overrides_fn=lambda: {},
+            deps=ResolveConfigDeps(
+                config_fn=lambda: global_cfg,
+                overrides_fn=lambda: {},
+            ),
         )
         assert result is global_cfg
 

--- a/tests/search/test_config_loader_contracts.py
+++ b/tests/search/test_config_loader_contracts.py
@@ -26,6 +26,7 @@ from kairix.core.search import config_loader
 from kairix.core.search.config import RetrievalConfig
 from kairix.core.search.config_loader import (
     ConfigValidationError,
+    ResolveConfigDeps,
     load_collections,
     load_config,
     parse_collections,
@@ -482,7 +483,7 @@ class TestResolveRetrievalConfigContract:
         argument the resolver returns the object produced by ``config_fn``.
         """
         sentinel = RetrievalConfig.defaults()
-        result = resolve_retrieval_config(config_fn=lambda: sentinel)
+        result = resolve_retrieval_config(deps=ResolveConfigDeps(config_fn=lambda: sentinel))
         assert result is sentinel
 
     def test_multi_collection_returns_global_config(self) -> None:
@@ -490,7 +491,10 @@ class TestResolveRetrievalConfigContract:
         in ``collections`` short-circuit per-collection lookup.
         """
         sentinel = RetrievalConfig.defaults()
-        result = resolve_retrieval_config(collections=["a", "b"], config_fn=lambda: sentinel)
+        result = resolve_retrieval_config(
+            collections=["a", "b"],
+            deps=ResolveConfigDeps(config_fn=lambda: sentinel),
+        )
         assert result is sentinel
 
     def test_unknown_single_collection_returns_global_config(
@@ -510,7 +514,10 @@ class TestResolveRetrievalConfigContract:
         )
         monkeypatch.setenv("KAIRIX_CONFIG_PATH", str(cfg_file))
         sentinel = RetrievalConfig.defaults()
-        result = resolve_retrieval_config(collection="not-present", config_fn=lambda: sentinel)
+        result = resolve_retrieval_config(
+            collection="not-present",
+            deps=ResolveConfigDeps(config_fn=lambda: sentinel),
+        )
         assert result is sentinel
 
     def test_single_collection_yaml_override_merged_over_global(
@@ -540,7 +547,10 @@ class TestResolveRetrievalConfigContract:
             vec_limit=7,
             bm25_limit=21,
         )
-        result = resolve_retrieval_config(collection="my-docs", config_fn=lambda: global_cfg)
+        result = resolve_retrieval_config(
+            collection="my-docs",
+            deps=ResolveConfigDeps(config_fn=lambda: global_cfg),
+        )
         assert result.fusion_strategy == "rrf"  # from override
         assert result.vec_limit == 30  # from override
         assert result.bm25_limit == 21  # preserved from global
@@ -572,15 +582,17 @@ class TestResolveRetrievalConfigContract:
         only ``decay_halflife_days`` on chunk_date_boost preserves the global
         ``enabled`` and ``guard_explicit_only`` flags.
 
-        Drives the public surface via the documented ``overrides_fn=``
-        injection seam; no env-var monkeypatching, no YAML file on disk.
+        Drives the public surface via the documented deps injection seam;
+        no env-var monkeypatching, no YAML file on disk.
         """
         result = resolve_retrieval_config(
             collection="dated-notes",
-            config_fn=RetrievalConfig.defaults,
-            overrides_fn=lambda: {
-                "dated-notes": {"boosts": {"temporal": {"chunk_date_boost": {"decay_halflife_days": 7}}}},
-            },
+            deps=ResolveConfigDeps(
+                config_fn=RetrievalConfig.defaults,
+                overrides_fn=lambda: {
+                    "dated-notes": {"boosts": {"temporal": {"chunk_date_boost": {"decay_halflife_days": 7}}}},
+                },
+            ),
         )
         defaults = RetrievalConfig.defaults()
         # Override applied: halflife from per-collection block.
@@ -596,10 +608,12 @@ class TestResolveRetrievalConfigContract:
         """
         result = resolve_retrieval_config(
             collection="dated-notes",
-            config_fn=RetrievalConfig.defaults,
-            overrides_fn=lambda: {
-                "dated-notes": {"boosts": {"temporal": {"date_path_boost": {"factor": 1.7}}}},
-            },
+            deps=ResolveConfigDeps(
+                config_fn=RetrievalConfig.defaults,
+                overrides_fn=lambda: {
+                    "dated-notes": {"boosts": {"temporal": {"date_path_boost": {"factor": 1.7}}}},
+                },
+            ),
         )
         defaults = RetrievalConfig.defaults()
         assert result.temporal.date_path_boost_factor == pytest.approx(1.7)
@@ -624,10 +638,12 @@ class TestResolveRetrievalConfigContract:
         )
         result = resolve_retrieval_config(
             collection="noisy-docs",
-            config_fn=lambda: global_cfg,
-            overrides_fn=lambda: {
-                "noisy-docs": {"rerank": {"model": "cross-encoder/ms-marco-TinyBERT-L-2-v2"}},
-            },
+            deps=ResolveConfigDeps(
+                config_fn=lambda: global_cfg,
+                overrides_fn=lambda: {
+                    "noisy-docs": {"rerank": {"model": "cross-encoder/ms-marco-TinyBERT-L-2-v2"}},
+                },
+            ),
         )
         # Override applied: model from per-collection block.
         assert result.rerank.model == "cross-encoder/ms-marco-TinyBERT-L-2-v2"


### PR DESCRIPTION
## Summary

Phase 4 of issue #199 — converts 4 of 12 files from `*_fn=None` test-only
kwargs to typed `<Component>Deps` dataclasses. F6 baseline shrinks from
12 to 8 files.

Each dataclass uses `field(default_factory=...)` to wire production
defaults — fields are typed as concrete callables (no `Optional[Callable]`)
so mypy sees a real type at every call site. This avoids the
`__post_init__` self-resolving pattern that landed the mypy regression
flagged in #204.

## Files converted

| File | Deps class | Replaced kwargs |
|------|-----------|-----------------|
| `kairix/agents/briefing/pipeline.py` | `BriefingDeps` | `synthesise_fn`, `write_fn` |
| `kairix/agents/research/graph.py` | `ResearchGraphDeps` | `search_fn`, `classify_fn`, `llm_backend`, `confidence_parser` |
| `kairix/agents/research/nodes.py` | `ClassifyIntentDeps`, `RetrieveDeps` | `classify_fn`, `search_fn` |
| `kairix/core/search/config_loader.py` | `ResolveConfigDeps` | `config_fn`, `overrides_fn` |

## Tests

- `tests/briefing/test_pipeline.py`, `tests/research/test_nodes.py`,
  `tests/research/test_graph.py`, `tests/search/test_collection_config.py`,
  `tests/search/test_config_loader_contracts.py`,
  `tests/bdd/steps/search_collection_retrieval_overrides_steps.py`
  updated to construct new `<Component>Deps(...)` shapes.
- `safe-commit.sh`: ruff lint, ruff format, mypy --strict, 3183 unit
  tests, all 13 arch fitness functions — all green.
- `pre-commit run --all-files` — all hooks pass.

## Test plan

- [x] `safe-commit.sh` green
- [x] `pre-commit run --all-files` green
- [x] F6 baseline reduced by 4 files (12 → 8)
- [x] All four files no longer flagged by `scripts/checks/check_no_test_only_kwargs.py`
- [x] mypy --strict clean on all 4 modified production files
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)