### PR TITLE
fix(ci+suite): point docker image at three-cubes org + reflib suite metadata

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -27,7 +27,9 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE: ghcr.io/quanyeomans/kairix
+  # Repo is at three-cubes/kairix; GITHUB_TOKEN can only push to the repo's own org.
+  # Old images at ghcr.io/quanyeomans/kairix remain in place but are no longer the publish target.
+  IMAGE: ghcr.io/three-cubes/kairix
 
 jobs:
   build-and-push:

--- a/suites/reflib-gold-v3.yaml
+++ b/suites/reflib-gold-v3.yaml
@@ -2,6 +2,9 @@ meta:
   version: '1.0'
   generated_by: kairix eval generate
   n_cases: 200
+  name: reflib
+  description: Reference library retrieval gold suite (200 cases across 6 categories)
+  default_collection: reference-library  # in_default: false in stock config; CLI auto-scopes
   categories:
   - recall
   - temporal


### PR DESCRIPTION
Backfill of v2026.5.14 docker-publish failed because IMAGE env still pointed at the pre-org-rename ghcr.io/quanyeomans/kairix. GITHUB_TOKEN can only push to the repo's own org. Switching to ghcr.io/three-cubes/kairix.

Also adds meta.name / meta.description / meta.default_collection to suites/reflib-gold-v3.yaml — first hook of #222 (suite metadata; CLI plumbing follows in a separate PR).

## Test plan
- [ ] Merge and re-trigger docker-publish for v2026.5.14
- [ ] Verify image lands at ghcr.io/three-cubes/kairix:v2026.5.14
- [ ] File PyPI trusted-publisher config gap separately (admin task)