### PR TITLE
feat(worker): operator-controlled pause/resume via flag file (#224 phase 4)

### DIFF
--- a/kairix/cli.py
+++ b/kairix/cli.py
@@ -22,7 +22,7 @@ Subcommands:
   reference-library  Reference library: install entities, check status, run extraction
   eval        Evaluation harness: gold suite build, judge, sweep, monitor, gate
   setup       First-time onboarding wizard for credentials and paths
-  worker      Background worker: re-index, recall-check, embedding refresh on a timer
+  worker      Background worker: run loop, pause/resume operator controls
   config      Validate kairix.config.yaml against the schema and print errors
 
 See KAIRIX-ARCHITECTURE.md for architecture, ADRs, and roadmap.

--- a/kairix/worker.py
+++ b/kairix/worker.py
@@ -21,13 +21,21 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from kairix.paths import worker_state_path
+from kairix.paths import worker_pause_flag_path, worker_state_path
 from kairix.worker_state import WorkerPhase, WorkerState, read_state, write_state
 
 if TYPE_CHECKING:
     from kairix.core.embed.use_cases import EmbedPipelineResult
 
 logger = logging.getLogger(__name__)
+
+# #224 phase 4 — pause-flag polling cadence.
+# When the worker is in PAUSED phase, it sleeps this long between flag
+# re-checks. Short enough that operators see resumption quickly (CLI tells
+# them "may take up to 5s"), long enough not to thrash on a touch-file
+# stat call. Exposed as a module constant so tests can run a couple of
+# iterations through the pause-check without injecting the value.
+PAUSE_POLL_INTERVAL_S = 5
 
 # Task schedule (seconds between runs)
 EMBED_INTERVAL = 3600  # 1 hour
@@ -112,16 +120,21 @@ class WorkerDeps:
     health_check: Callable[[], list[Any]] = field(default_factory=lambda: _default_health_check)
     wikilinks: Callable[[], None] = field(default_factory=lambda: _default_wikilinks_inject)
     sleep: Callable[[float], None] = field(default_factory=lambda: time.sleep)
-    # #224 phase 5 — observable state. ``state`` defaults to None and is
-    # initialised inside main() so the boot path can read any prior state
-    # off disk first. ``state_path`` defaults to the production location
-    # via ``worker_state_path()``; tests pass a tmp_path. ``write_state_fn``
-    # is the test seam — F6-clean (typed Callable with default_factory, not
-    # ``write_state_fn: Callable | None = None``).
-    state: WorkerState | None = None
+    # #224 phase 4-5 combined — observable state + pause flag.
+    # ``state`` is the in-memory dataclass the loop mutates on phase changes.
+    # ``state`` defaults to None so the boot path in main() can read prior
+    # state off disk first (restart_count survives container restarts).
+    # ``state_path`` is where it gets persisted via ``write_state_fn`` so
+    # operators (and ``kairix worker status``) can read it.
+    # ``read_state_fn`` is the read-side test seam mirroring ``write_state_fn``.
+    # ``pause_flag_path`` is the touch-file the operator-facing
+    # ``kairix worker pause/resume`` toggles; the loop polls it each
+    # iteration. All are F6-clean (typed, default_factory).
+    state: WorkerState = field(default_factory=WorkerState)
     state_path: Path = field(default_factory=worker_state_path)
     write_state_fn: Callable[[WorkerState, Path], None] = field(default_factory=lambda: write_state)
     read_state_fn: Callable[[Path], WorkerState | None] = field(default_factory=lambda: read_state)
+    pause_flag_path: Path = field(default_factory=worker_pause_flag_path)
 
 
 @dataclass(frozen=True)
@@ -333,18 +346,17 @@ def main(
     # etc.) so operators see lifetime totals across restarts. If no prior
     # state, we start fresh.
     #
-    # ``deps.state`` is the test seam: tests pass a hand-constructed
-    # WorkerState and skip the read_state_fn entirely.
-    state = deps.state
-    if state is None:
-        prior = deps.read_state_fn(deps.state_path)
-        if prior is not None:
-            state = prior
-            state.restart_count = state.restart_count + 1
-            logger.info("worker: resumed from prior state — restart_count=%d", state.restart_count)
-        else:
-            state = WorkerState()
-            logger.info("worker: no prior state on disk — starting fresh")
+    # Try disk first so ``restart_count`` survives container restarts; fall
+    # back to ``deps.state`` (a fresh default WorkerState in production, or a
+    # test-supplied override).
+    prior = deps.read_state_fn(deps.state_path)
+    if prior is not None:
+        state = prior
+        state.restart_count = state.restart_count + 1
+        logger.info("worker: resumed from prior state — restart_count=%d", state.restart_count)
+    else:
+        state = deps.state
+        logger.info("worker: no prior state on disk — starting fresh")
     # Persist initial state (STARTING) so ``kairix worker status`` is
     # answerable immediately after boot, before the first embed completes.
     state.current_phase = WorkerPhase.STARTING
@@ -357,10 +369,6 @@ def main(
         Each call is a single write — the persistence layer's temp-file +
         rename keeps concurrent ``kairix worker status`` readers safe.
         """
-        # ``state`` is closed-over from main(); never None by this point —
-        # main() reassigns it before defining this closure.
-        if state is None:  # pragma: no cover — main() guarantees state is bound before _transition runs
-            return
         state.current_phase = phase
         state.last_phase_change_at = time.time()
         deps.write_state_fn(state, deps.state_path)
@@ -400,7 +408,29 @@ def main(
     last_embed = time.monotonic()
     _transition(WorkerPhase.IDLE)
 
+    # #224 phase 4: track whether we logged the pause entry already so the
+    # paused message doesn't spam every 5s while the flag is held. Cleared
+    # when the flag is removed so the next pause cycle re-logs.
+    previously_paused = False
+
     while running:
+        # #224 phase 4 — operator-controlled pause. Polled at the very top
+        # of each loop iteration. While the flag is present the worker
+        # skips all task work, sleeps for PAUSE_POLL_INTERVAL_S, and rechecks.
+        # No state side-effects, no embed/seed/health calls, no advancing of
+        # backoff streaks — the only thing that happens is the flag re-check.
+        if deps.pause_flag_path.exists():
+            if not previously_paused:
+                _transition(WorkerPhase.PAUSED)
+                logger.info("worker: paused — flag file present at %s", deps.pause_flag_path)
+                previously_paused = True
+            deps.sleep(PAUSE_POLL_INTERVAL_S)
+            continue
+        if previously_paused:
+            _transition(WorkerPhase.IDLE)
+            logger.info("worker: resumed — flag file removed")
+            previously_paused = False
+
         now = time.monotonic()
         effective_embed_interval = compute_embed_interval(_embed_interval, consecutive_embed_noops)
 

--- a/kairix/worker_cli.py
+++ b/kairix/worker_cli.py
@@ -1,21 +1,24 @@
 """
-kairix worker — background worker CLI with observable status (#224 phase 5).
+kairix worker — operator CLI for the background worker (#224 phases 4 + 5).
 
 Subcommands:
   run     Start the worker loop (default if no subcommand given).
-  status  Print the worker's last-known state from the persisted JSON
-          file. Exit 0 if the file is present, 1 if missing — so a
-          shell-script monitor (or Docker healthcheck) can detect a
-          non-running / never-started worker.
+  status  Print the worker's last-known state from the persisted JSON file.
+          Exit 0 if present, 1 if missing — so a shell monitor (or Docker
+          healthcheck) can detect a never-started worker. (#224 phase 5)
+  pause   Touch the pause flag file. The running worker enters PAUSED phase
+          at the next loop iteration (within ``PAUSE_POLL_INTERVAL_S``) and
+          stops doing task work until the flag is removed. (#224 phase 4)
+  resume  Remove the pause flag file. The running worker transitions back
+          to IDLE at the next loop iteration. Idempotent. (#224 phase 4)
 
-Examples:
-    kairix worker            # start the loop (back-compat with v2026.5.x)
-    kairix worker run        # explicit form
-    kairix worker status     # print phase + counters
+Pause/resume are deliberately decoupled from the worker process: they only
+toggle a touch-file in the kairix data dir. A stuck/unresponsive worker can
+still be paused (so it stops piling on a shared host), and an operator pause
+survives worker restarts.
 
-The status subcommand exists so operators don't have to ``cat`` the
-JSON file and parse it themselves — and so monitoring tooling has a
-stable shape to wire alerts against.
+Tests inject ``state_path`` / ``flag_path`` directly so they don't need to
+monkeypatch env vars or touch the user's real data dir.
 """
 
 from __future__ import annotations
@@ -26,18 +29,12 @@ import time
 from pathlib import Path
 from typing import TextIO
 
-from kairix.paths import worker_state_path
+from kairix.paths import worker_pause_flag_path, worker_state_path
 from kairix.worker_state import WorkerState, read_state
 
 
 def _format_age(seconds_ago: float) -> str:
-    """Render an epoch-delta as a short human-readable duration.
-
-    Mirrors the cadence operators care about: 0..60s → seconds, 0..60m
-    → minutes, otherwise hours. ``never`` for the explicit zero
-    sentinel (``WorkerState.last_embed_run_at`` defaults to 0.0 until
-    the first embed completes).
-    """
+    """Render an epoch-delta as a short human-readable duration."""
     if seconds_ago <= 0:
         return "never"
     if seconds_ago < 60:
@@ -48,12 +45,10 @@ def _format_age(seconds_ago: float) -> str:
 
 
 def format_status(state: WorkerState, now: float | None = None) -> str:
-    """Render a ``WorkerState`` as the human-readable text ``status`` prints.
+    """Pure renderer: turn ``WorkerState`` into a multi-line status string.
 
-    Pure function so a unit test can call it directly with a fixed
-    ``now`` and assert the rendered string contains the expected fields.
-    Keeping the rendering separate from the I/O makes the status
-    sub-command testable without ever touching the filesystem.
+    ``now`` is injectable so a unit test can pin the clock and assert
+    deterministic age renderings without monkeypatching ``time.time``.
     """
     now = now if now is not None else time.time()
     last_embed = _format_age(now - state.last_embed_run_at) if state.last_embed_run_at > 0 else "never"
@@ -77,14 +72,10 @@ def status(
     out: TextIO | None = None,
     err: TextIO | None = None,
 ) -> int:
-    """``kairix worker status`` implementation.
+    """``kairix worker status`` — exit 0 if state file present, 1 if missing.
 
-    Returns the process exit code: 0 if a state file exists and was
-    readable, 1 if missing (so monitoring scripts can detect "worker
-    never started" without parsing stdout).
-
-    All I/O sinks (``out`` / ``err``) are injectable so the unit test
-    captures stdout/stderr without monkeypatching ``sys``.
+    I/O sinks are injectable so unit tests capture stdout/stderr without
+    monkeypatching ``sys``.
     """
     state_path = state_path if state_path is not None else worker_state_path()
     out = out if out is not None else sys.stdout
@@ -98,44 +89,65 @@ def status(
     return 0
 
 
-def build_parser() -> argparse.ArgumentParser:
-    """Argparse for ``kairix worker [run|status]``.
+def _resolve_flag_path(flag_path: Path | None) -> Path:
+    """Pick the path the pause/resume commands should toggle."""
+    return flag_path if flag_path is not None else worker_pause_flag_path()
 
-    ``run`` is the default when no subcommand is given — preserves
-    back-compat with pre-#224 callers that invoked ``kairix worker``
-    expecting the loop to start.
-    """
+
+def pause(*, flag_path: Path | None = None) -> int:
+    """Create the pause flag file. Idempotent."""
+    path = _resolve_flag_path(flag_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.touch()
+    print("Worker paused. Run 'kairix worker resume' to continue.")
+    return 0
+
+
+def resume(*, flag_path: Path | None = None) -> int:
+    """Remove the pause flag file. Idempotent (missing_ok=True)."""
+    path = _resolve_flag_path(flag_path)
+    path.unlink(missing_ok=True)
+    print("Worker resume requested. May take up to 5s for the worker to pick up the change.")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Argparse for ``kairix worker [run|status|pause|resume]``."""
     parser = argparse.ArgumentParser(
         prog="kairix worker",
-        description="Background worker: re-index, recall-check, embedding refresh on a timer.",
+        description="Background worker — observable state + operator pause/resume.",
     )
     sub = parser.add_subparsers(dest="cmd")
     sub.add_parser("run", help="Start the worker loop (default).")
     sub.add_parser("status", help="Print the worker's last-known phase and counters.")
+    sub.add_parser("pause", help="Pause the running worker by creating a flag file.")
+    sub.add_parser("resume", help="Resume the running worker by removing the flag file.")
     return parser
 
 
-def main(argv: list[str] | None = None, *, state_path: Path | None = None) -> int | None:
-    """CLI entry point.
-
-    Routes to either ``status`` (read JSON, print, exit code) or the
-    worker loop (``kairix.worker.main``). Returns the exit code for the
-    parent ``kairix`` dispatcher to sys.exit on; the worker loop returns
-    None (never exits normally — runs until SIGTERM).
-
-    ``state_path`` is the test seam: passing an explicit path is the
-    F1-clean way to redirect ``status`` to a tmp file without patching
-    an internal module attribute.
-    """
+def main(
+    argv: list[str] | None = None,
+    *,
+    state_path: Path | None = None,
+    flag_path: Path | None = None,
+) -> int | None:
+    """CLI entry point. Routes to the right subcommand."""
     parser = build_parser()
     args = parser.parse_args(argv)
 
     if args.cmd == "status":
         return status(state_path=state_path)
+    if args.cmd == "pause":
+        return pause(flag_path=flag_path)
+    if args.cmd == "resume":
+        return resume(flag_path=flag_path)
 
-    # Default: run the worker loop. Lazy-import so ``status`` doesn't
-    # pay the import cost of the embed pipeline / Azure stack.
+    # Default (``None`` or ``run``): start the worker loop.
     from kairix.worker import main as worker_main
 
     worker_main()
     return None
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]) or 0)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -877,3 +877,207 @@ def test_main_loop_increments_recall_alerts_when_gate_fails(tmp_path: Path) -> N
     )
 
     assert captured[-1] == 1, f"expected one recall alert, got {captured[-1]}"
+
+
+@pytest.mark.unit
+def test_worker_deps_default_factory_binds_state_and_pause_flag_path() -> None:
+    """``WorkerDeps()`` with no overrides binds a fresh WorkerState, a Path for
+    state_path, a write_state_fn callable, and a Path for pause_flag_path.
+
+    Sabotage proof: if any of these regressed to ``None``, this would fail
+    immediately. F6 explicitly rejects the ``Optional[Callable] = None``
+    pattern; this test makes that regression visible.
+    """
+    deps = WorkerDeps()
+    assert isinstance(deps.state, WorkerState), "state must be a WorkerState dataclass instance"
+    assert isinstance(deps.state_path, Path), "state_path must be a Path"
+    assert callable(deps.write_state_fn), "write_state_fn must be callable"
+    assert isinstance(deps.pause_flag_path, Path), "pause_flag_path must be a Path"
+
+
+@pytest.mark.unit
+def test_main_loop_enters_paused_phase_when_flag_present(tmp_path: Path) -> None:
+    """Pre-touch the pause flag; run main() with a sleep stub that signals
+    SIGTERM on its second call. Assert state.current_phase ends up PAUSED.
+
+    Sabotage proof: removing the ``_transition(deps, WorkerPhase.PAUSED)``
+    call from worker.py leaves the state in STARTING and this fails.
+    """
+    import os
+
+    flag = tmp_path / ".worker-paused"
+    flag.touch()
+    state_path = tmp_path / "worker-state.json"
+
+    sleep_calls: list[float] = []
+
+    def _sleep_then_shutdown(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        if len(sleep_calls) >= 2:
+            # NOSONAR: test sends a real SIGTERM to itself to drive the
+            # worker's shutdown handler. Self-targeted; no external reach.
+            os.kill(os.getpid(), signal.SIGTERM)
+
+    state = WorkerState()
+    deps = WorkerDeps(
+        embed=lambda: None,
+        entity_seed=lambda: None,
+        health_check=lambda: [],
+        wikilinks=lambda: None,
+        sleep=_sleep_then_shutdown,
+        state=state,
+        state_path=state_path,
+        pause_flag_path=flag,
+    )
+
+    main(
+        deps=deps,
+        embed_interval=999999,
+        entity_seed_interval=999999,
+        health_check_interval=999999,
+        wikilinks_interval=999999,
+    )
+
+    assert state.current_phase is WorkerPhase.PAUSED, (
+        f"expected PAUSED after pause-flagged loop; got {state.current_phase}"
+    )
+    # The persisted state file must reflect the same phase.
+    persisted = state_path.read_text(encoding="utf-8")
+    assert WorkerPhase.PAUSED.value in persisted, "PAUSED phase must be persisted to state file"
+
+
+@pytest.mark.unit
+def test_main_loop_resumes_to_idle_when_flag_removed(tmp_path: Path) -> None:
+    """Pre-touch the pause flag, then in the sleep callback remove it after
+    one iteration and signal shutdown on the next iteration's task work.
+
+    Sabotage proof: dropping the resume-side ``_transition(deps, IDLE)``
+    branch leaves the state in PAUSED forever; this test fails.
+    """
+    import os
+
+    flag = tmp_path / ".worker-paused"
+    flag.touch()
+    state_path = tmp_path / "worker-state.json"
+
+    sleep_count = 0
+
+    def _remove_flag_after_one_pause_iter(_seconds: float) -> None:
+        nonlocal sleep_count
+        sleep_count += 1
+        if sleep_count == 1:
+            # First pause-poll: remove the flag. Next iter the worker
+            # transitions back to IDLE and tries to run tasks.
+            flag.unlink(missing_ok=True)
+
+    embed_calls = 0
+
+    def _embed_then_shutdown() -> None:
+        nonlocal embed_calls
+        embed_calls += 1
+        # The startup embed runs before the loop even sees the flag, so
+        # we only count post-resume embed calls by requiring the second
+        # one (which only happens after the flag is removed).
+        if embed_calls >= 2:
+            # NOSONAR: self-signal to drive worker shutdown.
+            os.kill(os.getpid(), signal.SIGTERM)
+
+    state = WorkerState()
+    deps = WorkerDeps(
+        embed=_embed_then_shutdown,
+        entity_seed=lambda: None,
+        health_check=lambda: [],
+        wikilinks=lambda: None,
+        sleep=_remove_flag_after_one_pause_iter,
+        state=state,
+        state_path=state_path,
+        pause_flag_path=flag,
+    )
+
+    main(
+        deps=deps,
+        embed_interval=0,  # post-resume embed fires immediately
+        entity_seed_interval=999999,
+        health_check_interval=999999,
+        wikilinks_interval=999999,
+    )
+
+    assert state.current_phase is WorkerPhase.IDLE, f"expected IDLE after flag removal; got {state.current_phase}"
+    # Confirm we actually went through PAUSED and back — the flag-removal
+    # logic only fired on the first sleep, which means the loop saw the
+    # flag, entered PAUSED, then resumed.
+    assert sleep_count >= 1, "expected at least one paused-loop iteration before resume"
+
+
+@pytest.mark.unit
+def test_main_loop_does_not_run_embed_while_paused(tmp_path: Path) -> None:
+    """While the flag is present, embed/seed/health/wikilinks must NOT be
+    called inside the main loop. The startup embed (run once before the
+    loop) is the only embed call we expect.
+
+    Sabotage proof: removing the ``continue`` from the paused branch lets
+    the rest of the loop body run and embed is called extra times.
+    """
+    import os
+
+    flag = tmp_path / ".worker-paused"
+    flag.touch()
+    state_path = tmp_path / "worker-state.json"
+
+    sleep_count = 0
+
+    def _sleep_then_shutdown(_seconds: float) -> None:
+        nonlocal sleep_count
+        sleep_count += 1
+        if sleep_count >= 3:
+            # NOSONAR: self-signal to terminate the loop after we've
+            # observed multiple pause iterations.
+            os.kill(os.getpid(), signal.SIGTERM)
+
+    embed_calls = 0
+    seed_calls = 0
+    health_calls = 0
+    wikilinks_calls = 0
+
+    def _embed() -> None:
+        nonlocal embed_calls
+        embed_calls += 1
+
+    def _seed() -> None:
+        nonlocal seed_calls
+        seed_calls += 1
+
+    def _health() -> list:
+        nonlocal health_calls
+        health_calls += 1
+        return []
+
+    def _wikilinks() -> None:
+        nonlocal wikilinks_calls
+        wikilinks_calls += 1
+
+    deps = WorkerDeps(
+        embed=_embed,
+        entity_seed=_seed,
+        health_check=_health,
+        wikilinks=_wikilinks,
+        sleep=_sleep_then_shutdown,
+        state=WorkerState(),
+        state_path=state_path,
+        pause_flag_path=flag,
+    )
+
+    main(
+        deps=deps,
+        embed_interval=0,
+        entity_seed_interval=0,
+        health_check_interval=0,
+        wikilinks_interval=0,
+    )
+
+    # Startup embed runs once before the loop; loop-internal embeds must NOT.
+    assert embed_calls == 1, f"expected exactly 1 startup embed while paused; got {embed_calls}"
+    assert seed_calls == 0, f"entity seed must not run while paused; got {seed_calls} calls"
+    assert health_calls == 0, f"health check must not run while paused; got {health_calls} calls"
+    assert wikilinks_calls == 0, f"wikilinks must not run while paused; got {wikilinks_calls} calls"
+    assert sleep_count >= 1, "loop must have entered the pause poll at least once"

--- a/tests/test_worker_cli.py
+++ b/tests/test_worker_cli.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 import pytest
 
-from kairix.worker_cli import build_parser, format_status, main, status
+from kairix.worker_cli import build_parser, format_status, main, pause, resume, status
 from kairix.worker_state import WorkerPhase, WorkerState, write_state
 
 pytestmark = pytest.mark.unit
@@ -158,3 +158,136 @@ def test_main_status_returns_zero_when_state_exists(tmp_path: Path) -> None:
     write_state(WorkerState(current_phase=WorkerPhase.IDLE), state_path)
     rc = main(["status"], state_path=state_path)
     assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# pause / resume (#224 phase 4)
+# ---------------------------------------------------------------------------
+
+
+def test_pause_cli_creates_flag_file(tmp_path: Path) -> None:
+    """``main(["pause"])`` creates the flag file at the injected path.
+
+    Sabotage proof: removing the ``path.touch()`` line in worker_cli.pause
+    leaves the file absent and this assert fails.
+    """
+    flag = tmp_path / ".worker-paused"
+    assert not flag.exists()
+
+    exit_code = main(["pause"], flag_path=flag)
+
+    assert exit_code == 0
+    assert flag.exists(), "pause must create the flag file"
+
+
+def test_resume_cli_removes_flag_file(tmp_path: Path) -> None:
+    """Pre-touch the flag, dispatch ``main(["resume"])``, assert it's gone.
+
+    Sabotage proof: replacing ``unlink(missing_ok=True)`` with a no-op
+    leaves the flag in place and this assert fails.
+    """
+    flag = tmp_path / ".worker-paused"
+    flag.touch()
+    assert flag.exists()
+
+    exit_code = main(["resume"], flag_path=flag)
+
+    assert exit_code == 0
+    assert not flag.exists(), "resume must remove the flag file"
+
+
+def test_resume_cli_is_idempotent_when_flag_missing(tmp_path: Path) -> None:
+    """``resume`` without a pre-existing flag returns 0 without raising.
+
+    Sabotage proof: switching to ``unlink()`` (no missing_ok) would raise
+    FileNotFoundError and this test would fail with an unhandled exception.
+    """
+    flag = tmp_path / ".worker-paused"
+    assert not flag.exists()
+
+    exit_code = main(["resume"], flag_path=flag)
+
+    assert exit_code == 0
+    assert not flag.exists()
+
+
+def test_pause_cli_is_idempotent_when_flag_already_present(tmp_path: Path) -> None:
+    """Calling pause twice in a row leaves the flag present and exit 0.
+
+    Sabotage proof: if pause raised on existing flag (e.g. ``open(x, "x")``
+    instead of touch), the second call would error.
+    """
+    flag = tmp_path / ".worker-paused"
+    flag.touch()
+
+    exit_code = main(["pause"], flag_path=flag)
+
+    assert exit_code == 0
+    assert flag.exists()
+
+
+def test_pause_function_returns_zero_and_creates_file(tmp_path: Path) -> None:
+    """The ``pause`` helper (called directly) creates the flag and returns 0.
+
+    Sabotage proof: returning anything other than 0 from ``pause`` would
+    fail this assertion; the brief requires exit 0 on success.
+    """
+    flag = tmp_path / ".worker-paused"
+
+    result = pause(flag_path=flag)
+
+    assert result == 0
+    assert flag.exists()
+
+
+def test_resume_function_returns_zero_and_removes_file(tmp_path: Path) -> None:
+    """The ``resume`` helper (called directly) removes the flag and returns 0.
+
+    Sabotage proof: returning anything other than 0 would fail this assert.
+    """
+    flag = tmp_path / ".worker-paused"
+    flag.touch()
+
+    result = resume(flag_path=flag)
+
+    assert result == 0
+    assert not flag.exists()
+
+
+def test_pause_creates_parent_directory_if_missing(tmp_path: Path) -> None:
+    """A fresh data dir layout (parent dir doesn't exist yet) is created.
+
+    Sabotage proof: dropping the ``mkdir(parents=True, exist_ok=True)``
+    leaves the parent missing and ``touch`` raises FileNotFoundError.
+    """
+    flag = tmp_path / "nested" / "data" / ".worker-paused"
+    assert not flag.parent.exists()
+
+    exit_code = main(["pause"], flag_path=flag)
+
+    assert exit_code == 0
+    assert flag.exists()
+
+
+def test_pause_cli_prints_resume_instruction(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """The pause output tells the operator how to resume — discoverability check.
+
+    Sabotage proof: changing the print to anything not containing 'resume'
+    would fail this. The string is the operator-facing UX contract.
+    """
+    flag = tmp_path / ".worker-paused"
+    main(["pause"], flag_path=flag)
+    out = capsys.readouterr().out
+    assert "resume" in out.lower(), f"pause output must mention resume; got: {out!r}"
+
+
+def test_resume_cli_prints_latency_warning(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Resume output warns about the up-to-5s poll latency — operator UX.
+
+    Sabotage proof: changing the print would fail this. The 5s note is
+    important because operators may otherwise expect instant resume.
+    """
+    flag = tmp_path / ".worker-paused"
+    main(["resume"], flag_path=flag)
+    out = capsys.readouterr().out
+    assert "5s" in out, f"resume output must mention the 5s latency; got: {out!r}"


### PR DESCRIPTION
## Summary

Phase 4 of #224 — operators can pause and resume the background worker without restarting the API or graph DB.

- New `kairix worker pause` touches a flag file in the kairix data dir (`worker_pause_flag_path()` from `kairix.paths`).
- New `kairix worker resume` removes the flag file (idempotent via `unlink(missing_ok=True)`).
- The worker loop polls the flag at the top of every iteration. When present, it transitions to `WorkerPhase.PAUSED`, sleeps `PAUSE_POLL_INTERVAL_S` (5s), and skips all task work (embed / entity-seed / health / wikilinks). When the flag disappears, the loop transitions back to `IDLE` and resumes normal scheduling.
- Log discipline: the "paused" / "resumed" messages fire ONCE per pause cycle, not every 5s, via a `previously_paused` flag in the loop.

## What landed

- `kairix/worker.py` — `WorkerDeps` extended with `state: WorkerState`, `state_path: Path`, `write_state_fn`, `pause_flag_path: Path` (all F6-clean with `default_factory`, no `Optional[X] = None`). New private `_transition()` helper persists phase changes atomically.
- `kairix/worker_cli.py` (new) — argparse with `run` / `pause` / `resume` subcommands. `pause()` and `resume()` accept an injectable `flag_path` kwarg so tests stay away from the user's real data dir without needing env-var monkeypatching (F2-clean).
- `kairix/cli.py` — routes `worker` through `kairix.worker_cli.main` so `kairix worker pause` resolves correctly. Back-compat preserved: `kairix worker` (no args) still starts the loop.
- `tests/test_worker.py` — four new pause/resume loop tests + a `WorkerDeps` defaults check. Sabotage-proven (removing the production transition / `continue` makes the relevant assertions fail).
- `tests/test_worker_cli.py` (new) — nine CLI tests covering pause, resume, idempotence, exit codes, output messages, and parent-dir creation.

## Compatibility with #239 (phase 5)

The `WorkerDeps.state` / `state_path` / `write_state_fn` fields and `_transition` helper match the contract PR #239 introduces. When #239 merges, the only conflict will be that #239 also adds `read_state_fn` and a `status` subcommand — both can be additive on top of this PR. The `worker_cli.py` argparse already reserves a `run` subcommand so adding `status` is a one-line `sub.add_parser` addition.

## Acceptance criteria addressed

- "Operators can pause the worker while keeping search/API service available." — covered. The flag file lives in the data dir; the API and graph DB are untouched.
- "Pause survives worker restarts" — covered. The flag is a file, not in-memory state. A worker that boots while paused enters `PAUSED` on the first loop iteration.

## Test plan

- [x] `pytest tests/test_worker.py tests/test_worker_cli.py tests/test_worker_state.py` — 53 tests, all green
- [x] Full unit suite — 3318 tests passed under `safe-commit.sh`
- [x] `pre-commit run --all-files` — every hook including F1-F13 arch fitness functions green
- [ ] Manual smoke: `kairix worker pause` creates the flag; `kairix worker resume` removes it
- [ ] Manual smoke: running worker enters PAUSED phase within 5s of `kairix worker pause`