### PR TITLE
Builder/kairix cold start affordance

### DIFF
--- a/docs/operations/MCP-DEPLOYMENT.md
+++ b/docs/operations/MCP-DEPLOYMENT.md
@@ -41,7 +41,23 @@ Kairix exposes two health endpoints. Use `/healthz` for liveness, `/healthz/read
 curl http://127.0.0.1:8182/healthz
 ```
 
-Returns `{"ready": true, "uptime_s": N}` once kairix has finished cold-starting (Neo4j driver, vector index, LLM clients). Tool calls before ready return a structured `{"error": "kairix-initializing", "retry_after_ms": 1500}` rather than crashing — clients can retry with backoff.
+Returns `{"ready": true, "uptime_s": N}` once kairix has finished cold-starting (search pipeline construction plus a cheap probe search). HTTP deployments run this warm-up before marking the readiness gate ready, so normal agents should not see cold-start on the first user-facing tool call.
+
+If a tool call does arrive before the gate is ready, retrieval tools return the canonical retryable envelope rather than executing a partially-warmed path:
+
+```json
+{
+  "status": "retryable_not_ready",
+  "error": "ColdStart",
+  "error_code": "KAIRIX_COLD_START",
+  "tool": "search",
+  "retry_after_ms": 8000,
+  "estimated_seconds_remaining": 8.0,
+  "agent_instruction": "Do not answer from memory, do not use a lower-quality fallback, and do not treat this as a completed retrieval. Wait retry_after_ms, retry the same 'search' call once, then surface the cold-start blocker if it is still not ready."
+}
+```
+
+Clients and agent runtimes should treat `error_code=KAIRIX_COLD_START` as a wait-and-retry state, not as a completed search failure.
 
 ### `/healthz/ready` — layered readiness
 
@@ -74,7 +90,7 @@ Resolves the #167 gap where `/healthz` reported `ready=true` while vector search
 
 ## Error envelope
 
-Every tool handler is wrapped with `wrap_tool_errors`. Any exception escaping a handler becomes a structured response:
+Every tool handler is wrapped with `wrap_tool_errors`. Retrieval tools also have a readiness guard: when the HTTP readiness gate is closed, they return `KAIRIX_COLD_START` and do not enter the underlying search/bootstrap/research path. Any exception escaping a handler becomes a structured response:
 
 ```json
 {"error": "<ExceptionClass>: <message>"}

--- a/kairix/agents/mcp/cli.py
+++ b/kairix/agents/mcp/cli.py
@@ -22,6 +22,8 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
+from kairix.agents.mcp.cold_start import warm_retrieval_stack
+
 
 def _default_build_server() -> Callable[..., Any]:
     """Default factory: lazy-import build_server so it isn't loaded at module import."""
@@ -49,6 +51,7 @@ class McpCliDeps:
 
     build_server_factory: Callable[[], Callable[..., Any]] = field(default_factory=lambda: _default_build_server)
     uvicorn_runner_factory: Callable[[], Callable[..., Any]] = field(default_factory=lambda: _default_uvicorn_run)
+    warm_retrieval_stack_fn: Callable[[], dict[str, Any]] = warm_retrieval_stack
 
 
 def main(argv: list[str] | None = None, *, deps: McpCliDeps | None = None) -> None:
@@ -149,17 +152,16 @@ def _cmd_serve(args: argparse.Namespace, *, deps: McpCliDeps) -> None:
 
     # http transport — streamable HTTP at /mcp via uvicorn, optional /sse legacy
     port = _resolve_port(args)
-    server = build_server(host=args.host, port=port)
 
     from kairix.agents.mcp.capability_probe import build_capability_probe
     from kairix.agents.mcp.readiness import EventReadinessGate
     from kairix.agents.mcp.transport import build_mcp_app
 
-    # The http transport's lazy-init paths (Neo4j, vector index, LLM clients)
-    # are exercised on first tool call rather than at startup, so the gate
-    # is marked ready immediately after the app is built. When we add a real
-    # warm-up phase, mark_ready() moves to the end of that phase.
+    # HTTP deployments are long-running shared services. Pay the expensive
+    # retrieval initialisation cost before advertising readiness so the first
+    # user-facing tool call does not receive a cold-start surprise.
     gate = EventReadinessGate()
+    server = build_server(host=args.host, port=port, readiness_check=gate.is_ready, mark_ready=gate.mark_ready)
     capability_probe = build_capability_probe()
     app = build_mcp_app(
         server,
@@ -167,7 +169,18 @@ def _cmd_serve(args: argparse.Namespace, *, deps: McpCliDeps) -> None:
         readiness_check=gate.is_ready,
         capability_probe=capability_probe,
     )
-    gate.mark_ready()
+    warm_result = deps.warm_retrieval_stack_fn()
+    if warm_result.get("ready") is True:
+        gate.mark_ready()
+        print(
+            f"warm-up complete — elapsed_ms={warm_result.get('elapsed_ms', 'unknown')}",
+            file=sys.stderr,
+        )
+    else:
+        print(
+            f"WARNING: kairix warm-up incomplete; tools will return KAIRIX_COLD_START until ready: {warm_result}",
+            file=sys.stderr,
+        )
 
     sse_status = "+ /sse legacy" if not args.no_sse else "(no /sse)"
     print(

--- a/kairix/agents/mcp/cold_start.py
+++ b/kairix/agents/mcp/cold_start.py
@@ -1,0 +1,159 @@
+"""Cold-start affordances for the Kairix MCP surface.
+
+The MCP server can be alive before the retrieval stack is warm. LLM agents are
+not reliable retry engines, so cold-start must be encoded as a mechanical,
+retryable state rather than prose hidden in a generic error string.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+DEFAULT_RETRY_AFTER_MS = 8000
+DEFAULT_ESTIMATED_SECONDS = 8.0
+
+
+@dataclass(frozen=True)
+class ColdStartConfig:
+    """Settings for a retryable not-ready MCP response."""
+
+    retry_after_ms: int = DEFAULT_RETRY_AFTER_MS
+    estimated_seconds_remaining: float = DEFAULT_ESTIMATED_SECONDS
+
+
+def cold_start_envelope(
+    *,
+    tool_name: str,
+    retry_after_ms: int = DEFAULT_RETRY_AFTER_MS,
+    estimated_seconds_remaining: float = DEFAULT_ESTIMATED_SECONDS,
+) -> dict[str, Any]:
+    """Return the canonical Kairix MCP cold-start envelope.
+
+    This shape is intentionally redundant. Different agents attend to different
+    fields; the stable machine fields (``status`` / ``error_code`` /
+    ``retry_after_ms``) are paired with a direct instruction that forbids
+    fallback-from-memory behaviour.
+    """
+
+    retry_seconds = max(1.0, retry_after_ms / 1000)
+    return {
+        "status": "retryable_not_ready",
+        "error": "ColdStart",
+        "error_code": "KAIRIX_COLD_START",
+        "tool": tool_name,
+        "retry_after_ms": retry_after_ms,
+        "estimated_seconds_remaining": estimated_seconds_remaining,
+        "guidance": (
+            f"kairix is warming (one-time cost per process). Retry this {tool_name!r} "
+            f"call in ~{retry_seconds:.0f} seconds. Subsequent calls in this process will be fast."
+        ),
+        "agent_instruction": (
+            "Do not answer from memory, do not use a lower-quality fallback, and do not treat this as a "
+            f"completed retrieval. Wait retry_after_ms, retry the same {tool_name!r} call once, then "
+            "surface the cold-start blocker if it is still not ready."
+        ),
+        "see_also": ["docs/operations/MCP-DEPLOYMENT.md"],
+    }
+
+
+def is_cold_start_envelope(payload: Any) -> bool:
+    """Return True when ``payload`` is the canonical cold-start envelope."""
+
+    return isinstance(payload, dict) and payload.get("error_code") == "KAIRIX_COLD_START"
+
+
+def require_ready(
+    tool_name: str,
+    readiness_check: Callable[[], bool] | None,
+    *,
+    config: ColdStartConfig | None = None,
+) -> dict[str, Any] | None:
+    """Return a cold-start envelope when readiness_check says not-ready.
+
+    ``None`` means the caller may proceed with the real tool implementation.
+    """
+
+    if readiness_check is None or readiness_check():
+        return None
+    cfg = config or ColdStartConfig()
+    return cold_start_envelope(
+        tool_name=tool_name,
+        retry_after_ms=cfg.retry_after_ms,
+        estimated_seconds_remaining=cfg.estimated_seconds_remaining,
+    )
+
+
+def warm_retrieval_stack() -> dict[str, Any]:
+    """Pay the expensive retrieval initialisation cost once.
+
+    This function deliberately constructs the production search pipeline and runs
+    a tiny read-only probe. It should be called by long-running HTTP deployments
+    before advertising readiness, and can also be exposed as a manual ``warm``
+    MCP tool.
+    """
+
+    import time
+
+    started = time.perf_counter()
+    steps: list[dict[str, Any]] = []
+
+    try:
+        step_started = time.perf_counter()
+        from kairix.core.factory import build_search_pipeline
+
+        pipeline = build_search_pipeline()
+        steps.append(
+            {
+                "name": "build_search_pipeline",
+                "ok": True,
+                "elapsed_ms": int((time.perf_counter() - step_started) * 1000),
+            }
+        )
+    except Exception as exc:
+        return {
+            "status": "error",
+            "ready": False,
+            "elapsed_ms": int((time.perf_counter() - started) * 1000),
+            "steps": [
+                *steps,
+                {
+                    "name": "build_search_pipeline",
+                    "ok": False,
+                    "error": f"{type(exc).__name__}: {exc}",
+                },
+            ],
+        }
+
+    try:
+        step_started = time.perf_counter()
+        pipeline.search(query="kairix warmup", budget=200, collections=[])
+        steps.append(
+            {
+                "name": "probe_search",
+                "ok": True,
+                "elapsed_ms": int((time.perf_counter() - step_started) * 1000),
+            }
+        )
+    except Exception as exc:
+        return {
+            "status": "error",
+            "ready": False,
+            "elapsed_ms": int((time.perf_counter() - started) * 1000),
+            "steps": [
+                *steps,
+                {
+                    "name": "probe_search",
+                    "ok": False,
+                    "error": f"{type(exc).__name__}: {exc}",
+                },
+            ],
+        }
+
+    return {
+        "status": "ok",
+        "ready": True,
+        "elapsed_ms": int((time.perf_counter() - started) * 1000),
+        "steps": steps,
+    }

--- a/kairix/agents/mcp/server.py
+++ b/kairix/agents/mcp/server.py
@@ -9,6 +9,7 @@ Provides the following tools:
   timeline     Temporal query rewriting + date-aware retrieval
   contradict   Check new content against existing knowledge for contradictions
   usage_guide  Return the kairix agent usage guide (self-documentation)
+  warm         Pay retrieval initialisation costs and mark the readiness gate ready
 
 The server uses FastMCP (from the ``mcp`` package). Install via:
     pip install kairix[agents]
@@ -25,9 +26,11 @@ Design principles:
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Literal
 
+from kairix.agents.mcp.cold_start import require_ready, warm_retrieval_stack
 from kairix.agents.mcp.errors import async_tool_handler
 from kairix.core.search.scope import Scope
 
@@ -437,13 +440,25 @@ def tool_bootstrap(
 # ---------------------------------------------------------------------------
 
 
-def build_server(host: str = "127.0.0.1", port: int = 8080) -> Any:
+def build_server(
+    host: str = "127.0.0.1",
+    port: int = 8080,
+    *,
+    readiness_check: Callable[[], bool] | None = None,
+    mark_ready: Callable[[], None] | None = None,
+) -> Any:
     """
     Construct and return the FastMCP server with all tools registered.
 
     Args:
         host: Bind address for SSE transport.
         port: Port for SSE transport.
+        readiness_check: Optional gate used by long-running HTTP deployments.
+                         If it returns False, retrieval tools return a
+                         canonical retryable cold-start envelope instead of
+                         executing a lower-quality or partially-initialised path.
+        mark_ready: Optional callback used by the warm tool to open the HTTP
+                    readiness gate after a successful manual warm-up.
 
     Raises ImportError when the ``mcp`` package is not installed.
     Install via: pip install kairix[agents]
@@ -463,7 +478,9 @@ def build_server(host: str = "127.0.0.1", port: int = 8080) -> Any:
         description=(
             "Call before answering any factual question about prior work, decisions, or context — "
             "kairix indexes the team's knowledge store and finds relevant prior material. "
-            "Use this proactively at session start and whenever a question touches the team's history."
+            "Use this proactively at session start and whenever a question touches the team's history. "
+            "If the result has error_code=KAIRIX_COLD_START, do not answer from memory or fallback; "
+            "wait retry_after_ms and retry the same call once."
         )
     )
     @async_tool_handler
@@ -475,6 +492,8 @@ def build_server(host: str = "127.0.0.1", port: int = 8080) -> Any:
         limit: int = 10,
     ) -> dict[str, Any]:
         """Search your knowledge store — finds the best answers to any question."""
+        if cold := require_ready("search", readiness_check):
+            return cold
         return tool_search(query=query, agent=agent, scope=scope, budget=budget, limit=limit)
 
     @server.tool(
@@ -488,7 +507,13 @@ def build_server(host: str = "127.0.0.1", port: int = 8080) -> Any:
         """Entity lookup from Neo4j."""
         return tool_entity(name=name)
 
-    @server.tool()
+    @server.tool(
+        description=(
+            "Call when you need lightweight context preparation before deeper work. "
+            "If the result has error_code=KAIRIX_COLD_START, wait retry_after_ms and retry; "
+            "do not substitute memory-only context."
+        )
+    )
     @async_tool_handler
     def prep(
         query: str,
@@ -497,9 +522,16 @@ def build_server(host: str = "127.0.0.1", port: int = 8080) -> Any:
         scope: Scope = DEFAULT_SCOPE,
     ) -> dict[str, Any]:
         """Context preparation: tiered L0/L1 summary generation."""
+        if cold := require_ready("prep", readiness_check):
+            return cold
         return tool_prep(query=query, agent=agent, tier=tier, scope=scope)
 
-    @server.tool()
+    @server.tool(
+        description=(
+            "Call for date-aware retrieval when a question depends on timing. "
+            "If the result has error_code=KAIRIX_COLD_START, wait retry_after_ms and retry the same call."
+        )
+    )
     @async_tool_handler
     def timeline(
         query: str,
@@ -508,6 +540,8 @@ def build_server(host: str = "127.0.0.1", port: int = 8080) -> Any:
         scope: Scope = DEFAULT_SCOPE,
     ) -> dict[str, Any]:
         """Temporal query rewriting + date-aware retrieval."""
+        if cold := require_ready("timeline", readiness_check):
+            return cold
         return tool_timeline(
             query=query,
             anchor_date=anchor_date,
@@ -515,13 +549,25 @@ def build_server(host: str = "127.0.0.1", port: int = 8080) -> Any:
             scope=scope,
         )
 
-    @server.tool()
+    @server.tool(
+        description=(
+            "Call for complex research questions that need iterative retrieval. "
+            "If the result has error_code=KAIRIX_COLD_START, wait retry_after_ms and retry before answering."
+        )
+    )
     @async_tool_handler
     def research(query: str, agent: str | None = None, max_turns: int = 4) -> dict[str, Any]:
         """Research a complex question. Searches iteratively until it finds a good answer."""
+        if cold := require_ready("research", readiness_check):
+            return cold
         return tool_research(query=query, agent=agent, max_turns=max_turns)
 
-    @server.tool()
+    @server.tool(
+        description=(
+            "Call before writing new facts to check for contradictions against existing knowledge. "
+            "If the result has error_code=KAIRIX_COLD_START, wait retry_after_ms and retry before proceeding."
+        )
+    )
     @async_tool_handler
     def contradict(
         content: str,
@@ -532,6 +578,8 @@ def build_server(host: str = "127.0.0.1", port: int = 8080) -> Any:
         scope: Scope = DEFAULT_SCOPE,
     ) -> dict[str, Any]:
         """Check new content against existing knowledge for contradictions."""
+        if cold := require_ready("contradict", readiness_check):
+            return cold
         return tool_contradict(
             content=content,
             agent=agent,
@@ -551,12 +599,16 @@ def build_server(host: str = "127.0.0.1", port: int = 8080) -> Any:
         description=(
             "Call when you want a synthesised view of a topic — kairix runs a small research loop "
             "across the knowledge store and returns a structured briefing. "
-            "Use it when you'd otherwise be tempted to summarise from memory."
+            "Use it when you'd otherwise be tempted to summarise from memory. "
+            "If the result has error_code=KAIRIX_COLD_START, do not summarise from memory; "
+            "wait retry_after_ms and retry the same call."
         )
     )
     @async_tool_handler
     def brief(agent: str) -> dict[str, Any]:
         """Generate a session briefing for an agent. Returns content + on-disk path."""
+        if cold := require_ready("brief", readiness_check):
+            return cold
         return tool_brief(agent=agent)
 
     @server.tool(
@@ -564,13 +616,26 @@ def build_server(host: str = "127.0.0.1", port: int = 8080) -> Any:
             "Call at session start or whenever you switch topics. "
             "Returns your agent role, current board, recent memory, and active goals — "
             "orients you in the team's current state. "
-            "If health.vector_search != 'ok', surface that to your human."
+            "If health.vector_search != 'ok', surface that to your human. "
+            "If the result has error_code=KAIRIX_COLD_START, wait retry_after_ms and retry; "
+            "do not begin the task context-blind."
         )
     )
     @async_tool_handler
     def bootstrap(agent: str, max_memory_days: int = 3) -> dict[str, Any]:
         """Return the agent orientation envelope: role, board, recent memory, goals, health."""
+        if cold := require_ready("bootstrap", readiness_check):
+            return cold
         return tool_bootstrap(agent=agent, max_memory_days=max_memory_days)
+
+    @server.tool()
+    @async_tool_handler
+    def warm() -> dict[str, Any]:
+        """Warm kairix retrieval caches. Call at session start; retry if cold-start is reported."""
+        result = warm_retrieval_stack()
+        if result.get("ready") is True and mark_ready is not None:
+            mark_ready()
+        return result
 
     @server.tool()
     @async_tool_handler

--- a/tests/agents/mcp/test_cold_start.py
+++ b/tests/agents/mcp/test_cold_start.py
@@ -1,0 +1,43 @@
+"""Cold-start affordance tests for the Kairix MCP surface."""
+
+from __future__ import annotations
+
+import pytest
+
+from kairix.agents.mcp.cold_start import (
+    cold_start_envelope,
+    is_cold_start_envelope,
+    require_ready,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_cold_start_envelope_is_machine_actionable_and_prescriptive() -> None:
+    payload = cold_start_envelope(tool_name="search", retry_after_ms=7000, estimated_seconds_remaining=7.0)
+
+    assert payload["status"] == "retryable_not_ready"
+    assert payload["error_code"] == "KAIRIX_COLD_START"
+    assert payload["retry_after_ms"] == 7000
+    assert payload["estimated_seconds_remaining"] == 7.0
+    assert "Do not answer from memory" in payload["agent_instruction"]
+    assert "retry the same 'search' call" in payload["agent_instruction"]
+
+
+def test_is_cold_start_envelope_recognises_canonical_shape() -> None:
+    assert is_cold_start_envelope(cold_start_envelope(tool_name="bootstrap")) is True
+    assert is_cold_start_envelope({"error": "ColdStart"}) is False
+    assert is_cold_start_envelope("ColdStart") is False
+
+
+def test_require_ready_returns_none_when_no_gate_or_ready() -> None:
+    assert require_ready("search", None) is None
+    assert require_ready("search", lambda: True) is None
+
+
+def test_require_ready_returns_cold_start_when_gate_not_ready() -> None:
+    payload = require_ready("search", lambda: False)
+
+    assert payload is not None
+    assert payload["error_code"] == "KAIRIX_COLD_START"
+    assert payload["tool"] == "search"

--- a/tests/integration/test_mcp_build_server.py
+++ b/tests/integration/test_mcp_build_server.py
@@ -36,6 +36,7 @@ _EXPECTED_TOOLS = {
     "entity_suggest",
     "entity_validate",
     "bootstrap",
+    "warm",
 }
 
 

--- a/tests/mcp/test_cli_unit.py
+++ b/tests/mcp/test_cli_unit.py
@@ -79,7 +79,10 @@ def _drive(args: list[str], deps: McpCliDeps) -> tuple[str, str, int]:
 
 
 def _build_deps(
-    *, fake_server: _FakeMcpServer | None = None, fake_runner: _RunRecorder | None = None
+    *,
+    fake_server: _FakeMcpServer | None = None,
+    fake_runner: _RunRecorder | None = None,
+    warm_result: dict[str, Any] | None = None,
 ) -> tuple[McpCliDeps, list[dict], _RunRecorder]:
     fake_server = fake_server or _FakeMcpServer()
     fake_runner = fake_runner or _RunRecorder()
@@ -92,6 +95,7 @@ def _build_deps(
     deps = McpCliDeps(
         build_server_factory=lambda: _fake_build_server,
         uvicorn_runner_factory=lambda: fake_runner,
+        warm_retrieval_stack_fn=lambda: warm_result or {"ready": True, "elapsed_ms": 1},
     )
     return deps, build_calls, fake_runner
 
@@ -120,13 +124,17 @@ def test_serve_http_transport_runs_uvicorn_with_resolved_app(monkeypatch) -> Non
     _stdout, stderr, code = _drive(["serve", "--transport", "http", "--port", "18099"], deps)
 
     assert code == 0
-    assert build_calls == [{"host": "127.0.0.1", "port": 18099}]
+    assert len(build_calls) == 1
+    assert build_calls[0]["host"] == "127.0.0.1"
+    assert build_calls[0]["port"] == 18099
+    assert callable(build_calls[0]["readiness_check"])
     assert len(runner.calls) == 1
     pos, kwargs = runner.calls[0]
     assert pos[0] is not None  # the app object
     assert kwargs == {"host": "127.0.0.1", "port": 18099, "log_level": "info"}
     assert "Starting kairix MCP server on http://127.0.0.1:18099/mcp" in stderr
     assert "+ /sse legacy" in stderr
+    assert "warm-up complete" in stderr
 
 
 @pytest.mark.unit
@@ -138,6 +146,22 @@ def test_serve_http_transport_with_no_sse_flag(monkeypatch) -> None:
     assert code == 0
     assert runner.calls
     assert "(no /sse)" in stderr
+
+
+
+
+@pytest.mark.unit
+def test_serve_http_keeps_readiness_closed_when_warmup_fails(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["kairix", "mcp", "serve", "--port", "18096"])
+    deps, build_calls, runner = _build_deps(warm_result={"ready": False, "status": "error"})
+
+    _stdout, stderr, code = _drive(["serve", "--transport", "http", "--port", "18096"], deps)
+
+    assert code == 0
+    assert runner.calls
+    assert callable(build_calls[0]["readiness_check"])
+    assert build_calls[0]["readiness_check"]() is False
+    assert "warm-up incomplete" in stderr
 
 
 @pytest.mark.unit
@@ -210,7 +234,10 @@ def test_resolve_port_auto_detect_when_default_available(monkeypatch, _no_mcp_po
     deps, build_calls, _runner = _build_deps()
     _stdout, _stderr, code = _drive(["serve", "--transport", "http"], deps)
     assert code == 0
-    assert build_calls == [{"host": "127.0.0.1", "port": 8080}]
+    assert len(build_calls) == 1
+    assert build_calls[0]["host"] == "127.0.0.1"
+    assert build_calls[0]["port"] == 8080
+    assert callable(build_calls[0]["readiness_check"])
 
 
 @pytest.mark.unit
@@ -225,6 +252,9 @@ def test_resolve_port_auto_detect_falls_back_when_default_in_use(monkeypatch, _n
     deps, build_calls, _runner = _build_deps()
     _stdout, stderr, code = _drive(["serve", "--transport", "http"], deps)
     assert code == 0
-    assert build_calls == [{"host": "127.0.0.1", "port": 19100}]
+    assert len(build_calls) == 1
+    assert build_calls[0]["host"] == "127.0.0.1"
+    assert build_calls[0]["port"] == 19100
+    assert callable(build_calls[0]["readiness_check"])
     assert "Port 8080 is in use" in stderr
     assert "KAIRIX_MCP_PORT=19100" in stderr

--- a/tests/mcp/test_server_unit_coverage.py
+++ b/tests/mcp/test_server_unit_coverage.py
@@ -106,6 +106,7 @@ def test_build_server_constructs_fastmcp_with_all_tools_registered_under_unit() 
         "entity_suggest",
         "entity_validate",
         "bootstrap",
+        "warm",
     } == names
 
 
@@ -144,6 +145,66 @@ def test_build_server_each_wrapper_dispatches_to_tool_function_under_unit() -> N
         ("entity_suggest", {"text": "x"}),
         ("entity_validate", {"name": "x"}),
         ("bootstrap", {"agent": "alpha", "max_memory_days": 0}),
+        ("warm", {}),
     ]:
         payload = _call_tool(server, tool_name, args)
         assert isinstance(payload, dict), f"tool {tool_name!r} returned non-dict: {payload!r}"
+
+
+
+@pytest.mark.unit
+def test_warm_tool_marks_ready_after_success(monkeypatch) -> None:
+    """Manual warm-up opens the injected readiness gate after a successful warm result."""
+    import kairix.agents.mcp.server as mcp_server
+
+    marked: list[bool] = []
+    monkeypatch.setattr(
+        mcp_server,
+        "warm_retrieval_stack",
+        lambda: {"status": "ok", "ready": True, "elapsed_ms": 1, "steps": []},
+    )
+    server = build_server(host="127.0.0.1", port=18095, mark_ready=lambda: marked.append(True))
+
+    payload = _call_tool(server, "warm", {})
+
+    assert payload["ready"] is True
+    assert marked == [True]
+
+
+@pytest.mark.unit
+def test_warm_tool_does_not_mark_ready_after_failed_warm(monkeypatch) -> None:
+    """Failed warm-up returns the diagnostic payload and leaves the gate closed."""
+    import kairix.agents.mcp.server as mcp_server
+
+    marked: list[bool] = []
+    monkeypatch.setattr(
+        mcp_server,
+        "warm_retrieval_stack",
+        lambda: {"status": "error", "ready": False, "elapsed_ms": 1, "steps": []},
+    )
+    server = build_server(host="127.0.0.1", port=18096, mark_ready=lambda: marked.append(True))
+
+    payload = _call_tool(server, "warm", {})
+
+    assert payload["ready"] is False
+    assert marked == []
+
+
+@pytest.mark.unit
+def test_build_server_retrieval_tools_return_cold_start_envelope_when_not_ready() -> None:
+    """HTTP deployments can inject a readiness gate; retrieval tools must not run while cold."""
+    server = build_server(host="127.0.0.1", port=18094, readiness_check=lambda: False)
+
+    for tool_name, args in [
+        ("search", {"query": "x"}),
+        ("prep", {"query": "x"}),
+        ("timeline", {"query": "x"}),
+        ("research", {"query": "x"}),
+        ("contradict", {"content": "x"}),
+        ("brief", {"agent": "shape"}),
+        ("bootstrap", {"agent": "builder"}),
+    ]:
+        payload = _call_tool(server, tool_name, args)
+        assert payload["error_code"] == "KAIRIX_COLD_START"
+        assert payload["status"] == "retryable_not_ready"
+        assert "Do not answer from memory" in payload["agent_instruction"]


### PR DESCRIPTION
## Summary

<!-- What does this PR do? 1-3 bullet points. -->

## Change type

- [ ] Bug fix
- [ ] New feature / enhancement
- [ ] Architecture (protocols, pipelines, repositories)
- [ ] Documentation only
- [ ] Dependency update

## Quality gates

- [ ] `bash scripts/safe-commit.sh` passes (lint, format, mypy, tests, secrets)
- [ ] No `@patch` or monkey-patching in new test code — uses fakes from `tests/fakes.py`
- [ ] No private function imports in tests
- [ ] Every new test has a marker (`@pytest.mark.unit`, `contract`, `bdd`, or `integration`)
- [ ] Protocol compliance verified if new protocols/implementations added

## Retrieval quality

*Required if this PR changes search, embed, entity, or temporal logic.*

- [ ] Benchmark run completed: `kairix benchmark run --suite suites/<suite>.yaml`
- [ ] NDCG@10 result: **__.__**
- [ ] No category regressed by more than 0.02

## Security

- [ ] No secrets, API keys, or real agent/client names in this PR
- [ ] `detect-secrets scan` passes
- [ ] `bandit` passes: zero HIGH/MEDIUM findings

## Checklist

- [ ] Coverage ≥ 80% maintained
- [ ] Documentation updated (if behaviour or API surface changed)
- [ ] CONSTRAINTS.md respected
