### PR TITLE
refactor(contracts/eval): drop kairix._azure import via default_chat_backend factory (Wave 3 / #201, F5 -1)

### DIFF
--- a/.architecture/baseline/no-internal-test-imports-files.txt
+++ b/.architecture/baseline/no-internal-test-imports-files.txt
@@ -1,5 +1,4 @@
 tests/bdd/steps/recall_steps.py
-tests/contracts/test_eval_protocols.py
 tests/search/test_config_loader.py
 tests/store/test_crawler.py
 tests/test_paths.py

--- a/tests/contracts/test_eval_protocols.py
+++ b/tests/contracts/test_eval_protocols.py
@@ -53,15 +53,22 @@ class TestChatBackendContract:
         with pytest.raises(ValueError, match="No API credentials"):
             backend.complete("p", api_key="k", endpoint="e", deployment="d")
 
-    def test_azure_chat_backend_satisfies_protocol(self) -> None:
-        """The production ``AzureChatBackend`` adapter satisfies the protocol.
+    def test_production_chat_backend_satisfies_protocol(self) -> None:
+        """The production chat-backend factory returns a ``ChatBackend``.
 
-        Phase 2a adds the adapter class so production callers can inject a
+        Phase 2a adds the adapter so production callers can inject a
         ``ChatBackend`` rather than calling ``chat_completion`` directly.
-        """
-        from kairix._azure import AzureChatBackend
 
-        assert isinstance(AzureChatBackend(), ChatBackend)
+        F5-clean: drive through the public ``default_chat_backend()``
+        factory rather than importing the concrete adapter class from the
+        private ``kairix._azure`` module. The concrete class is an
+        implementation detail; what callers depend on is the protocol
+        surface.
+        """
+        from kairix.quality.eval.generate import default_chat_backend
+
+        backend = default_chat_backend()
+        assert isinstance(backend, ChatBackend)
 
 
 @pytest.mark.contract


### PR DESCRIPTION
## Summary
- Rewrites `tests/contracts/test_eval_protocols.py::test_azure_chat_backend_satisfies_protocol` to drive through the public `default_chat_backend()` factory in `kairix.quality.eval.generate` instead of importing `AzureChatBackend` directly from the private `kairix._azure` module.
- Renames the test to `test_production_chat_backend_satisfies_protocol` since the concrete adapter class is now treated as an implementation detail — what the contract asserts is the protocol surface.
- Drops `tests/contracts/test_eval_protocols.py` from `.architecture/baseline/no-internal-test-imports-files.txt`. 4 F5 violators remain (down from 5).

Follows the same pattern as e523cd8b (eval/generate promotion + protocol-shape assertion).

## Test plan
- [x] `bash scripts/safe-commit.sh` green (lint, format, mypy strict, 3296 tests pass, arch fitness, secrets)
- [x] `pre-commit run --all-files` green (all F1-F13 gates pass)
- [x] `pytest tests/contracts/test_eval_protocols.py -v` — 18/18 pass
- [x] F5 baseline now lists 4 files; net-new F5 violator count is 0

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>