### PR TITLE
refactor(store/crawler): promote helpers to public (Wave 3 / #201, F5 -1)

### DIFF
--- a/.architecture/baseline/no-internal-test-imports-files.txt
+++ b/.architecture/baseline/no-internal-test-imports-files.txt
@@ -1,5 +1,4 @@
 tests/bdd/steps/recall_steps.py
 tests/contracts/test_eval_protocols.py
 tests/search/test_config_loader.py
-tests/store/test_crawler.py
 tests/test_paths.py

--- a/kairix/knowledge/store/crawler.py
+++ b/kairix/knowledge/store/crawler.py
@@ -79,7 +79,7 @@ def crawl_organisations(
     for org_dir in sorted(clients_dir.iterdir()):
         if not org_dir.is_dir():
             continue
-        org_id = _to_slug(org_dir.name)
+        org_id = slugify(org_dir.name)
         # Canonical note: {OrgDir}/{OrgDir}.md (index file)
         index_md = org_dir / f"{org_dir.name}.md"
         canonical: Path | None
@@ -92,19 +92,19 @@ def crawl_organisations(
 
         fm: dict[str, Any] = {}
         if canonical:
-            fm = _parse_frontmatter(canonical)
+            fm = parse_frontmatter(canonical)
 
         vault_path = str(canonical.relative_to(root)) if canonical else str(org_dir.relative_to(root))
         node = OrganisationNode(
             id=org_id,
-            name=fm.get("name") or _to_display_name(org_dir.name),
+            name=fm.get("name") or display_name(org_dir.name),
             tier=str(fm.get("tier", "client")),
             engagement_status=str(fm.get("engagement_status", "active")),
             vault_path=vault_path,
-            industry=_as_list(fm.get("industry")),
-            geography=_as_list(fm.get("geography")),
-            stakeholder_personas=_as_list(fm.get("stakeholder_personas")),
-            aliases=_as_list(fm.get("aliases")),
+            industry=as_list(fm.get("industry")),
+            geography=as_list(fm.get("geography")),
+            stakeholder_personas=as_list(fm.get("stakeholder_personas")),
+            aliases=as_list(fm.get("aliases")),
         )
         orgs[org_dir.name.lower()] = node
         orgs[org_id] = node
@@ -133,8 +133,8 @@ def crawl_persons(
     persons: dict[str, PersonNode] = {}
     for people_dir in _find_people_dirs(root):
         for md_file in sorted(people_dir.glob("*.md")):
-            person_id = _to_slug(md_file.stem)
-            fm = _parse_frontmatter(md_file)
+            person_id = slugify(md_file.stem)
+            fm = parse_frontmatter(md_file)
             vault_path = str(md_file.relative_to(root))
 
             # Resolve org by name lookup in discovered orgs
@@ -143,14 +143,14 @@ def crawl_persons(
 
             person_node = PersonNode(
                 id=person_id,
-                name=fm.get("name") or _to_display_name(md_file.stem),
+                name=fm.get("name") or display_name(md_file.stem),
                 org=org_id,
                 role=str(fm.get("role") or ""),
                 relationship_type=str(fm.get("relationship_type") or "network"),
                 last_interaction=str(fm.get("last_interaction") or ""),
                 vault_path=vault_path,
-                interests=_as_list(fm.get("interests")),
-                aliases=_as_list(fm.get("aliases")),
+                interests=as_list(fm.get("interests")),
+                aliases=as_list(fm.get("aliases")),
             )
             persons[person_id] = person_node
             report.persons_found += 1
@@ -190,13 +190,13 @@ def crawl_outcomes(root: Path, report: CrawlReport, neo4j_client: Any, dry_run: 
         return
 
     for md_file in sorted(outcomes_dir.rglob("*.md")):
-        outcome_id = _to_slug(md_file.stem)
-        fm = _parse_frontmatter(md_file)
+        outcome_id = slugify(md_file.stem)
+        fm = parse_frontmatter(md_file)
         vault_path = str(md_file.relative_to(root))
 
         outcome_node = OutcomeNode(
             id=outcome_id,
-            name=fm.get("name") or _to_display_name(md_file.stem),
+            name=fm.get("name") or display_name(md_file.stem),
             domain=str(fm.get("domain") or ""),
             vault_path=vault_path,
         )
@@ -230,7 +230,7 @@ def crawl_wikilink_edges(
 
         source_path = str(md_file.relative_to(root))
         for link_target in _WIKILINK_PATTERN.findall(text):
-            target_slug = _to_slug(link_target.split("/")[-1])
+            target_slug = slugify(link_target.split("/")[-1])
             if target_slug not in all_known:
                 continue
             # Determine label of target
@@ -240,7 +240,7 @@ def crawl_wikilink_edges(
                 to_label, to_id = "Person", persons[target_slug].id
 
             edge = GraphEdge(
-                from_id=_to_slug(md_file.stem),
+                from_id=slugify(md_file.stem),
                 from_label="Document",
                 to_id=to_id,
                 to_label=to_label,
@@ -292,7 +292,7 @@ def crawl(
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 
-def _parse_frontmatter(path: Path) -> dict[str, Any]:
+def parse_frontmatter(path: Path) -> dict[str, Any]:
     """Parse YAML frontmatter from a markdown file. Returns {} on any failure.
 
     Delegates text extraction to ``extract_existing_frontmatter``, then
@@ -345,21 +345,7 @@ def _find_people_dirs(document_root: Path) -> list[Path]:
     return found
 
 
-def _to_slug(name: str) -> str:
-    """Convert a vault directory/file name to a lowercase hyphenated slug.
-
-    Delegates to ``kairix.utils.slugify`` — kept as a local alias for
-    backwards compatibility (tests import this private name).
-    """
-    return slugify(name)
-
-
-def _to_display_name(name: str) -> str:
-    """Convert slug/filename to a display name (title case, hyphens → spaces)."""
-    return display_name(name)
-
-
-def _as_list(value: Any) -> list[str]:
+def as_list(value: Any) -> list[str]:
     """Normalise a scalar, list, or None frontmatter field to list[str]."""
     if value is None:
         return []
@@ -370,7 +356,7 @@ def _as_list(value: Any) -> list[str]:
 
 def _resolve_org_id(org_raw: str, orgs: dict[str, OrganisationNode]) -> str:
     """Find an org id by name or partial match in the discovered orgs dict."""
-    slug = _to_slug(org_raw)
+    slug = slugify(org_raw)
     if slug in orgs:
         return str(orgs[slug].id)
     # Partial match: org_raw is a substring of a known org name

--- a/tests/store/test_crawler.py
+++ b/tests/store/test_crawler.py
@@ -13,12 +13,11 @@ import pytest
 
 from kairix.knowledge.store.crawler import (
     CrawlReport,
-    _as_list,
-    _parse_frontmatter,
-    _to_display_name,
-    _to_slug,
+    as_list,
     crawl,
+    parse_frontmatter,
 )
+from kairix.utils import display_name, slugify
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -48,37 +47,37 @@ def _make_neo4j(available: bool = True) -> MagicMock:
 
 @pytest.mark.unit
 def test_to_slug_basic() -> None:
-    assert _to_slug("Acme Australia") == "acme-australia"
+    assert slugify("Acme Australia") == "acme-australia"
 
 
 @pytest.mark.unit
 def test_to_slug_hyphens_preserved() -> None:
-    assert _to_slug("test-person") == "test-person"
+    assert slugify("test-person") == "test-person"
 
 
 @pytest.mark.unit
 def test_to_slug_special_chars() -> None:
-    assert _to_slug("Example Ventures!") == "example-ventures"
+    assert slugify("Example Ventures!") == "example-ventures"
 
 
 @pytest.mark.unit
-def test_to_display_name() -> None:
-    assert _to_display_name("acme-australia") == "Acme Australia"
+def testdisplay_name() -> None:
+    assert display_name("acme-australia") == "Acme Australia"
 
 
 @pytest.mark.unit
 def test_as_list_none() -> None:
-    assert _as_list(None) == []
+    assert as_list(None) == []
 
 
 @pytest.mark.unit
 def test_as_list_scalar() -> None:
-    assert _as_list("consulting") == ["consulting"]
+    assert as_list("consulting") == ["consulting"]
 
 
 @pytest.mark.unit
 def test_as_list_list() -> None:
-    assert _as_list(["a", "b"]) == ["a", "b"]
+    assert as_list(["a", "b"]) == ["a", "b"]
 
 
 @pytest.mark.unit
@@ -87,7 +86,7 @@ def test_parse_frontmatter_valid(tmp_path: Path) -> None:
         tmp_path / "test.md",
         "---\nname: Acme\ntier: client\n---\n# Body",
     )
-    fm = _parse_frontmatter(md)
+    fm = parse_frontmatter(md)
     assert fm["name"] == "Acme"
     assert fm["tier"] == "client"
 
@@ -95,13 +94,13 @@ def test_parse_frontmatter_valid(tmp_path: Path) -> None:
 @pytest.mark.unit
 def test_parse_frontmatter_no_frontmatter(tmp_path: Path) -> None:
     md = _write(tmp_path / "test.md", "# Just content\nno frontmatter")
-    fm = _parse_frontmatter(md)
+    fm = parse_frontmatter(md)
     assert fm == {}
 
 
 @pytest.mark.unit
 def test_parse_frontmatter_missing_file() -> None:
-    fm = _parse_frontmatter(Path("/nonexistent/file.md"))
+    fm = parse_frontmatter(Path("/nonexistent/file.md"))
     assert fm == {}
 
 


### PR DESCRIPTION
## Summary
- Promotes `_parse_frontmatter` -> `parse_frontmatter` and `_as_list` -> `as_list` in `kairix/knowledge/store/crawler.py`.
- Drops the `_to_slug` / `_to_display_name` local shims; production code (and the test file) now call `kairix.utils.slugify` / `display_name` directly.
- Updates `tests/store/test_crawler.py` to import the public names.
- Removes `tests/store/test_crawler.py` from `.architecture/baseline/no-internal-test-imports-files.txt`. F5 violators -1.

Continues the Wave 3 / #201 F5 cleanup pattern (see #216, e26e5c0e, d87c2fd6, e523cd8b).

## Test plan
- [x] `pytest tests/store/test_crawler.py` -> 26 passed
- [x] `bash scripts/safe-commit.sh` -> all gates green (3296 tests, ruff, mypy, arch fitness, secrets)
- [x] `pre-commit run --all-files` -> all hooks pass (including F5)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>