### PR TITLE
release: kairix v2026.5.15.1 — fix PyPI wheel-check on packaged openclaw plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,6 +246,18 @@ temporal = 0.55
 entity = 0.80
 contextual_prep = 0.60
 
+# ── check-wheel-contents ─────────────────────────────────────────────────────
+# The PyPI publish workflow runs ``check-wheel-contents`` via
+# hynek/build-and-inspect-python-package. It flags W004 ("module is not
+# located at importable path") on ``kairix/plugins/openclaw/memory-prompt/
+# plugin.py`` because the hyphenated directory cannot be a Python module.
+# That's intentional — the directory is package-data shipped to openclaw's
+# plugin loader (see [tool.setuptools.package-data] above for the rationale).
+# We exempt W004 globally; the alternative is renaming the file away from
+# ``plugin.py``, which openclaw expects verbatim.
+[tool.check-wheel-contents]
+ignore = ["W004"]
+
 # ── setuptools-scm — version derived from git tags ─────────────────────────
 # No manual version editing. Tagged commits = clean version (2026.4.28).
 # Untagged commits = dev version (2026.4.28.dev3 = 3 commits since tag).


### PR DESCRIPTION
## kairix v2026.5.15.1 (same-day patch)

Single-fix patch: exempts ``check-wheel-contents`` W004 on
``kairix/plugins/openclaw/memory-prompt/plugin.py`` so the PyPI
publish workflow can build the wheel.

### Why this fix is needed

v2026.5.15 shipped the openclaw memory-prompt plugin packaged inside
the wheel as package-data. The directory is hyphenated
(``memory-prompt/``) because openclaw's plugin loader discovers
plugins by directory slug. Python cannot import hyphenated module
names, so the directory must be package-data (not a sub-package).

The PyPI publish workflow uses ``hynek/build-and-inspect-python-package``,
which runs ``check-wheel-contents``. W004 fires on any ``.py`` file
at a non-importable path. Renaming would break openclaw's plugin
discovery, so the canonical fix is to ignore W004 globally.