### PR TITLE
refactor(recall_check): promote build_adaptive_queries + get_recall_queries to public (F5 -1)

### DIFF
--- a/.architecture/baseline/no-internal-test-imports-files.txt
+++ b/.architecture/baseline/no-internal-test-imports-files.txt
@@ -1,3 +1,2 @@
-tests/bdd/steps/recall_steps.py
 tests/search/test_config_loader.py
 tests/test_paths.py

--- a/kairix/core/embed/recall_check.py
+++ b/kairix/core/embed/recall_check.py
@@ -77,7 +77,7 @@ class VectorSearcher(Protocol):
     def search_vectors(self, vector: np.ndarray, *, limit: int) -> list[str]: ...
 
 
-def _get_recall_queries(
+def get_recall_queries(
     db: sqlite3.Connection | None = None,
     *,
     cache_path: Path | None = CANARY_CACHE,
@@ -102,7 +102,7 @@ def _get_recall_queries(
             return cached
 
     if db is not None:
-        adaptive = _build_adaptive_queries(db)
+        adaptive = build_adaptive_queries(db)
         if adaptive:
             if cache_path is not None:
                 save_canary_cache(adaptive, cache_path)
@@ -111,7 +111,7 @@ def _get_recall_queries(
     return list(DEFAULT_RECALL_QUERIES)
 
 
-def _build_adaptive_queries(db: sqlite3.Connection) -> list[tuple[str, str, str]]:
+def build_adaptive_queries(db: sqlite3.Connection) -> list[tuple[str, str, str]]:
     """Build recall queries from a random sample of indexed document titles.
 
     Called once per canary cache lifetime. The randomness here is fine
@@ -420,7 +420,7 @@ class RecallChecker:
         if recall_queries is not None:
             queries = recall_queries
         else:
-            queries = _get_recall_queries(db, cache_path=canary_cache_path, rebuild=rebuild_canaries)
+            queries = get_recall_queries(db, cache_path=canary_cache_path, rebuild=rebuild_canaries)
         passed = 0
         detail: list[dict[str, Any]] = []
 
@@ -526,7 +526,7 @@ def run_recall_gate(
     and ``alert_callback`` is invoked with a human-readable message.
 
     The canary suite is sourced from a persistent on-disk cache so the
-    same queries fire on every run — see ``_get_recall_queries``. Pass
+    same queries fire on every run — see ``get_recall_queries``. Pass
     ``rebuild_canaries=True`` (or run ``kairix embed --rebuild-canaries``)
     to discard the cache and re-sample.
 

--- a/tests/bdd/steps/recall_steps.py
+++ b/tests/bdd/steps/recall_steps.py
@@ -20,8 +20,8 @@ from pytest_bdd import given, parsers, then, when
 from kairix.core.embed.recall_check import (
     DEFAULT_RECALL_QUERIES,
     RecallChecker,
-    _build_adaptive_queries,
-    _get_recall_queries,
+    build_adaptive_queries,
+    get_recall_queries,
     run_recall_gate,
 )
 
@@ -59,8 +59,8 @@ def index_with_titled_documents() -> None:
 
 
 @when("the recall check builds adaptive queries")
-def build_adaptive_queries() -> None:
-    _state["queries"] = _build_adaptive_queries(_state["db"])
+def step_build_adaptive_queries() -> None:
+    _state["queries"] = build_adaptive_queries(_state["db"])
 
 
 @then("at least 3 recall queries are generated")
@@ -95,7 +95,7 @@ def build_queries() -> None:
     # exercises the build path each run (otherwise the first scenario
     # populates ~/.cache/kairix/recall-canaries.json and subsequent
     # scenarios load from that cache).
-    _state["queries"] = _get_recall_queries(_state["db"], cache_path=None)
+    _state["queries"] = get_recall_queries(_state["db"], cache_path=None)
 
 
 @then("the default recall queries are used")

--- a/tests/embed/test_canary_cache.py
+++ b/tests/embed/test_canary_cache.py
@@ -9,9 +9,10 @@ unrelated query sets.
 
 These tests pin the contract by exercising the **public** API
 (``RecallChecker.check`` + ``load_canary_cache`` / ``save_canary_cache``)
-and observing the cache file as a side effect. We do not import the
-private ``_get_recall_queries`` helper — that's an F5 violation and
-also means we'd be testing the wrong surface.
+and observing the cache file as a side effect. We deliberately do not
+reach for ``get_recall_queries`` directly — driving the canary-cache
+behaviour through ``RecallChecker.check`` exercises the same surface
+production callers hit.
 
 Pinned behaviour:
 

--- a/tests/embed/test_recall_check.py
+++ b/tests/embed/test_recall_check.py
@@ -488,7 +488,7 @@ def test_recall_checker_falls_through_to_defaults_when_db_has_no_recall_queries_
     """
     db_path = tmp_path / "no-recall-table.sqlite"
     db = sqlite3.connect(str(db_path))
-    # Just a documents table — _get_recall_queries probes for a recall_queries
+    # Just a documents table — get_recall_queries probes for a recall_queries
     # table; absent → returns DEFAULT_RECALL_QUERIES.
     db.execute("CREATE TABLE documents (id INTEGER PRIMARY KEY, path TEXT)")
     db.commit()


### PR DESCRIPTION
## Summary

- Promotes `_build_adaptive_queries` and `_get_recall_queries` in `kairix/core/embed/recall_check.py` to public names so the BDD scenarios in `tests/bdd/steps/recall_steps.py` can exercise them without reaching into private surface.
- Drops `tests/bdd/steps/recall_steps.py` from `.architecture/baseline/no-internal-test-imports-files.txt` (F5 -1).
- Both helpers are pure utility functions (sqlite-only, no I/O surprises) so the rename is a straight public-surface promotion — same pattern as e26e5c0e (reflib/extract) and 7b763e06 (recall_check on the prod side).

## Notes

- Renamed step function from `build_adaptive_queries` to `step_build_adaptive_queries` to avoid shadowing the imported helper.
- Updated stale `_get_recall_queries` comment references in `tests/embed/test_recall_check.py` and `tests/embed/test_canary_cache.py` to point at the new public name; reworded the canary-cache module docstring (the "we don't import the private helper because F5" rationale no longer applies — kept the deliberate-public-API stance instead).

## Test plan

- [x] `bash scripts/safe-commit.sh` green (3296 tests pass, all fitness functions pass)
- [x] `pre-commit run --all-files` green
- [x] `tests/bdd` + `tests/embed/test_recall_check.py` + `tests/embed/test_canary_cache.py` pass locally (222 tests)
- [x] F5 baseline shrinks by one file