### PR TITLE
fix(install): kairix.service unit-file bugs + missing install steps

### DIFF
--- a/docs/operations/OPERATIONS.md
+++ b/docs/operations/OPERATIONS.md
@@ -317,9 +317,19 @@ If kairix container fails to start with `failed to bind host port 127.0.0.1:8080
 If you run kairix as a systemd-managed Docker stack on a long-running VM, copy the example units from `scripts/install/` and tailor them. They pin the correct dependency ordering (kairix.service → kairix-fetch-secrets.service → docker.service) so the deployment self-heals after a reboot rather than crash-looping when `/run/secrets/kairix.env` is empty (resolved in v2026.5.10, see #167).
 
 ```bash
+# Create the data directory the unit declares in ReadWritePaths= before
+# enabling the unit, otherwise systemd's mount namespace setup will fail
+# with "Failed to set up mount namespacing: /var/lib/kairix: No such
+# file or directory" (exit 226/NAMESPACE) — the unit appears failed
+# even though the containers come up cleanly outside systemd. The
+# ReadWritePaths= entries in the shipped unit use the `-` prefix so
+# they don't strictly require this, but creating the canonical path
+# explicitly is cheaper than chasing a phantom-failure unit later.
+sudo install -d -m 0750 -o kairix -g kairix /var/lib/kairix
+
 sudo install -m 0644 scripts/install/kairix.service.example /etc/systemd/system/kairix.service
 sudo install -m 0644 scripts/install/kairix-fetch-secrets.service.example /etc/systemd/system/kairix-fetch-secrets.service
-sudo install -m 0755 scripts/install/permissions-preflight.sh /opt/kairix/bin/permissions-preflight.sh
+sudo install -m 0750 -o kairix -g kairix scripts/install/permissions-preflight.sh /opt/kairix/bin/permissions-preflight.sh
 sudo systemctl daemon-reload
 sudo systemctl enable --now kairix-fetch-secrets.service kairix.service
 ```

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -8,6 +8,7 @@ These are the **VM-facing** runbooks. Docker-compose and how-to-style operationa
 |---|---|---|
 | Search wrong / empty, recall canary regressed, `kairix onboard check` reports failures | [kairix-retrieval-health](kairix-retrieval-health.md) | Diagnosis tree by failed subsystem (secrets → vector → BM25/FTS → agent knowledge → chunk_date → Neo4j); per-failure recovery; full reset; recall-canary regression triage |
 | Package upgrade, unit-file change, secrets-fetcher change on a systemd-managed VM | [kairix-systemd-update](kairix-systemd-update.md) | Safe update sequence, in-flight drain, rollback, verification |
+| `systemctl status kairix.service` reports `failed` but containers respond on `:8080/health` | [kairix-service-failed-containers-healthy](kairix-service-failed-containers-healthy.md) | Diagnosis by journal headline (226/NAMESPACE, StartLimit warning, preflight FAIL, missing script); per-cause recovery; why systemd state and container state can disagree |
 | Alpha-tag gate from `release-vm-deploy.yml` failing or stuck pending | `kairix-alpha-deploy-webhook` runbook (lives in your sibling infrastructure repo, alongside the systemd unit + apply script for the webhook) | Bootstrap, install, triage for the VM-side webhook that runs onboard-check + benchmark on each alpha tag |
 
 ## Pre-flight before any recovery

--- a/docs/runbooks/kairix-service-failed-containers-healthy.md
+++ b/docs/runbooks/kairix-service-failed-containers-healthy.md
@@ -1,0 +1,133 @@
+# Runbook — `kairix.service` failed in systemd but containers are healthy
+
+You landed here because `systemctl status kairix.service` shows `failed` (or `activating (auto-restart)`) while `curl http://localhost:8080/health` returns `{"ok":true,"status":"live"}` and `docker compose ps` shows the kairix containers as `Up (healthy)`.
+
+This is a known disconnect: the docker containers were started by a previous successful run (or by a manual `docker compose up -d`) and continue to serve traffic under dockerd's own restart policy. systemd's view is stale. Search and ingest still work; the systemd state is lying.
+
+## Diagnose
+
+Run this first. The output names the layer that is broken.
+
+```bash
+sudo journalctl -xeu kairix.service --no-pager | tail -30
+```
+
+Match the headline error against the table.
+
+| Headline in journal | Layer | Fix |
+|---|---|---|
+| `Failed to set up mount namespacing: /var/lib/kairix: No such file or directory` and `code=exited, status=226/NAMESPACE` | systemd namespace setup | [§1](#1-readwritepaths-target-missing) |
+| `Unknown key name 'StartLimitIntervalSec' in section 'Service', ignoring` (any daemon-reload) | unit-file section misplacement | [§2](#2-startlimit-keys-in-wrong-section) |
+| `(kairix-preflight) FAIL: required env keys missing after merging .env + secrets` while the merged file does have the keys | preflight invoked as non-root | [§3](#3-execstartpre-not-running-as-root) |
+| `permissions-preflight.sh: No such file or directory` | preflight script not copied to runtime path | [§4](#4-preflight-not-installed) |
+
+Pick the matching section, apply the fix, then go to [§5 Verify](#5-verify).
+
+## 1. `ReadWritePaths=` target missing
+
+The shipped unit declares `ReadWritePaths=/opt/kairix /var/lib/kairix /run/secrets`. If any of those paths does not exist, systemd refuses to set up the mount namespace and the unit exits 226 before `ExecStartPre=` runs.
+
+fix: create the missing directory with the right ownership, then start the unit.
+
+next: run `systemctl status kairix.service` and confirm `Active: active (exited)`.
+
+```bash
+sudo install -d -m 0750 -o kairix -g kairix /var/lib/kairix
+sudo systemctl reset-failed kairix.service
+sudo systemctl start kairix.service
+```
+
+Updated installs (v2026.6.6 and later) ship the unit with `ReadWritePaths=-/opt/kairix -/var/lib/kairix -/run/secrets` (`-` prefix = path is optional). If you are running an older unit, either replace the unit file from `scripts/install/kairix.service.example` or pin the directory explicitly as above.
+
+## 2. `StartLimit*` keys in wrong section
+
+`StartLimitIntervalSec=` and `StartLimitBurst=` belong in `[Unit]`, not `[Service]`. systemd silently ignores them under `[Service]` and the unit has no startup-rate limit at all — every restart counts as a fresh attempt and the unit can crash-loop forever on a host with a broken preflight.
+
+fix: replace the unit file with the canonical example, then daemon-reload.
+
+next: run `sudo systemctl daemon-reload` and confirm no `Unknown key name` warning appears in `journalctl -xe`.
+
+```bash
+sudo install -m 0644 scripts/install/kairix.service.example /etc/systemd/system/kairix.service
+sudo systemctl daemon-reload
+sudo systemctl reset-failed kairix.service
+sudo systemctl start kairix.service
+```
+
+## 3. `ExecStartPre=` not running as root
+
+The preflight script's self-heal section (`chown` / `chmod` of `.env`) and its `/run/secrets/kairix.env` read both need root. If the unit declares `User=kairix` and `ExecStartPre=` is *not* prefixed with `+`, systemd runs the preflight as the kairix user and the script's checks fail on hosts where `/run/secrets/kairix.env` is `root:root` mode 0640.
+
+fix: prefix `ExecStartPre=` with `+` in the unit file.
+
+next: `daemon-reload` and start the unit.
+
+```bash
+sudo sed -i 's|^ExecStartPre=/opt/kairix/bin/permissions-preflight.sh|ExecStartPre=+/opt/kairix/bin/permissions-preflight.sh|' /etc/systemd/system/kairix.service
+sudo systemctl daemon-reload
+sudo systemctl reset-failed kairix.service
+sudo systemctl start kairix.service
+```
+
+Or replace the whole file with the canonical example, which carries the `+` prefix:
+
+```bash
+sudo install -m 0644 scripts/install/kairix.service.example /etc/systemd/system/kairix.service
+```
+
+## 4. Preflight not installed
+
+The unit references `/opt/kairix/bin/permissions-preflight.sh`, but the install step that copies the script there was skipped or wiped (e.g. by a half-finished `openclaw-upgrade.sh`).
+
+fix: install the script from the source repo (do not symlink — `ProtectSystem=strict` blocks symlinks that point outside the `ReadWritePaths=` set, and you will land back in §1 with a 226).
+
+next: confirm the script runs cleanly under root.
+
+```bash
+sudo install -m 0750 -o kairix -g kairix \
+    /data/development/kairix/scripts/install/permissions-preflight.sh \
+    /opt/kairix/bin/permissions-preflight.sh
+
+sudo /opt/kairix/bin/permissions-preflight.sh
+# expect: [kairix-preflight] ok — all host-side preflight checks pass
+
+sudo systemctl reset-failed kairix.service
+sudo systemctl start kairix.service
+```
+
+## 5. Verify
+
+Confirm all four signals are green. If any fails, return to the diagnose table.
+
+```bash
+systemctl status kairix.service --no-pager | head -8
+# expect: Active: active (exited), ExecStartPre status=0/SUCCESS, ExecStart status=0/SUCCESS
+
+curl -fsS http://localhost:8080/health
+# expect: {"ok":true,"status":"live"}
+
+systemctl --failed --no-pager
+# expect: 0 loaded units listed.
+
+sudo journalctl --since '5 minutes ago' --no-pager | grep -iE 'kairix.*Unknown key|kairix.*NAMESPACE|kairix-preflight FAIL'
+# expect: no output
+```
+
+## Why this disconnect happens
+
+Docker manages container lifecycles itself (`restart: unless-stopped` in the compose file). A `docker compose up -d` from a successful past run leaves the containers running under dockerd even when the systemd unit that started them is later wedged. systemd's `Type=oneshot` semantics mean the unit's state reflects only the `ExecStartPre=` + `ExecStart=` exit codes from the *last* attempt, not the running container fleet.
+
+Once you have fixed the failing layer, systemd's state catches up to docker's reality at the next clean start.
+
+## Escalation
+
+If §1-4 all apply, or the diagnose-table headline is not listed, attach to the issue:
+
+- `sudo systemctl status kairix.service --no-pager`
+- `sudo journalctl -xeu kairix.service --no-pager | tail -100`
+- `cat /etc/systemd/system/kairix.service`
+- `ls -la /opt/kairix/bin/ /var/lib/kairix/ /run/secrets/kairix.env`
+- `sudo /opt/kairix/bin/permissions-preflight.sh 2>&1`
+- Output of `docker compose ps` in `/opt/kairix/app/`.
+
+File at <https://github.com/three-cubes/kairix/issues> with title `kairix-service-failed-containers-healthy: <headline>`.

--- a/scripts/install/kairix.service.example
+++ b/scripts/install/kairix.service.example
@@ -19,6 +19,12 @@ After=network-online.target docker.service kairix-fetch-secrets.service
 # Strict: kairix MUST NOT start until /run/secrets/kairix.env has been
 # written. Without this, vector search comes up degraded (BM25 only).
 Requires=docker.service kairix-fetch-secrets.service
+# Bounded retry — 5 attempts in 5 min then give up so a broken host
+# doesn't loop forever. These keys belong in [Unit], not [Service] —
+# placing them under [Service] makes systemd log "Unknown key name"
+# and silently skip them, leaving the unit with no startup-rate limit.
+StartLimitIntervalSec=300
+StartLimitBurst=5
 
 [Service]
 # ---------------------------------------------------------------------------
@@ -84,17 +90,23 @@ RemainAfterExit=true
 # if .env / secrets / required env vars are missing — surfacing the
 # failure here is far more diagnostic than docker compose's
 # "permission denied" cycle.
-ExecStartPre=/opt/kairix/bin/permissions-preflight.sh
+#
+# The `+` prefix runs the command as root regardless of User= above.
+# The preflight script's own self-heal section (chown/chmod of .env)
+# requires root, and reading /run/secrets/kairix.env (root:root mode
+# 0640 from kairix-fetch-secrets) requires root or group membership
+# the kairix user does not have on every host. Without `+`, this
+# ExecStartPre runs as User=kairix and fails its sudo-based read
+# check on hosts where /run/secrets/kairix.env is root-only.
+ExecStartPre=+/opt/kairix/bin/permissions-preflight.sh
 
 ExecStart=/usr/bin/docker compose up -d
 ExecStop=/usr/bin/docker compose stop
 
-# Restart only on actual failure (not clean shutdown). Bounded retry —
-# 5 attempts in 5 min then give up so a broken host doesn't loop forever.
+# Restart only on actual failure (not clean shutdown). The
+# StartLimit* keys that bound the retry budget live in [Unit] above.
 Restart=on-failure
 RestartSec=10
-StartLimitIntervalSec=300
-StartLimitBurst=5
 
 # ---------------------------------------------------------------------------
 # Hardening (override per host as needed)
@@ -102,7 +114,12 @@ StartLimitBurst=5
 NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=true
-ReadWritePaths=/opt/kairix /var/lib/kairix /run/secrets
+# `-` prefix marks each path optional so namespace setup does not fail
+# with `Failed to set up mount namespacing: <path>: No such file or
+# directory` (exit 226/NAMESPACE) on a host where one of these paths
+# has not been created yet. /var/lib/kairix in particular is created
+# lazily by some install paths.
+ReadWritePaths=-/opt/kairix -/var/lib/kairix -/run/secrets
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Audit of a deployed `vm-openclaw` host found `kairix.service` in `failed` state for 3 days while the underlying docker containers stayed healthy (serving traffic via `:8080/health`). Four bugs in the shipped unit and install instructions explain the disconnect; each will re-bite any fresh install or any redeploy. This PR fixes all four plus adds a runbook so the diagnose-to-recover path is one read.

## Bugs fixed

### `scripts/install/kairix.service.example`

1. **`StartLimitIntervalSec=300` and `StartLimitBurst=5` are in `[Service]` instead of `[Unit]`.** systemd silently ignores them in `[Service]` and logs `Unknown key name 'StartLimitIntervalSec' in section 'Service', ignoring` on every daemon-reload. The unit has no startup-rate limit — when a downstream check fails it can crash-loop forever instead of giving up after 5 attempts in 5 min. **Fix:** move both keys into `[Unit]`.

2. **`ExecStartPre=` runs as `User=kairix` without the `+` prefix.** The preflight script's self-heal section (`chown` / `chmod` of `.env`) requires root, and reading `/run/secrets/kairix.env` (root:root mode 0640 from `kairix-fetch-secrets`) requires root too. Without `+`, the preflight runs as the kairix user and fails its read check on every host where `/run/secrets` is root-only. The script's own header comment already documents the assumption that it runs *"as root via ExecStartPre="*. **Fix:** prefix with `+`.

3. **`ReadWritePaths=` entries are not optional.** systemd refuses to set up the mount namespace if any target is missing — exit 226/NAMESPACE with `Failed to set up mount namespacing: /var/lib/kairix: No such file or directory`. **Fix:** prefix each path with `-` so a missing dir does not block namespace setup.

### `docs/operations/OPERATIONS.md`

4. **Missing `sudo install -d /var/lib/kairix` step before the unit installs.** The unit declares `ReadWritePaths=` on that path; if the install path never creates it, the unit fails at namespace setup (bug 3 above). The `-` prefix in the unit guards against the worst case; this step closes the loop so operators do not chase a phantom-failure unit after the install. Also tighten the preflight install perms to match its runtime identity.

### `docs/runbooks/kairix-service-failed-containers-healthy.md` (new)

5. New runbook covering the systemd-state-vs-container-state disconnect. Diagnoses by journal headline (226/NAMESPACE, StartLimit warning, preflight FAIL, missing script) and matches each to a fix/next/run recovery. Index row added to `docs/runbooks/README.md`.

## How to reproduce the original failure

On a host where any one of the above bugs applies:

\`\`\`bash
sudo systemctl start kairix.service
sudo systemctl status kairix.service
# Active: failed (Result: exit-code), Process: ExecStartPre=... (code=exited, status=226/NAMESPACE)

curl -fsS http://localhost:8080/health
# {"ok":true,"status":"live"}   ← docker keeps the containers up; systemd state is stale
\`\`\`

The disconnect happens because docker manages container lifecycles itself (`restart: unless-stopped` in the compose file). A `docker compose up -d` from a previous successful run leaves the containers running under dockerd even when the systemd unit that started them is later wedged. `Type=oneshot` semantics mean the unit's state reflects only the `ExecStartPre=` + `ExecStart=` exit codes from the *last* attempt, not the running container fleet.

## Test plan

- [x] `systemd-analyze verify` was not available locally; verified syntactically against the shipped example and via deploy on `vm-openclaw`.
- [x] After applying all four unit-file fixes plus the `/var/lib/kairix` install step and copying the preflight to its runtime path, `systemctl start kairix.service` succeeded with `ExecStartPre status=0/SUCCESS, ExecStart status=0/SUCCESS`, and the unit settled into `active (exited)`.
- [x] `systemctl --failed` returned `0 loaded units listed.`
- [x] No `Unknown key name 'StartLimitIntervalSec'` warnings in `journalctl --since` since the unit was reinstalled.
- [x] `curl -fsS http://localhost:8080/health` returns `{"ok":true,"status":"live"}` consistently.