### PR TITLE
release: kairix v2026.5.15.2 — fix production crash on tests.fakes import in factory

### DIFF
--- a/kairix/core/factory.py
+++ b/kairix/core/factory.py
@@ -68,10 +68,63 @@ def _resolve_retrieval_config(config: RetrievalConfig | None) -> RetrievalConfig
     return load_config()
 
 
+class _NullVectorRepository:
+    """No-op VectorRepository fallback for degraded deployments.
+
+    Production fallback when the usearch index is missing or fails to load.
+    Returns empty result sets so the rest of the SearchPipeline can continue
+    in BM25-only mode. Defined inline (not in ``tests/fakes.py``) because
+    production code must never import from ``tests/`` — the directory is
+    not shipped in the installable wheel.
+    """
+
+    def search(
+        self,
+        query_vec: list[float],
+        k: int,
+        collections: list[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        # Reference args so F19 (unused-params-named) sees them as used.
+        # Names are fixed by the production caller (backends.py:94 uses
+        # ``k=`` and ``collections=`` keyword arguments).
+        _ = (query_vec, k, collections)
+        return []
+
+    def add_vectors(self, items: list[tuple[str, list[float]]]) -> int:
+        _ = items
+        return 0
+
+    def count(self) -> int:
+        return 0
+
+
+class _NullGraphRepository:
+    """No-op GraphRepository fallback for degraded deployments.
+
+    Production fallback when Neo4j is unreachable or its driver fails.
+    Reports ``available=False`` so entity-boost callers route around it.
+    Defined inline for the same reason as :class:`_NullVectorRepository`.
+    """
+
+    @property
+    def available(self) -> bool:
+        return False
+
+    def find_entity(self, name: str) -> dict[str, Any] | None:
+        _ = name
+        return None
+
+    def entity_in_degrees(self) -> list[dict[str, Any]]:
+        return []
+
+    def cypher(self, query: str, params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+        _ = (query, params)
+        return []
+
+
 def _build_vector_repo() -> Any:
-    """Construct the usearch vector repo, falling back to an empty fake on failure."""
+    """Construct the usearch vector repo, falling back to a null repo on failure."""
     from kairix.core.search.vector_repository import UsearchVectorRepository
-    from tests.fakes import FakeVectorRepository
 
     try:
         from kairix.core.search.vec_index import get_vector_index
@@ -82,21 +135,19 @@ def _build_vector_repo() -> Any:
         logger.warning("factory: usearch index not available — vector search disabled")
     except Exception as e:
         logger.warning("factory: failed to load vector index — %s", e)
-    return FakeVectorRepository()
+    return _NullVectorRepository()
 
 
 def _build_graph() -> Any:
-    """Construct the Neo4j graph repo, falling back to an unavailable fake on failure."""
+    """Construct the Neo4j graph repo, falling back to a null repo on failure."""
     try:
         from kairix.knowledge.graph.client import get_client
         from kairix.knowledge.graph.repository import Neo4jGraphRepository
 
         return Neo4jGraphRepository(client=get_client())
     except Exception as e:
-        from tests.fakes import FakeGraphRepository
-
         logger.warning("factory: Neo4j unavailable — %s", e)
-        return FakeGraphRepository(available=False)
+        return _NullGraphRepository()
 
 
 def _build_fusion(cfg: RetrievalConfig) -> Any:

--- a/tests/core/test_factory.py
+++ b/tests/core/test_factory.py
@@ -393,11 +393,15 @@ def test_build_search_pipeline_uses_real_vector_index_when_available() -> None:
 @pytest.mark.unit
 def test_build_search_pipeline_falls_back_when_get_vector_index_raises() -> None:
     """Drives lines 125-129 — when ``get_vector_index`` raises, the
-    factory logs a warning and substitutes ``FakeVectorRepository``.
+    factory logs a warning and substitutes a null vector repo.
+
+    Asserts behavioural fallback: ``search()`` returns ``[]`` and
+    ``count()`` returns 0, without depending on the fallback class
+    name (the inline ``_NullVectorRepository`` is private to factory).
 
     Sabotage proof: if the except handler stopped recovering, the
-    factory call would raise; this test asserts it returns a
-    well-formed pipeline.
+    factory call would raise; this test asserts a well-formed
+    pipeline whose vector search degrades silently.
     """
     from kairix.core.search import vec_index as vec_index_mod
 
@@ -412,9 +416,10 @@ def test_build_search_pipeline_falls_back_when_get_vector_index_raises() -> None
     finally:
         vec_index_mod.get_vector_index = real
 
-    # The factory threaded a FakeVectorRepository in instead of crashing.
-    repo_name = type(pipeline.vector._vector_repo).__name__
-    assert repo_name == "FakeVectorRepository"
+    # The factory threaded a null vector repo in instead of crashing.
+    repo = pipeline.vector._vector_repo
+    assert repo.search(query_vec=[0.0] * 4, k=10, collections=None) == []
+    assert repo.count() == 0
 
 
 @pytest.mark.unit
@@ -531,9 +536,13 @@ def test_build_search_pipeline_falls_back_to_fake_graph_when_get_client_raises()
     finally:
         client_mod.get_client = real
 
-    # Pipeline still constructed — graph fell back to FakeGraphRepository.
-    assert type(pipeline.graph).__name__ == "FakeGraphRepository"
+    # Pipeline still constructed — graph fell back to a null repo.
+    # Asserts the protocol surface (available=False) rather than the
+    # private inline ``_NullGraphRepository`` class name.
     assert pipeline.graph.available is False
+    assert pipeline.graph.find_entity("any") is None
+    assert pipeline.graph.entity_in_degrees() == []
+    assert pipeline.graph.cypher("RETURN 1") == []
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## kairix v2026.5.15.2 (same-day critical patch)

Fixes a production crash discovered during the v2026.5.15.1 VM deploy.

### What broke

\`kairix/core/factory.py\` imported \`FakeVectorRepository\` and \`FakeGraphRepository\` from \`tests.fakes\` as degraded-path fallbacks. The installable wheel does not ship the \`tests/\` directory, so any deployment where usearch fails to load or Neo4j is unreachable hit \`ModuleNotFoundError: No module named 'tests'\` instead of falling back gracefully.

Symptom: \`kairix onboard check\` reports \`vector_search_working\` failed with *"No module named 'tests'"*.

Regression introduced in PR #247 commit \`21ff2e68\` — the cognitive-complexity refactor extracted \`_build_vector_repo\` / \`_build_graph\` helpers carrying the existing tests.fakes imports forward without flagging them as a production-uninstallable layering violation.

### Fix

- Define \`_NullVectorRepository\` and \`_NullGraphRepository\` inline in \`factory.py\`. Both implement the Protocol surface with empty/false returns so the degraded path keeps the rest of the SearchPipeline alive in BM25-only mode (vector) or no-entity-boost mode (graph).
- Update \`tests/core/test_factory.py\` fallback assertions to check protocol behaviour (\`search()→[]\`, \`available→False\`) instead of the private class name — future refactors of the fallback type won't break the suite.
- Reference args via \`_ = (...)\` so F19 (unused-params-named) sees them used; can't rename to \`_x\` because production callers pass \`k=\` and \`collections=\` by keyword (\`backends.py:94\`).

### Follow-ups (separately)

- File: add a fitness function (F24) blocking \`from tests.*\` in \`kairix/*\` so this class of regression cannot recur.

## Test plan

- [x] All gates green via safe-commit.sh (3966 tests, F1-F23 + arch fitness all clean)
- [ ] Post-merge: tag v2026.5.15.2, verify publish workflows land
- [ ] Re-deploy on VM via \`docker compose pull && up -d\`
- [ ] \`kairix onboard check --json\` returns 9/9
- [ ] \`kairix benchmark run reflib\` exits 0 against pinned gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)