### PR TITLE
test(F6): wizard/retrieval/worker typed *Deps dataclasses (#199)

### DIFF
--- a/.architecture/baseline/no-test-only-kwargs-files.txt
+++ b/.architecture/baseline/no-test-only-kwargs-files.txt
@@ -2,6 +2,3 @@ kairix/knowledge/contradict/detector.py
 kairix/knowledge/summaries/generate.py
 kairix/platform/llm/backends.py
 kairix/platform/onboard/check.py
-kairix/platform/setup/wizard.py
-kairix/quality/eval/retrieval.py
-kairix/worker.py

--- a/kairix/platform/setup/wizard.py
+++ b/kairix/platform/setup/wizard.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 import os
 from collections.abc import Callable
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -74,12 +75,30 @@ def load_template(name: str) -> dict[str, Any]:
         return yaml.safe_load(f) or {}
 
 
+@dataclass
+class WizardDeps:
+    """Injectable dependencies for ``run_setup``.
+
+    Replaces the F6-violating ``connection_test_fn=None`` test-only kwarg
+    with a typed dataclass. Production code calls ``run_setup`` without
+    ``deps`` — the default factory wires the real LLM connection probe.
+    Tests construct ``WizardDeps(connection_test=lambda *_a, **_k: True)``
+    and pass it through.
+
+    The field is non-Optional with a ``default_factory`` (per CLAUDE.md
+    F6 guidance) so mypy sees the production callable directly — no
+    ``assert deps.x is not None`` ladder is needed inside the wizard.
+    """
+
+    connection_test: Callable[[str, str, str, str], bool] = field(default_factory=lambda: _test_llm_connection)
+
+
 def run_setup(
     output_path: str = "kairix.config.yaml",
     ctx: SetupContext | None = None,
     preset: str | None = None,
     document_path: str | None = None,
-    connection_test_fn: Callable[[str, str, str, str], bool] | None = None,
+    deps: WizardDeps | None = None,
 ) -> bool:
     """Run the setup wizard.
 
@@ -87,13 +106,13 @@ def run_setup(
     and JSON output modes via SetupContext.
 
     Args:
-        connection_test_fn: Callable(provider, endpoint, api_key, embed_model) -> bool.
-                            Defaults to _test_llm_connection.
+        deps: Injectable dependencies. Tests construct
+              ``WizardDeps(connection_test=fake)``; production omits the kwarg
+              and the default factory wires ``_test_llm_connection``.
 
     Returns True if setup completed successfully.
     """
-    if connection_test_fn is None:
-        connection_test_fn = _test_llm_connection
+    deps = deps if deps is not None else WizardDeps()
     if ctx is None:
         ctx = SetupContext.auto_detect()
 
@@ -156,7 +175,7 @@ def run_setup(
         prompt(ctx, "Chat model name")  # consumed by future config expansion
 
     print("\n  Testing connection...")
-    if connection_test_fn(provider_key, endpoint, api_key, embed_model):
+    if deps.connection_test(provider_key, endpoint, api_key, embed_model):
         print("  \u2713 Connected successfully\n")
     else:
         print("  \u2717 Connection failed — check your credentials and try again\n")

--- a/kairix/quality/benchmark/runner.py
+++ b/kairix/quality/benchmark/runner.py
@@ -320,8 +320,9 @@ def retrieve(
                   to verify the resolved RetrievalConfig flows through.
                   ``None`` means use the production pipeline.
     """
-    from kairix.quality.eval.retrieval import retrieve
+    from kairix.quality.eval.retrieval import RetrievalDeps, retrieve
 
+    deps = RetrievalDeps(searcher=searcher) if searcher is not None else None
     result = retrieve(
         query=query,
         system=system,
@@ -330,7 +331,7 @@ def retrieve(
         db_path=db_path,
         collection=collection,
         fusion_override=fusion_override,
-        search_fn=searcher,
+        deps=deps,
     )
     return result.paths, result.snippets, result.meta
 

--- a/kairix/quality/eval/retrieval.py
+++ b/kairix/quality/eval/retrieval.py
@@ -9,6 +9,7 @@ retrieve() from here rather than maintaining local wrappers.
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -24,6 +25,46 @@ class RetrievalResult:
     meta: dict[str, Any] = field(default_factory=dict)
 
 
+def _default_pipeline_builder(*, config: Any) -> Any:
+    """Production pipeline factory — wraps ``build_search_pipeline``.
+
+    The lazy local-import avoids a module-import-time circular when
+    callers reach ``kairix.quality.eval.retrieval`` before
+    ``kairix.core.factory`` finishes loading. The wrapper exists so
+    ``RetrievalDeps.pipeline_builder`` has a stable, typed default.
+    """
+    from kairix.core.factory import build_search_pipeline
+
+    return build_search_pipeline(config=config)
+
+
+@dataclass
+class RetrievalDeps:
+    """Injectable dependencies for ``retrieve`` and ``_retrieve_hybrid``.
+
+    Replaces the F6-violating ``search_fn=None`` / ``pipeline_builder=None``
+    test-only kwargs with a typed dataclass. Production code calls
+    ``retrieve(...)`` without ``deps`` and the default factory wires the
+    real ``build_search_pipeline``. Tests construct
+    ``RetrievalDeps(searcher=fake)`` (to bypass pipeline construction) or
+    ``RetrievalDeps(pipeline_builder=spy)`` (to observe the resolved
+    ``RetrievalConfig`` that flows through).
+
+    ``searcher`` stays Optional because the two seams are mutually
+    exclusive: a pre-bound searcher means "skip pipeline construction"
+    and ``None`` means "build the pipeline via ``pipeline_builder``."
+    The name doesn't end in ``_fn`` so it stays clear of F6 even with
+    the ``None`` default.
+
+    ``pipeline_builder`` is non-Optional with a ``default_factory`` (per
+    CLAUDE.md F6 guidance) so mypy sees the production callable directly —
+    no ``assert deps.x is not None`` ladder is needed inside ``retrieve``.
+    """
+
+    pipeline_builder: Callable[..., Any] = field(default_factory=lambda: _default_pipeline_builder)
+    searcher: Callable[..., Any] | None = None
+
+
 def retrieve(
     query: str,
     system: str = "hybrid",
@@ -34,8 +75,7 @@ def retrieve(
     collections: list[str] | None = None,
     fusion_override: str | None = None,
     config: Any | None = None,
-    search_fn: Any | None = None,
-    pipeline_builder: Any | None = None,
+    deps: RetrievalDeps | None = None,
 ) -> RetrievalResult:
     """
     Run retrieval and return a RetrievalResult.
@@ -50,11 +90,11 @@ def retrieve(
         collections:      Explicit collections list (takes precedence over collection).
         fusion_override:  Override fusion strategy (hybrid only).
         config:           Pre-built RetrievalConfig (hybrid only; overrides fusion_override).
-        search_fn:        Pre-bound search function. Bypasses pipeline construction
-                          when provided (used by tests + agents that own their own pipeline).
-        pipeline_builder: Pipeline factory; defaults to ``build_search_pipeline``.
-                          Tests pass a spy to verify the resolved RetrievalConfig
-                          flows through (mirrors the ``search_fn=`` seam).
+        deps:             Injectable dependencies. Tests construct
+                          ``RetrievalDeps(searcher=fake)`` or
+                          ``RetrievalDeps(pipeline_builder=spy)``; production omits the
+                          kwarg and the default factory wires
+                          ``build_search_pipeline``.
 
     Returns:
         RetrievalResult with paths, snippets, and metadata.
@@ -62,6 +102,7 @@ def retrieve(
     Raises:
         ValueError: Unknown system name.
     """
+    deps = deps if deps is not None else RetrievalDeps()
     if system == "hybrid":
         return _retrieve_hybrid(
             query=query,
@@ -70,8 +111,7 @@ def retrieve(
             collections=collections,
             fusion_override=fusion_override,
             config=config,
-            search_fn=search_fn,
-            pipeline_builder=pipeline_builder,
+            deps=deps,
         )
     elif system == "bm25":
         return _retrieve_bm25(query=query, agent=agent, limit=limit)
@@ -96,8 +136,7 @@ def _retrieve_hybrid(
     collections: list[str] | None = None,
     fusion_override: str | None = None,
     config: Any | None = None,
-    search_fn: Any | None = None,
-    pipeline_builder: Any | None = None,
+    deps: RetrievalDeps | None = None,
 ) -> RetrievalResult:
     """Hybrid search backend.
 
@@ -108,6 +147,7 @@ def _retrieve_hybrid(
     eval/benchmark path so ``--collection reference-library`` actually
     receives reflib's tuned overrides.
     """
+    deps = deps if deps is not None else RetrievalDeps()
     # Resolve config BEFORE building the pipeline. The historical bug
     # (config reassigned after pipeline already built) is closed by doing
     # all resolution up front.
@@ -121,13 +161,10 @@ def _retrieve_hybrid(
 
         config = replace(config, fusion_strategy=fusion_override)
 
-    if search_fn is None:
-        if pipeline_builder is None:
-            from kairix.core.factory import build_search_pipeline
-
-            pipeline_builder = build_search_pipeline
-        _pipeline = pipeline_builder(config=config)
-        search_fn = _pipeline.search
+    searcher = deps.searcher
+    if searcher is None:
+        _pipeline = deps.pipeline_builder(config=config)
+        searcher = _pipeline.search
 
     # Build explicit collections list when --collection is set
     effective_collections = collections or ([collection] if collection else None)
@@ -141,7 +178,7 @@ def _retrieve_hybrid(
         search_kwargs["agent"] = agent
         search_kwargs["scope"] = "shared+agent"
 
-    sr = search_fn(**search_kwargs)
+    sr = searcher(**search_kwargs)
     paths = [b.result.path for b in sr.results]
     snippets = [b.content[:500] for b in sr.results]
     meta = {

--- a/kairix/worker.py
+++ b/kairix/worker.py
@@ -17,6 +17,7 @@ import os
 import signal
 import time
 from collections.abc import Callable
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -79,7 +80,32 @@ def _default_health_check() -> list[Any]:
     return run_all_checks()
 
 
-def run_embed(embed_fn: Callable[[], Any] | None = None) -> None:
+@dataclass
+class WorkerDeps:
+    """Injectable dependencies for the worker loop and its task helpers.
+
+    Replaces the F6-violating ``embed_fn=None`` / ``entity_seed_fn=None`` /
+    ``health_check_fn=None`` / ``wikilinks_fn=None`` / ``sleep_fn=None``
+    test-only kwargs with a typed dataclass. Production code calls
+    ``main()`` without ``deps`` and the default factory wires the real
+    task callables. Tests construct
+    ``WorkerDeps(embed=fake, sleep=lambda _s: None)`` and pass it through.
+
+    Each callable field is non-Optional with a ``default_factory`` (per
+    CLAUDE.md F6 guidance: avoid the ``Optional[Callable] + post-init``
+    pattern that "just landed a mypy bug") so mypy sees the production
+    callable directly — no ``assert deps.x is not None`` ladder is
+    needed inside the worker loop.
+    """
+
+    embed: Callable[[], Any] = field(default_factory=lambda: _default_embed)
+    entity_seed: Callable[[], None] = field(default_factory=lambda: _default_entity_seed)
+    health_check: Callable[[], list[Any]] = field(default_factory=lambda: _default_health_check)
+    wikilinks: Callable[[], None] = field(default_factory=lambda: _default_wikilinks_inject)
+    sleep: Callable[[float], None] = field(default_factory=lambda: time.sleep)
+
+
+def run_embed(deps: WorkerDeps | None = None) -> None:
     """Run incremental embed — indexes new and changed documents.
 
     The worker treats every outcome of the embed pipeline as
@@ -95,15 +121,14 @@ def run_embed(embed_fn: Callable[[], Any] | None = None) -> None:
     worker process. That coupling is removed here: the use case
     returns a ``EmbedPipelineResult`` dataclass; we inspect it and log.
 
-    ``embed_fn`` injection seam: tests pass a callable returning either
-    the result dataclass or None (legacy). Production passes
+    ``deps.embed`` is the injection seam: tests pass a callable returning
+    either the result dataclass or None (legacy). Production passes
     ``_default_embed`` which runs the use case.
     """
-    if embed_fn is None:
-        embed_fn = _default_embed
+    deps = deps if deps is not None else WorkerDeps()
     try:
         logger.info("worker: starting incremental embed")
-        result = embed_fn()
+        result = deps.embed()
         if result is None:
             logger.info("worker: embed complete")
             return
@@ -141,24 +166,25 @@ def run_embed(embed_fn: Callable[[], Any] | None = None) -> None:
         logger.warning("worker: embed pipeline raised — %s", exc)
 
 
-def run_entity_seed(entity_seed_fn: Callable[[], None] | None = None) -> None:
+def run_entity_seed(deps: WorkerDeps | None = None) -> None:
     """Run entity relationship seeding from document store structure.
 
     Args:
-        entity_seed_fn: Callable that performs the entity seed. Defaults to
-                        the production store crawl CLI entry point.
+        deps: Injectable worker dependencies. Tests construct
+              ``WorkerDeps(entity_seed=fake)``; production omits the
+              kwarg and the default factory wires the real store crawl
+              CLI entry point.
     """
-    if entity_seed_fn is None:
-        entity_seed_fn = _default_entity_seed
+    deps = deps if deps is not None else WorkerDeps()
     try:
         logger.info("worker: starting entity seed")
-        entity_seed_fn()
+        deps.entity_seed()
         logger.info("worker: entity seed complete")
     except Exception as exc:
         logger.warning("worker: entity seed failed — %s", exc)
 
 
-def run_wikilinks_inject(wikilinks_fn: Callable[[], None] | None = None) -> None:
+def run_wikilinks_inject(deps: WorkerDeps | None = None) -> None:
     """Inject ``[[wikilinks]]`` on first mention into agent-written documents.
 
     Closes #100 — the host cron's nightly ``kairix wikilinks inject
@@ -171,30 +197,29 @@ def run_wikilinks_inject(wikilinks_fn: Callable[[], None] | None = None) -> None
     bootstrapping), and that must NOT terminate the worker. Same
     ``(Exception, SystemExit)`` discipline as ``run_embed``.
 
-    ``wikilinks_fn`` is the injection seam tests use; production passes
-    ``_default_wikilinks_inject``.
+    ``deps.wikilinks`` is the injection seam tests use; production
+    falls through to ``_default_wikilinks_inject``.
     """
-    if wikilinks_fn is None:
-        wikilinks_fn = _default_wikilinks_inject
+    deps = deps if deps is not None else WorkerDeps()
     try:
         logger.info("worker: starting wikilinks inject")
-        wikilinks_fn()
+        deps.wikilinks()
         logger.info("worker: wikilinks inject complete")
     except (Exception, SystemExit) as exc:
         logger.warning("worker: wikilinks inject raised — %s", exc)
 
 
-def run_health_check(health_check_fn: Callable[[], list[Any]] | None = None) -> None:
+def run_health_check(deps: WorkerDeps | None = None) -> None:
     """Log a health check.
 
     Args:
-        health_check_fn: Callable that returns a list of check results.
-                         Defaults to the production run_all_checks.
+        deps: Injectable worker dependencies. Tests construct
+              ``WorkerDeps(health_check=fake)``; production omits the
+              kwarg and the default factory wires ``run_all_checks``.
     """
-    if health_check_fn is None:
-        health_check_fn = _default_health_check
+    deps = deps if deps is not None else WorkerDeps()
     try:
-        results = health_check_fn()
+        results = deps.health_check()
         passed = sum(1 for r in results if r.ok)
         total = len(results)
         logger.info("worker: health check %d/%d passed", passed, total)
@@ -204,11 +229,7 @@ def run_health_check(health_check_fn: Callable[[], list[Any]] | None = None) -> 
 
 def main(
     *,
-    embed_fn: Callable[[], None] | None = None,
-    entity_seed_fn: Callable[[], None] | None = None,
-    health_check_fn: Callable[[], list[Any]] | None = None,
-    wikilinks_fn: Callable[[], None] | None = None,
-    sleep_fn: Callable[[float], None] | None = None,
+    deps: WorkerDeps | None = None,
     embed_interval: int | None = None,
     entity_seed_interval: int | None = None,
     health_check_interval: int | None = None,
@@ -216,19 +237,22 @@ def main(
 ) -> None:
     """Run the worker loop.
 
-    All dependencies are injectable for testing. Production defaults are
-    used when arguments are None.
+    All callable dependencies are bundled into ``WorkerDeps``;
+    interval ints stay as plain kwargs because they're scalar
+    config (not test-substitution seams). Production omits ``deps``
+    and the default factory wires the real task callables.
     """
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s %(levelname)s %(message)s",
     )
 
+    deps = deps if deps is not None else WorkerDeps()
+
     _embed_interval = embed_interval if embed_interval is not None else EMBED_INTERVAL
     _entity_interval = entity_seed_interval if entity_seed_interval is not None else ENTITY_SEED_INTERVAL
     _health_interval = health_check_interval if health_check_interval is not None else HEALTH_CHECK_INTERVAL
     _wikilinks_interval = wikilinks_interval if wikilinks_interval is not None else WIKILINKS_INTERVAL
-    _sleep = sleep_fn if sleep_fn is not None else time.sleep
 
     logger.info(
         "kairix worker starting — embed every %ds, entity seed every %ds, wikilinks every %ds",
@@ -255,33 +279,33 @@ def main(
     signal.signal(signal.SIGINT, _shutdown)
 
     # Run embed immediately on startup
-    run_embed(embed_fn)
+    run_embed(deps)
     last_embed = time.monotonic()
 
     while running:
         now = time.monotonic()
 
         if now - last_embed >= _embed_interval:
-            run_embed(embed_fn)
+            run_embed(deps)
             last_embed = now
 
         if now - last_entity >= _entity_interval:
-            run_entity_seed(entity_seed_fn)
+            run_entity_seed(deps)
             last_entity = now
 
         if now - last_health >= _health_interval:
-            run_health_check(health_check_fn)
+            run_health_check(deps)
             last_health = now
 
         if now - last_wikilinks >= _wikilinks_interval:
-            run_wikilinks_inject(wikilinks_fn)
+            run_wikilinks_inject(deps)
             last_wikilinks = now
 
         # Sleep 60 seconds between checks
         for _ in range(60):
             if not running:
                 break
-            _sleep(1)
+            deps.sleep(1)
 
     logger.info("kairix worker stopped")
 

--- a/tests/eval/test_retrieval_config_resolution.py
+++ b/tests/eval/test_retrieval_config_resolution.py
@@ -8,9 +8,10 @@ receives X's tuned overrides, and the historical ``fusion_override``
 ordering bug (config reassigned *after* the pipeline was built) is gone.
 
 The tests substitute the production ``build_search_pipeline`` with a
-``_PipelineBuilderSpy`` via the ``pipeline_builder=`` injection seam so
+``_PipelineBuilderSpy`` via ``RetrievalDeps(pipeline_builder=...)`` so
 the resolved config can be observed without spinning up Azure / Neo4j /
-usearch. The same shape as the existing ``search_fn=`` seam.
+usearch. ``RetrievalDeps`` (issue #199) replaced the F6-violating
+``search_fn=`` / ``pipeline_builder=`` test-only kwargs.
 """
 
 from __future__ import annotations
@@ -25,7 +26,7 @@ import pytest
 
 from kairix.core.search import config_loader
 from kairix.core.search.config import RetrievalConfig
-from kairix.quality.eval.retrieval import retrieve
+from kairix.quality.eval.retrieval import RetrievalDeps, retrieve
 
 pytestmark = pytest.mark.contract
 
@@ -110,7 +111,12 @@ def test_per_collection_override_flows_into_pipeline_builder(tmp_path: Path, mon
     monkeypatch.setenv("KAIRIX_CONFIG_PATH", str(cfg_file))
 
     builder, captured = _builder_spy()
-    retrieve(query="anything", system="hybrid", collection="reflib-test", pipeline_builder=builder)
+    retrieve(
+        query="anything",
+        system="hybrid",
+        collection="reflib-test",
+        deps=RetrievalDeps(pipeline_builder=builder),
+    )
 
     assert len(captured) == 1, f"expected exactly one pipeline build; got {len(captured)}"
     cfg = captured[0]
@@ -147,7 +153,12 @@ def test_global_config_used_when_no_per_collection_override_present(
 
     builder, captured = _builder_spy()
     # vault-areas has no per-collection retrieval block → global wins.
-    retrieve(query="anything", system="hybrid", collection="vault-areas", pipeline_builder=builder)
+    retrieve(
+        query="anything",
+        system="hybrid",
+        collection="vault-areas",
+        deps=RetrievalDeps(pipeline_builder=builder),
+    )
 
     cfg = captured[0]
     assert cfg.fusion_strategy == "bm25_primary", (
@@ -187,7 +198,7 @@ def test_fusion_override_layered_on_top_of_resolved_config(tmp_path: Path, monke
         system="hybrid",
         collection="docs",
         fusion_override="rrf",
-        pipeline_builder=builder,
+        deps=RetrievalDeps(pipeline_builder=builder),
     )
 
     cfg = captured[0]
@@ -216,7 +227,75 @@ def test_explicit_config_bypasses_resolution(tmp_path: Path, monkeypatch: pytest
 
     explicit = RetrievalConfig.minimal()
     builder, captured = _builder_spy()
-    retrieve(query="x", system="hybrid", config=explicit, pipeline_builder=builder)
+    retrieve(
+        query="x",
+        system="hybrid",
+        config=explicit,
+        deps=RetrievalDeps(pipeline_builder=builder),
+    )
 
     # Identity-passed: same object, no merge.
     assert captured[0] is explicit
+
+
+def test_retrieval_deps_default_factory_binds_callable_pipeline_builder() -> None:
+    """``RetrievalDeps()`` with no overrides constructs a deps bag whose
+    ``pipeline_builder`` is a callable, not ``None``.
+
+    Sabotage proof: the issue calls out ``Optional[Callable] = None``
+    self-resolving in ``__post_init__`` as the rejected pattern that
+    "just landed a mypy bug". ``default_factory`` must bind a real
+    callable or this assertion fires. The complementary ``searcher``
+    field stays Optional because the two seams are mutually exclusive
+    (a pre-bound searcher means "skip pipeline construction").
+    """
+    deps = RetrievalDeps()
+    assert callable(deps.pipeline_builder), (
+        f"default_factory must bind a callable; got {deps.pipeline_builder!r}. "
+        "Regressing to ``pipeline_builder: Callable | None = None`` would leave this None."
+    )
+    assert deps.searcher is None, "searcher defaults to None — no pre-bound searcher"
+
+
+def test_retrieval_deps_searcher_takes_precedence_over_pipeline_builder(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When ``RetrievalDeps(searcher=fn)`` is provided, the pipeline builder is
+    NOT invoked. Sabotage proof: the builder is a callable that raises if
+    called — the test only passes when the searcher path bypasses it.
+    """
+
+    @dataclass
+    class _CallableSearchResult:
+        results: list[Any] = field(default_factory=list)
+        intent: Any = field(default_factory=lambda: type("Intent", (), {"value": "semantic"})())
+        bm25_count: int = 0
+        vec_count: int = 0
+        fused_count: int = 0
+        vec_failed: bool = False
+        latency_ms: float = 0.0
+
+    def _exploding_builder(*, config: Any) -> Any:
+        raise AssertionError(
+            "pipeline_builder must NOT be called when searcher= is provided. "
+            "_retrieve_hybrid bypassed the searcher seam."
+        )
+
+    captured: list[dict[str, Any]] = []
+
+    def _spy_searcher(**kwargs: Any) -> _CallableSearchResult:
+        captured.append(kwargs)
+        return _CallableSearchResult()
+
+    cfg_file = tmp_path / "kairix.config.yaml"
+    cfg_file.write_text("retrieval:\n  fusion_strategy: rrf\n")
+    monkeypatch.setenv("KAIRIX_CONFIG_PATH", str(cfg_file))
+
+    retrieve(
+        query="hello",
+        system="hybrid",
+        deps=RetrievalDeps(searcher=_spy_searcher, pipeline_builder=_exploding_builder),
+    )
+
+    assert len(captured) == 1, "searcher should be called exactly once"
+    assert captured[0]["query"] == "hello"

--- a/tests/setup/test_wizard.py
+++ b/tests/setup/test_wizard.py
@@ -72,7 +72,7 @@ def test_docker_compose_valid_yaml() -> None:
 @pytest.mark.unit
 def test_wizard_rejects_nonexistent_document_root(tmp_path: Path) -> None:
     """Setup wizard fails cleanly when document root doesn't exist."""
-    from kairix.platform.setup.wizard import run_setup
+    from kairix.platform.setup.wizard import WizardDeps, run_setup
 
     output = tmp_path / "test-config.yaml"
     nonexistent = str(tmp_path / "does-not-exist")
@@ -85,7 +85,7 @@ def test_wizard_rejects_nonexistent_document_root(tmp_path: Path) -> None:
         ctx=ctx,
         document_path=nonexistent,
         preset="general",
-        connection_test_fn=lambda *_a, **_k: True,
+        deps=WizardDeps(connection_test=lambda *_a, **_k: True),
     )
 
     assert result is False, "Wizard should reject a non-existent document root"
@@ -97,7 +97,7 @@ def test_wizard_rejects_nonexistent_document_root_no_continue_option(
     tmp_path: Path,
 ) -> None:
     """Wizard must hard-reject a non-existent document root (no 'continue anyway?' escape)."""
-    from kairix.platform.setup.wizard import run_setup
+    from kairix.platform.setup.wizard import WizardDeps, run_setup
 
     output = tmp_path / "test-config.yaml"
     nonexistent = str(tmp_path / "does-not-exist")
@@ -113,7 +113,7 @@ def test_wizard_rejects_nonexistent_document_root_no_continue_option(
         ctx=ctx,
         document_path=nonexistent,
         preset="general",
-        connection_test_fn=lambda *_a, **_k: True,
+        deps=WizardDeps(connection_test=lambda *_a, **_k: True),
     )
 
     assert result is False
@@ -123,7 +123,7 @@ def test_wizard_rejects_nonexistent_document_root_no_continue_option(
 @pytest.mark.unit
 def test_wizard_accepts_valid_document_root(tmp_path: Path) -> None:
     """Setup wizard accepts a valid existing document root."""
-    from kairix.platform.setup.wizard import run_setup
+    from kairix.platform.setup.wizard import WizardDeps, run_setup
 
     output = tmp_path / "test-config.yaml"
     doc_dir = tmp_path / "docs"
@@ -137,7 +137,7 @@ def test_wizard_accepts_valid_document_root(tmp_path: Path) -> None:
         ctx=ctx,
         document_path=str(doc_dir),
         preset="general",
-        connection_test_fn=lambda *_a, **_k: True,
+        deps=WizardDeps(connection_test=lambda *_a, **_k: True),
     )
 
     assert result is True
@@ -147,7 +147,7 @@ def test_wizard_accepts_valid_document_root(tmp_path: Path) -> None:
 @pytest.mark.unit
 def test_run_setup_generates_config(tmp_path: Path, monkeypatch) -> None:
     """run_setup writes a valid YAML config file."""
-    from kairix.platform.setup.wizard import run_setup
+    from kairix.platform.setup.wizard import WizardDeps, run_setup
 
     output = tmp_path / "test-config.yaml"
 
@@ -175,7 +175,7 @@ def test_run_setup_generates_config(tmp_path: Path, monkeypatch) -> None:
 
     run_setup(
         output_path=str(output),
-        connection_test_fn=lambda *_a, **_k: False,
+        deps=WizardDeps(connection_test=lambda *_a, **_k: False),
     )
     # Setup may return False due to connection failure + "continue anyway"
     # but the config file should still be written
@@ -187,3 +187,65 @@ def test_run_setup_generates_config(tmp_path: Path, monkeypatch) -> None:
             config = yaml.safe_load(f)
         assert "retrieval" in config
         assert isinstance(config["retrieval"], dict)
+
+
+@pytest.mark.unit
+def test_wizard_deps_default_factory_binds_callable() -> None:
+    """``WizardDeps()`` with no overrides constructs a deps bag whose
+    ``connection_test`` field is a callable, not ``None``.
+
+    Sabotage proof: this is the corner the F6 issue specifically calls
+    out — ``Optional[Callable] = None`` self-resolving in ``__post_init__``
+    has landed mypy bugs. ``default_factory`` must bind a real callable
+    or this assertion fires. The test reads only the public field; it
+    does not import the private default function (that would violate F5).
+    """
+    from kairix.platform.setup.wizard import WizardDeps
+
+    deps = WizardDeps()
+    # The type system narrows this away, but we want a runtime sabotage:
+    # if the implementation regressed to ``Optional[Callable] = None``
+    # without a __post_init__, ``deps.connection_test`` would be None at
+    # runtime even if mypy were satisfied. The cast through callable() is
+    # what catches that.
+    assert callable(deps.connection_test), (
+        f"default_factory must bind a callable; got {deps.connection_test!r}. "
+        "Regressing to ``connection_test: Callable | None = None`` without a "
+        "post-init wire-up would leave this None and break run_setup."
+    )
+
+
+@pytest.mark.unit
+def test_wizard_deps_override_used_by_run_setup(tmp_path: Path) -> None:
+    """``run_setup(deps=WizardDeps(connection_test=fake))`` routes the wizard's
+    connection probe through the injected fake.
+
+    Sabotage proof: the fake records every call. If the wizard ignored
+    ``deps`` and fell through to the production probe, no calls would be
+    recorded and this test would fail.
+    """
+    from kairix.platform.setup.prompts import SetupContext
+    from kairix.platform.setup.wizard import WizardDeps, run_setup
+
+    calls: list[tuple[str, str, str, str]] = []
+
+    def _spy(provider: str, endpoint: str, api_key: str, embed_model: str) -> bool:
+        calls.append((provider, endpoint, api_key, embed_model))
+        return True
+
+    output = tmp_path / "test-config.yaml"
+    doc_dir = tmp_path / "docs"
+    doc_dir.mkdir()
+
+    ctx = SetupContext(interactive=False, json_mode=False, state_path=tmp_path / ".state.json")
+    run_setup(
+        output_path=str(output),
+        ctx=ctx,
+        document_path=str(doc_dir),
+        preset="general",
+        deps=WizardDeps(connection_test=_spy),
+    )
+
+    assert len(calls) == 1, f"injected probe should run exactly once; got {len(calls)} calls"
+    # Provider key from prompt default (Azure)
+    assert calls[0][0] == "azure"

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4,8 +4,8 @@ Covers:
   - run_embed catches exceptions without crashing
   - run_entity_seed catches exceptions without crashing
   - run_health_check catches exceptions without crashing
-  - run_embed calls embed_fn on success
-  - run_entity_seed calls entity_seed_fn on success
+  - run_embed calls deps.embed on success
+  - run_entity_seed calls deps.entity_seed on success
   - run_health_check counts results on success
   - Shutdown signal (SIGTERM / SIGINT) sets running=False and exits the loop
   - Main loop scheduling logic
@@ -23,6 +23,7 @@ from kairix.worker import (
     ENTITY_SEED_INTERVAL,
     HEALTH_CHECK_INTERVAL,
     WIKILINKS_INTERVAL,
+    WorkerDeps,
     main,
     run_embed,
     run_entity_seed,
@@ -44,7 +45,7 @@ def test_run_embed_catches_exceptions() -> None:
     def _failing_embed() -> None:
         raise RuntimeError("embed failed")
 
-    run_embed(embed_fn=_failing_embed)  # should not raise
+    run_embed(deps=WorkerDeps(embed=_failing_embed))  # should not raise
 
 
 def test_run_embed_catches_import_error() -> None:
@@ -53,21 +54,21 @@ def test_run_embed_catches_import_error() -> None:
     def _import_error_embed() -> None:
         raise ImportError("no module")
 
-    run_embed(embed_fn=_import_error_embed)
+    run_embed(deps=WorkerDeps(embed=_import_error_embed))
 
 
-def test_run_embed_calls_embed_fn() -> None:
-    """run_embed should call the injected embed_fn."""
+def test_run_embed_calls_embed_callable() -> None:
+    """run_embed should call the injected ``deps.embed`` callable."""
     calls: list[bool] = []
 
     def _tracking_embed() -> None:
         calls.append(True)
 
-    run_embed(embed_fn=_tracking_embed)
+    run_embed(deps=WorkerDeps(embed=_tracking_embed))
     assert len(calls) == 1
 
 
-def test_run_embed_survives_systemexit_from_embed_fn() -> None:
+def test_run_embed_survives_systemexit_from_embed_callable() -> None:
     """A ``SystemExit`` from the embed step MUST NOT propagate.
 
     This pins the v2026.5.10 fix: pre-fix, the worker called the embed
@@ -81,7 +82,7 @@ def test_run_embed_survives_systemexit_from_embed_fn() -> None:
         raise SystemExit(1)
 
     # Must not raise — SystemExit is caught and logged, worker continues.
-    run_embed(embed_fn=_exiting_embed)
+    run_embed(deps=WorkerDeps(embed=_exiting_embed))
 
 
 def test_run_embed_logs_recall_alert_from_pipeline_result(caplog: pytest.LogCaptureFixture) -> None:
@@ -104,7 +105,7 @@ def test_run_embed_logs_recall_alert_from_pipeline_result(caplog: pytest.LogCapt
     )
 
     with caplog.at_level("WARNING"):
-        run_embed(embed_fn=lambda: result)
+        run_embed(deps=WorkerDeps(embed=lambda: result))
 
     assert any("recall gate alert" in rec.message for rec in caplog.records), (
         f"expected 'recall gate alert' in logs; got: {[r.message for r in caplog.records]}"
@@ -126,7 +127,7 @@ def test_run_embed_logs_failed_chunk_count_from_pipeline_result(caplog: pytest.L
     )
 
     with caplog.at_level("WARNING"):
-        run_embed(embed_fn=lambda: result)
+        run_embed(deps=WorkerDeps(embed=lambda: result))
 
     assert any("3 chunks failed" in rec.message for rec in caplog.records), (
         f"expected '3 chunks failed' in logs; got: {[r.message for r in caplog.records]}"
@@ -144,7 +145,7 @@ def test_run_entity_seed_catches_exceptions() -> None:
     def _failing_seed() -> None:
         raise RuntimeError("store crawl failed")
 
-    run_entity_seed(entity_seed_fn=_failing_seed)  # should not raise
+    run_entity_seed(deps=WorkerDeps(entity_seed=_failing_seed))  # should not raise
 
 
 def test_run_entity_seed_catches_import_error() -> None:
@@ -153,17 +154,17 @@ def test_run_entity_seed_catches_import_error() -> None:
     def _import_error_seed() -> None:
         raise ImportError("no module")
 
-    run_entity_seed(entity_seed_fn=_import_error_seed)
+    run_entity_seed(deps=WorkerDeps(entity_seed=_import_error_seed))
 
 
-def test_run_entity_seed_calls_entity_seed_fn() -> None:
-    """run_entity_seed should call the injected entity_seed_fn."""
+def test_run_entity_seed_calls_entity_seed_callable() -> None:
+    """run_entity_seed should call the injected ``deps.entity_seed``."""
     calls: list[bool] = []
 
     def _tracking_seed() -> None:
         calls.append(True)
 
-    run_entity_seed(entity_seed_fn=_tracking_seed)
+    run_entity_seed(deps=WorkerDeps(entity_seed=_tracking_seed))
     assert len(calls) == 1
 
 
@@ -183,7 +184,7 @@ def test_run_health_check_catches_exceptions() -> None:
     def _failing_check() -> list:
         raise RuntimeError("check failed")
 
-    run_health_check(health_check_fn=_failing_check)  # should not raise
+    run_health_check(deps=WorkerDeps(health_check=_failing_check))  # should not raise
 
 
 def test_run_health_check_catches_import_error() -> None:
@@ -192,7 +193,7 @@ def test_run_health_check_catches_import_error() -> None:
     def _import_error_check() -> list:
         raise ImportError("no module")
 
-    run_health_check(health_check_fn=_import_error_check)
+    run_health_check(deps=WorkerDeps(health_check=_import_error_check))
 
 
 def test_run_health_check_counts_results() -> None:
@@ -205,7 +206,7 @@ def test_run_health_check_counts_results() -> None:
             _FakeCheckResult(ok=True),
         ]
 
-    run_health_check(health_check_fn=_mixed_results)  # should not raise
+    run_health_check(deps=WorkerDeps(health_check=_mixed_results))  # should not raise
 
 
 # ---------------------------------------------------------------------------
@@ -230,6 +231,54 @@ def test_worker_constants() -> None:
 
 
 # ---------------------------------------------------------------------------
+# WorkerDeps default factories — F6 sabotage proofs
+# ---------------------------------------------------------------------------
+
+
+def test_worker_deps_default_factory_binds_callable_for_every_field() -> None:
+    """``WorkerDeps()`` with no overrides constructs a deps bag whose every
+    callable field is non-None and callable.
+
+    Sabotage proof: the F6 issue specifically rejects the
+    ``Optional[Callable] = None`` self-resolving pattern as having "just
+    landed a mypy bug". Every field on this dataclass uses
+    ``default_factory`` instead. If any field regressed to ``None`` by
+    default, the corresponding ``callable()`` check fires. The test reads
+    only the public field names (``embed``, ``entity_seed``, etc.) and
+    does not import the private ``_default_*`` helpers — that would
+    violate F5 (no internal-name imports in tests).
+    """
+    deps = WorkerDeps()
+    for name in ("embed", "entity_seed", "health_check", "wikilinks", "sleep"):
+        value = getattr(deps, name)
+        assert callable(value), (
+            f"default_factory for WorkerDeps.{name} must bind a callable; "
+            f"got {value!r}. Regressing to ``{name}: Callable | None = None`` would leave this None."
+        )
+
+
+def test_worker_deps_partial_override_preserves_other_defaults() -> None:
+    """Constructing ``WorkerDeps(embed=fake)`` overrides only ``embed``;
+    the other four fields keep their default-factory-bound callables.
+
+    Sabotage proof: production tests rely on this — they swap one callable
+    while letting the rest fall through. If the dataclass demanded every
+    field set explicitly, this would fail with TypeError. If a default
+    regressed to ``None``, ``callable()`` would fail for that field.
+    """
+
+    def fake_embed() -> None:
+        return None
+
+    deps = WorkerDeps(embed=fake_embed)
+    assert deps.embed is fake_embed, "the override field must be the injected callable"
+    # Other fields keep their factory-bound defaults — none are None.
+    for name in ("entity_seed", "health_check", "wikilinks", "sleep"):
+        value = getattr(deps, name)
+        assert callable(value), f"WorkerDeps.{name} must remain callable after partial override"
+
+
+# ---------------------------------------------------------------------------
 # Shutdown signal tests
 # ---------------------------------------------------------------------------
 
@@ -250,10 +299,12 @@ def test_shutdown_handler_sets_running_false() -> None:
             os.kill(os.getpid(), signal.SIGTERM)
 
     main(
-        embed_fn=embed_then_signal,
-        entity_seed_fn=lambda: None,
-        health_check_fn=lambda: [],
-        sleep_fn=lambda _s: None,
+        deps=WorkerDeps(
+            embed=embed_then_signal,
+            entity_seed=lambda: None,
+            health_check=lambda: [],
+            sleep=lambda _s: None,
+        ),
         embed_interval=999999,
         entity_seed_interval=999999,
         health_check_interval=999999,
@@ -287,10 +338,12 @@ def test_main_loop_runs_embed_on_interval() -> None:
         return []
 
     main(
-        embed_fn=embed_counter,
-        entity_seed_fn=entity_then_noop,
-        health_check_fn=health_then_noop,
-        sleep_fn=lambda _s: None,
+        deps=WorkerDeps(
+            embed=embed_counter,
+            entity_seed=entity_then_noop,
+            health_check=health_then_noop,
+            sleep=lambda _s: None,
+        ),
         # Set all intervals to 0 so every task fires on every loop iteration
         embed_interval=0,
         entity_seed_interval=0,
@@ -317,10 +370,12 @@ def test_shutdown_handler_via_sigint() -> None:
             os.kill(os.getpid(), signal.SIGINT)
 
     main(
-        embed_fn=embed_then_sigint,
-        entity_seed_fn=lambda: None,
-        health_check_fn=lambda: [],
-        sleep_fn=lambda _s: None,
+        deps=WorkerDeps(
+            embed=embed_then_sigint,
+            entity_seed=lambda: None,
+            health_check=lambda: [],
+            sleep=lambda _s: None,
+        ),
         embed_interval=999999,
         entity_seed_interval=999999,
         health_check_interval=999999,
@@ -334,14 +389,14 @@ def test_shutdown_handler_via_sigint() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_run_wikilinks_inject_calls_wikilinks_fn() -> None:
+def test_run_wikilinks_inject_calls_wikilinks_callable() -> None:
     called = False
 
     def _inject() -> None:
         nonlocal called
         called = True
 
-    run_wikilinks_inject(wikilinks_fn=_inject)
+    run_wikilinks_inject(deps=WorkerDeps(wikilinks=_inject))
     assert called
 
 
@@ -349,7 +404,7 @@ def test_run_wikilinks_inject_catches_exceptions() -> None:
     def _failing() -> None:
         raise RuntimeError("kapow")
 
-    run_wikilinks_inject(wikilinks_fn=_failing)  # must not raise
+    run_wikilinks_inject(deps=WorkerDeps(wikilinks=_failing))  # must not raise
 
 
 def test_run_wikilinks_inject_survives_systemexit() -> None:
@@ -360,7 +415,7 @@ def test_run_wikilinks_inject_survives_systemexit() -> None:
     def _exits() -> None:
         raise SystemExit(1)
 
-    run_wikilinks_inject(wikilinks_fn=_exits)  # must not propagate
+    run_wikilinks_inject(deps=WorkerDeps(wikilinks=_exits))  # must not propagate
 
 
 def test_main_loop_calls_wikilinks_at_interval() -> None:
@@ -379,11 +434,13 @@ def test_main_loop_calls_wikilinks_at_interval() -> None:
         call_counts["wikilinks"] += 1
 
     main(
-        embed_fn=_embed_then_shutdown,
-        entity_seed_fn=lambda: None,
-        health_check_fn=lambda: [],
-        wikilinks_fn=_wikilinks,
-        sleep_fn=lambda _s: None,
+        deps=WorkerDeps(
+            embed=_embed_then_shutdown,
+            entity_seed=lambda: None,
+            health_check=lambda: [],
+            wikilinks=_wikilinks,
+            sleep=lambda _s: None,
+        ),
         embed_interval=0,
         entity_seed_interval=999999,
         health_check_interval=999999,


### PR DESCRIPTION
## Summary

Phase 4 / wave 1 of #199 — F6 (no `*_fn=None` test-only kwargs in production) for three of the twelve baselined files. Converts the test-only kwargs on `run_setup`, `retrieve`, and `worker.main` (plus its task helpers) to typed `*Deps` dataclasses with `default_factory` (NOT the `Optional[Callable]` self-resolving pattern, which the issue calls out as having "just landed a mypy bug").

`kairix/quality/benchmark/runner.py` (also in the original 12-file list) is being handled by PR #209 — this PR forwards through that file's existing `search_fn` kwarg into the new `RetrievalDeps(searcher=...)` so the two PRs are independent.

## Files updated

- `kairix/platform/setup/wizard.py` — introduces `WizardDeps(connection_test: Callable[..., bool])`. `run_setup(deps: WizardDeps | None = None)` replaces `connection_test_fn=None`. **F6 baseline: removed.** F7 baseline: kept (per-file coverage at ~66%; lifting that floor is a separate ticket).
- `kairix/quality/eval/retrieval.py` — introduces `RetrievalDeps(pipeline_builder: Callable, searcher: Callable | None)`. `retrieve(deps: RetrievalDeps | None = None)` replaces parallel `search_fn=None` / `pipeline_builder=None` kwargs. `searcher` stays Optional because the two seams are mutually exclusive (a pre-bound searcher means "skip pipeline construction"); the name doesn't end in `_fn` so it's clear of F6. **F6 baseline: removed.**
- `kairix/worker.py` — introduces `WorkerDeps(embed, entity_seed, health_check, wikilinks, sleep)`. `main()` and the four `run_*` helpers all take `deps: WorkerDeps | None = None`, replacing the five separate `*_fn=None` kwargs on `main()` plus per-helper `*_fn=None` kwargs. **F6 baseline: removed.**
- `kairix/quality/benchmark/runner.py` — only the call site updated: forwards `search_fn=` (its own F6-baselined kwarg, scope of #209) into `RetrievalDeps(searcher=...)`. The runner's signature is unchanged.

## Test plan

- [x] `bash scripts/safe-commit.sh` — ruff lint/format, mypy --strict, pytest unit+bdd+contract (3189 passed), arch fitness (F1-F13 except F7/F9 which run in CI), detect-secrets, confidential check.
- [x] `pre-commit run --all-files` — all hooks pass.
- [x] All 49 tests in the touched test modules pass (`tests/setup/`, `tests/eval/`, `tests/test_worker.py`, `tests/benchmark/test_collection_scope.py`).
- [ ] CI Stage 0 (arch fitness, F6) green — the three files are no longer expected on the F6 baseline.
- [ ] CI Stage 2 (unit + F7 per-file 85%) green — wizard.py stays on F7 baseline; retrieval.py and worker.py were never on it.
- [ ] CI Stage 3 (integration), Stage 5 (security), Docker green.

## Sabotage proofs added

- `WizardDeps()`, `RetrievalDeps()`, `WorkerDeps()` constructed with no args — every callable field is verified `callable()` (no internal-name imports of the `_default_*` helpers, per F5). Catches a regression to the rejected `Optional[Callable] = None` pattern.
- `RetrievalDeps(searcher=spy, pipeline_builder=exploding_builder)` — when `searcher` is set the builder must NOT be called; the exploding builder makes the test fail loudly if the precedence flips.
- `WizardDeps(connection_test=spy)` — `run_setup` is driven through the public surface and the spy records every call; injection is proven end-to-end.
- `WorkerDeps(embed=fake)` — partial override leaves the other four factory-bound defaults intact (each verified callable).

## Baselines updated

- F6: removed `kairix/platform/setup/wizard.py`, `kairix/quality/eval/retrieval.py`, `kairix/worker.py` from `.architecture/baseline/no-test-only-kwargs-files.txt` (3 of 12 lines gone; `runner.py` stays — that's #209's scope).
- F7 / F9: no change. `wizard.py` stays at ~66% per-file coverage; lifting it past the 85% floor is a separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)