### PR TITLE
docs(ops): docker-compose.example.yml resource caps + SHARED-HOSTS guide (#224 phase 6)

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,0 +1,161 @@
+# Kairix — Docker Compose example with bounded resources for shared hosts
+#
+# Companion to docker-compose.yml. This example uses the modern
+# `deploy.resources` syntax (Compose Spec) instead of the legacy top-level
+# `mem_limit` / `cpus` keys so the same file works under `docker compose up`
+# AND `docker stack deploy`. Both syntaxes are equivalent at the cgroup level
+# when Docker Compose drives the runtime; the `deploy.resources` form is
+# preferred for new deployments because it nests reservations + limits in one
+# block per service and matches Swarm/Kubernetes vocabulary.
+#
+# When to use this file
+# ---------------------
+# Use this example when kairix shares a host with other latency-sensitive
+# services (chat agents, ingest pipelines, a graph database, etc.) — see
+# docs/operations/SHARED-HOSTS.md for the full guidance. On a dedicated host
+# you can keep docker-compose.yml's looser caps.
+#
+# How to use this file
+# --------------------
+#   # Override the default compose file:
+#   docker compose -f docker-compose.example.yml up -d
+#
+#   # Or layer it on top of docker-compose.yml so you only override the
+#   # services you want bounded (recommended for production):
+#   docker compose -f docker-compose.yml -f docker-compose.example.yml up -d
+#
+# Tuning notes
+# ------------
+# The numbers below are starting points sized for a 4 vCPU / 8 GiB shared
+# VM running kairix + neo4j + one or two co-located agents. Watch
+# `docker stats` for a week and tighten or loosen from there. Don't lower
+# reservations below the steady-state RSS reported by `docker stats` — the
+# scheduler will swap or OOM-kill instead of throttling.
+#
+# Failure modes you'll see if these caps are too tight:
+#   - kairix:        503s from /mcp during rerank-model load; OOMKilled on
+#                    cold start with a small embedding cache.
+#   - kairix-worker: scan takes longer per cycle (acceptable) or gets
+#                    OOMKilled mid-embed (raise mem limit).
+#   - neo4j:         page-cache thrash, slow Cypher; raise mem limit before
+#                    raising heap.
+
+services:
+  kairix:
+    image: ghcr.io/three-cubes/kairix:latest
+    ports:
+      - "127.0.0.1:8080:8080"  # localhost-only; kairix has no built-in auth.
+    volumes:
+      - ./documents:/data/documents
+      - kairix-data:/data/kairix
+      # - ./kairix.config.yaml:/opt/kairix/kairix.config.yaml:ro
+    env_file:
+      - .env
+    environment:
+      - KAIRIX_NEO4J_URI=bolt://neo4j:7687
+      - KAIRIX_NEO4J_USER=neo4j
+      - KAIRIX_NEO4J_PASSWORD=${KAIRIX_NEO4J_PASSWORD}
+    depends_on:
+      neo4j:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "kairix", "onboard", "check"]
+      interval: 60s
+      timeout: 30s
+      retries: 3
+      start_period: 30s
+    # API / MCP service. Steady-state RSS is ~1.2 GiB after rerank-model
+    # load; cold-start spikes briefly higher. Reservation guarantees the
+    # scheduler hands kairix enough memory to come up cleanly. Limit caps
+    # how much it can grow before Docker OOM-kills the container.
+    #
+    # Bump cpu.limit if /mcp shows queueing under concurrent tool calls
+    # (async-tool refactor in v2026.5.10.5 — see #177 — gives concurrent
+    # tool calls real parallelism). Bump memory.limit if you see OOMKilled
+    # events in `docker events` during rerank load.
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 1Gi
+        reservations:
+          cpus: "0.5"
+          memory: 512Mi
+
+  kairix-worker:
+    image: ghcr.io/three-cubes/kairix:latest
+    command: ["worker"]
+    volumes:
+      - ./documents:/data/documents
+      - kairix-data:/data/kairix
+      # - ./kairix.config.yaml:/opt/kairix/kairix.config.yaml:ro
+    env_file:
+      - .env
+    environment:
+      - KAIRIX_NEO4J_URI=bolt://neo4j:7687
+      - KAIRIX_NEO4J_USER=neo4j
+      - KAIRIX_NEO4J_PASSWORD=${KAIRIX_NEO4J_PASSWORD}
+    depends_on:
+      neo4j:
+        condition: service_healthy
+    # The worker is the noisy neighbour. Idle worker should sit at ~0 CPU
+    # after #224 phase 1 (idle backoff). When it scans / embeds it bursts.
+    # Reservation is low so the scheduler doesn't strand CPU during idle.
+    # Limit is high so legitimate embed bursts don't take an hour. If you
+    # see request timeouts on co-located services during a worker burst,
+    # tighten cpus.limit toward 0.5 — embed cycles will get longer but
+    # the host stops choking. If you see worker OOMKilled during a large
+    # backfill, raise memory.limit (large vector index loads dominate RSS).
+    #
+    # Switching to `restart: on-failure` (instead of `unless-stopped`)
+    # prevents a restart storm if the worker fails after start — see
+    # docs/operations/SHARED-HOSTS.md "Restart-storm anti-pattern".
+    restart: on-failure:5
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 1Gi
+        reservations:
+          cpus: "0.25"
+          memory: 256Mi
+
+  neo4j:
+    image: neo4j:5-community
+    # Pin for production: neo4j:5.24.0-community
+    environment:
+      NEO4J_AUTH: neo4j/${KAIRIX_NEO4J_PASSWORD}
+      NEO4J_PLUGINS: '[]'
+      # Heap and page-cache sizing must fit inside the container memory
+      # limit below. Rule of thumb: heap_max + pagecache <= memory.limit
+      # minus ~512Mi for the JVM and OS. Defaults are conservative; tune
+      # via NEO4J_server_memory_heap_max_size and
+      # NEO4J_server_memory_pagecache_size if your graph grows.
+    volumes:
+      - neo4j-data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "cypher-shell -u neo4j -p ${KAIRIX_NEO4J_PASSWORD} 'RETURN 1' || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+    # Neo4j on a shared host. The community edition's defaults are tuned
+    # for a dedicated machine and will gladly take everything you give it;
+    # explicit caps stop a runaway query from OOMing the host. Reservation
+    # guarantees enough headroom for the page cache to be useful even when
+    # other tenants are busy. If you raise heap_max, raise memory.limit
+    # in step — Neo4j will swap silently long before it errors.
+    deploy:
+      resources:
+        limits:
+          cpus: "2.0"
+          memory: 2Gi
+        reservations:
+          cpus: "0.5"
+          memory: 512Mi
+
+volumes:
+  kairix-data:
+  neo4j-data:

--- a/docs/operations/SHARED-HOSTS.md
+++ b/docs/operations/SHARED-HOSTS.md
@@ -1,0 +1,105 @@
+# Shared-host deployments
+
+How to run kairix on a host that also runs other services without the worker starving its neighbours. This is the operator-facing companion to issue #224.
+
+Use this guide when kairix is co-located with:
+
+- a chat or agent runtime that has its own latency budget;
+- another ingest pipeline;
+- a graph database or other memory-hungry workload;
+- anything where a sustained CPU burst from the kairix worker would be noticed.
+
+For dedicated-host deployments you can stay on the default `docker-compose.yml` — the looser caps there are fine when nothing else competes for the host.
+
+---
+
+## Recommended headroom
+
+Kairix is two workloads stacked. The serving path (`kairix` container, `/mcp` endpoint, search) is latency-sensitive and lightly loaded between requests. The background worker (`kairix-worker`) does scans, embeds, and entity maintenance — it bursts hard during work, and should sit at ~0 CPU when idle (after #224 phase 1's idle backoff lands).
+
+For a single shared host running kairix + neo4j + one or two co-located agents, plan for:
+
+| Resource | Minimum | Comfortable | Notes |
+|---|---|---|---|
+| CPU | 2 vCPU | 4 vCPU | Worker bursts are short but heavy. 2 vCPU works if you accept slow embed cycles; 4 vCPU lets the worker finish a backfill in a reasonable window. |
+| Memory | 4 GiB | 8 GiB | kairix ~1.2 GiB steady, neo4j ~1-2 GiB, worker ~256 MiB idle / ~1 GiB during embed. Leave 1-2 GiB for the host kernel and other tenants. |
+| Disk | 10 GiB | 20+ GiB | The usearch index and SQLite content store grow with your document count; plan ~1 GiB per 50k chunks. |
+
+If the host is smaller than the minimum row, kairix will run but you will see exactly the symptoms #224 describes: event-loop starvation in co-located services, sporadic request timeouts, and restart churn. Stop the worker before stopping anything else — see "Pausing the worker safely" below.
+
+---
+
+## The worker is the noisy neighbour
+
+The serving path is well-behaved. The worker is the one that needs explicit caps.
+
+What the worker does that costs CPU and I/O:
+
+1. **Scan.** Walks the document store, hashes changed files. Cheap on small stores, expensive on large or networked filesystems.
+2. **Embed.** Calls the embedding provider for new or changed chunks. Network-bound if you use a cloud provider, CPU-bound if you use a local model.
+3. **Index load.** Loads the usearch ANN index into memory. Cost paid per worker generation; large indexes dominate RSS.
+4. **Recall and entity maintenance.** Recall canary, entity seeding, graph maintenance. Runs even when no embedding work happened (the bug #224 phase 1-2 is fixing).
+5. **Repeat.** Loops on its scan interval.
+
+Until #224 phase 1's idle backoff lands, the loop spins even on a no-op cycle, and steps 4 and 5 are where the worker becomes the noisy neighbour. With idle backoff in place, the worker stays at ~0 CPU between real work; without it, the only safe operating mode on a constrained host is to pause the worker when you don't need new content indexed.
+
+Bounded resources are the second line of defence. See `docker-compose.example.yml` at the repo root for `deploy.resources` blocks tuned for this scenario. The worker gets:
+
+- A **low CPU reservation** (0.25 vCPU) so the scheduler doesn't strand CPU during idle.
+- A **higher CPU limit** (1.0 vCPU) so legitimate embed bursts finish in a reasonable time.
+- A **modest memory reservation** (256 MiB) matching idle RSS.
+- A **firm memory limit** (1 GiB) that's enough for a typical embed cycle but not enough for a runaway maintenance run to take the host down.
+
+If you see request timeouts on co-located services during a worker burst, tighten the worker's `cpus.limit` toward 0.5 vCPU. Embed cycles will get longer; the host will stop choking. That's usually the right trade on a shared host.
+
+---
+
+## Pausing the worker safely
+
+The serving path stays healthy when the worker is stopped — this was confirmed during the #224 incident and is the basis of the "decouple serving from indexing" pattern.
+
+Today, stop the worker container directly:
+
+```bash
+docker compose stop kairix-worker
+```
+
+Search, `/mcp` calls, and the graph database keep working. The index is read-only from the serving path's perspective — you just stop getting new content indexed until you start the worker again:
+
+```bash
+docker compose start kairix-worker
+```
+
+A first-class `kairix worker pause` / `kairix worker resume` interface lands with #224 phase 4. Once it's available it will pause the loop in-process without restarting the container, which avoids the index reload cost on resume. Until then, `docker compose stop` is the recommended pause.
+
+---
+
+## Restart-storm anti-pattern
+
+The default `docker-compose.yml` uses `restart: unless-stopped` on every service. That's fine when failures are rare. On a constrained host it can mask a degraded worker: the worker starts, hits an out-of-memory condition or a config error, exits, and the runtime restarts it immediately. Each restart pays the full cold-start cost (index load, recall canary, entity seed). The host stays at sustained 100% CPU with no progress.
+
+If you have ever seen "the worker is always busy but the index never moves", this is what you saw.
+
+Mitigations, in order of preference:
+
+1. **Use `restart: on-failure` with a max-attempts cap.** The example file ships with `restart: on-failure:5`. After five failed restarts the container stays down and the failure becomes visible instead of being papered over. Exec into the host and read `docker logs kairix-worker --tail 200` to see why it's failing.
+2. **Surface restart count via `kairix worker status`** (lands with #224 phase 5). The status command will report restart count and last-failure reason, so a health probe or monitoring loop can detect churn even when `docker ps` shows the container as "running".
+3. **For Compose Spec deployments (Swarm), use `restart_policy` with `max_attempts` and a sensible `window`.** Same intent, native to Compose Spec.
+
+If the worker is failing repeatedly, do not raise its memory limit blindly. Read the logs first — the most common cause is a misconfigured `KAIRIX_DOCUMENT_ROOT` or a missing embed provider credential, neither of which more memory fixes.
+
+---
+
+## Putting it together
+
+1. Read this page.
+2. Copy `docker-compose.example.yml` from the repo root as your starting compose file (or layer it over `docker-compose.yml`).
+3. Watch `docker stats` for a week. Tighten or loosen `deploy.resources` to match what you actually see.
+4. Set `restart: on-failure:5` on the worker (the example file does this for you).
+5. When you co-locate something latency-sensitive, run `docker compose stop kairix-worker` before any benchmark or load test. Confirm the latency issue tracks the worker; if it does, plan the worker's runtime around the latency-sensitive workload's quiet hours, or split it onto its own host.
+
+See also:
+
+- [`docker-compose.example.yml`](../../docker-compose.example.yml) — example compose with bounded `deploy.resources` blocks.
+- [OPERATIONS.md](OPERATIONS.md) — deployment, configuration, secrets.
+- [Issue #224](https://github.com/three-cubes/kairix/issues/224) — full requirements for shared-host worker discipline.


### PR DESCRIPTION
## Summary

Closes the deployment-guidance + bounded-resources acceptance criteria for #224 (shared-host worker discipline).

- New `docker-compose.example.yml` at the repo root with annotated `deploy.resources` blocks for `kairix`, `kairix-worker`, and `neo4j`. Uses modern Compose Spec syntax so the same file works under both `docker compose up` and `docker stack deploy`. Each block documents the steady-state RSS that drove the numbers, when to bump, and the failure mode you'll see if it's too tight.
- New `docs/operations/SHARED-HOSTS.md` covering CPU/memory headroom for co-located deployments, why the worker is the noisy neighbour, how to pause the worker safely today (`docker compose stop kairix-worker`) and where the first-class `kairix worker pause` / `kairix worker status` interfaces will land (phases 4-5), and the restart-storm anti-pattern with `restart: on-failure:N` as the mitigation.

No code changes. Docs + YAML only.

## Ops decisions documented

- Single shared host: minimum 2 vCPU / 4 GiB, comfortable 4 vCPU / 8 GiB.
- API: 0.5 vCPU reservation / 1.0 limit; 512 MiB reservation / 1 GiB limit.
- Worker: 0.25 vCPU reservation / 1.0 limit; 256 MiB reservation / 1 GiB limit. Low reservation matches idle; high limit lets embed bursts finish.
- Neo4j: 0.5 vCPU reservation / 2.0 limit; 512 MiB reservation / 2 GiB limit. Explicit caps so a runaway query can't OOM the host.
- Worker uses `restart: on-failure:5` (not `unless-stopped`) in the example to surface restart churn instead of masking it.

## Test plan

- [x] `pre-commit run --files docker-compose.example.yml docs/operations/SHARED-HOSTS.md` — passes (check-yaml + arch-fitness)
- [x] `bash scripts/safe-commit.sh` — all gates green (ruff, mypy, 3305 tests, arch fitness, secrets, confidential)
- [x] `python -c "import yaml; yaml.safe_load(...)"` — example compose parses
- [ ] Manual: `docker compose -f docker-compose.example.yml config` on a host with Docker installed (CI doesn't have docker; spot-check by reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)