### PR TITLE
ci(release): fan out to docker-publish + publish-pypi via workflow_dispatch (resolves #230)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,6 +15,15 @@ on:
       - "kairix/**"
       - "pyproject.toml"
       - "reference-library/**"
+  workflow_dispatch:
+    # Manual entrypoint used by release.yml to re-fire publish after a
+    # GITHUB_TOKEN-created release (which doesn't fan out — #230). Also
+    # useful for backfilling a missed release.
+    inputs:
+      ref:
+        description: 'Git ref to build (tag for release builds, e.g. v2026.5.14)'
+        required: true
+        type: string
 
 env:
   REGISTRY: ghcr.io
@@ -29,6 +38,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          # workflow_dispatch checks out the input ref so we build the
+          # tagged commit, not the default branch tip.
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
 
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
@@ -44,9 +57,14 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           REF_NAME: ${{ github.ref_name }}
+          INPUT_REF: ${{ inputs.ref }}
         run: |
           if [ "$EVENT_NAME" = "release" ]; then
             VERSION="${REF_NAME#v}"
+            echo "tags=${IMAGE}:latest,${IMAGE}:${VERSION}" >> "$GITHUB_OUTPUT"
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            # Treat manual dispatch with a vX.Y.Z ref the same as a release.
+            VERSION="${INPUT_REF#v}"
             echo "tags=${IMAGE}:latest,${IMAGE}:${VERSION}" >> "$GITHUB_OUTPUT"
           else
             echo "tags=${IMAGE}:develop" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -11,6 +11,14 @@ name: "4 · PyPI publish (release)"
 on:
   release:
     types: [created]
+  workflow_dispatch:
+    # Manual entrypoint used by release.yml to re-fire publish after a
+    # GITHUB_TOKEN-created release (which doesn't fan out — #230).
+    inputs:
+      ref:
+        description: 'Git tag to build + publish (e.g. v2026.5.14)'
+        required: true
+        type: string
 
 jobs:
   build:
@@ -21,6 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
           fetch-depth: 0  # setuptools-scm needs full history
 
       - uses: hynek/build-and-inspect-python-package@fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e # v2
@@ -60,7 +69,9 @@ jobs:
         # the long form; ``import kairix`` and the ``kairix`` console
         # script are unchanged for end users.
         env:
-          TAG_NAME: ${{ github.event.release.tag_name }}
+          # release event provides .release.tag_name; workflow_dispatch
+          # passes the tag via inputs.ref.
+          TAG_NAME: ${{ github.event.release.tag_name || inputs.ref }}
         run: |
           VERSION="${TAG_NAME#v}"
           pip install "kairix-agentic-knowledge-mgt==${VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ on:
 
 permissions:
   contents: write  # required to create tags + releases
+  actions: write   # required to dispatch downstream publish workflows (#230)
 
 jobs:
   release:
@@ -82,6 +83,19 @@ jobs:
               --notes-file /tmp/release-notes.md \
               --verify-tag
 
+      - name: Fan out to docker-publish + publish-pypi
+        # Releases created via GITHUB_TOKEN don't fan out to other
+        # workflows (GitHub's recursion guard — #230). We explicitly
+        # dispatch the downstream workflows here so a single
+        # `gh workflow run release.yml` call ends with image + PyPI
+        # published, no manual follow-up required.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          gh workflow run docker-publish.yml --ref main --field ref="$VERSION"
+          gh workflow run publish-pypi.yml   --ref main --field ref="$VERSION"
+
       - name: Summary
         env:
           VERSION: ${{ inputs.version }}
@@ -91,8 +105,7 @@ jobs:
             echo ""
             echo "- Tag pushed: \`$VERSION\`"
             echo "- GitHub Release created with notes from CHANGELOG.md"
-            echo ""
-            echo "Downstream workflows fire on the release event:"
-            echo "- 3 · Docker publish (release)"
-            echo "- 4 · PyPI publish (release)"
+            echo "- Downstream publishes dispatched:"
+            echo "  - 3 · Docker publish (release)"
+            echo "  - 4 · PyPI publish (release)"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Fixes the GITHUB_TOKEN fan-out gap that left v2026.5.14 without auto-published Docker image + PyPI package.

## Changes

- `docker-publish.yml`: add `workflow_dispatch` input `ref`; honour it in checkout + tag derivation.
- `publish-pypi.yml`: same shape — `workflow_dispatch` input `ref`, honoured in checkout + smoke-test tag.
- `release.yml`: add `actions: write` permission + final step that calls `gh workflow run` for both publish workflows after the GitHub Release is created.

## Outcome

A single `gh workflow run release.yml -f version=vX.Y.Z` now ends with:
1. Tag pushed
2. GitHub Release created with CHANGELOG-extracted notes
3. Docker image built + pushed (`:latest` + `:vX.Y.Z`)
4. PyPI package built + published + smoke-tested

No manual follow-up.

## Test plan

- [x] Land on develop
- [ ] Merge to main
- [ ] Manually trigger docker-publish.yml + publish-pypi.yml for v2026.5.14 (one-time backfill — the next release will use the chained release.yml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)