### PR TITLE
Onboarding tranche 3: OAuth sources, capability tour, demo-debt fixes (#483 #484 #485 #486 #487 #488 #489 #490 #479)

### DIFF
--- a/.github/workflows/fresh-install-smoke.yml
+++ b/.github/workflows/fresh-install-smoke.yml
@@ -1,0 +1,64 @@
+name: "Fresh-install smoke (F81)"
+
+# F81 first cut — proves a stranger's fresh install boots: clean dir →
+# the README's literal docker-compose quick-start path → assertions
+# (healthz/ready, MCP handshake, setup wizard behind its flag, BM25
+# search). CI has no provider secrets, so the embedding/vector legs are
+# excluded in this cut; see the scope note in
+# scripts/checks/check-fresh-install-smoke.sh.
+#
+# NON-required workflow: not a branch-protection check, does not block
+# PR merge. Runs nightly on main, on demand, and on PRs touching the
+# fresh-install surface.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Nightly on main, offset from soak-suite / other nightlies.
+    - cron: "23 16 * * *"
+  pull_request:
+    paths:
+      - 'docker-compose.yml'
+      - 'Dockerfile'
+      - 'docker/**'
+      - 'kairix/platform/setup/**'
+      - 'kairix/install/**'
+      - 'scripts/install/**'
+      - 'scripts/checks/check-fresh-install-smoke.sh'
+      - '.github/workflows/fresh-install-smoke.yml'
+      - '.env.example'
+      - 'kairix.config.example.yaml'
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  fresh-install-smoke:
+    name: "Fresh install smoke"
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      # Same build + gha-cache pattern as ci.yml's "Docker build" job, so
+      # both workflows share layer cache. Tagged under the production
+      # image name because docker-compose.yml interpolates
+      # ghcr.io/three-cubes/kairix:${KAIRIX_IMAGE_TAG}; the tag is local
+      # only (load, never push).
+      - name: Build candidate image
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          load: true
+          tags: ghcr.io/three-cubes/kairix:fresh-smoke
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run fresh-install smoke
+        env:
+          KAIRIX_IMAGE_TAG: fresh-smoke
+        run: bash scripts/checks/check-fresh-install-smoke.sh

--- a/docker/README.md
+++ b/docker/README.md
@@ -39,13 +39,21 @@ and neo4j database via a shared in-memory volume.
 
 ### Secrets fetched
 
-| KV Secret Name                        | Env Var Written                    |
-|---------------------------------------|------------------------------------|
-| `kairix-llm-api-key`                | `KAIRIX_LLM_API_KEY`             |
-| `kairix-llm-endpoint`               | `KAIRIX_LLM_ENDPOINT`            |
-| `kairix-embed-model`   | `KAIRIX_EMBED_MODEL`    |
-| `kairix-llm-model`  | `KAIRIX_LLM_MODEL` |
-| `kairix-neo4j-password`               | `KAIRIX_NEO4J_PASSWORD`            |
+Canonical names follow [`docs/operations/secrets-configuration.md`](../docs/operations/secrets-configuration.md)
+(`kairix-<scope>-<area>-<leaf>`). The sidecar fetches the canonical KV name
+first and falls back to the pre-canonical short name (e.g. `kairix-llm-api-key`)
+so existing vaults keep working. Each value is written under its canonical
+env var plus the legacy alias (removed with #369).
+
+| Canonical KV Secret Name          | Env Vars Written                                        |
+|-----------------------------------|---------------------------------------------------------|
+| `kairix-provider-llm-api-key`     | `KAIRIX_PROVIDER_LLM_API_KEY` + `KAIRIX_LLM_API_KEY`    |
+| `kairix-provider-llm-endpoint`    | `KAIRIX_PROVIDER_LLM_ENDPOINT` + `KAIRIX_LLM_ENDPOINT`  |
+| `kairix-provider-llm-model`       | `KAIRIX_PROVIDER_LLM_MODEL` + `KAIRIX_LLM_MODEL`        |
+| `kairix-provider-embed-api-key`   | `KAIRIX_PROVIDER_EMBED_API_KEY` + `KAIRIX_EMBED_API_KEY` |
+| `kairix-provider-embed-endpoint`  | `KAIRIX_PROVIDER_EMBED_ENDPOINT` + `KAIRIX_EMBED_ENDPOINT` |
+| `kairix-provider-embed-model`     | `KAIRIX_PROVIDER_EMBED_MODEL` + `KAIRIX_EMBED_MODEL`    |
+| `kairix-infra-neo4j-password`     | `KAIRIX_INFRA_NEO4J_PASSWORD` + `KAIRIX_NEO4J_PASSWORD` |
 
 ## Usage
 

--- a/docker/vault-agent/entrypoint.sh
+++ b/docker/vault-agent/entrypoint.sh
@@ -13,14 +13,46 @@ fetch_and_write() {
     tmpfile=$(mktemp "${SECRETS_DIR}/.secrets.XXXXXX")
     chmod 600 "$tmpfile"
     _fetch() { local secret_name="$1"; az keyvault secret show --vault-name "$kv_name_local" --name "$secret_name" --query value -o tsv 2>/dev/null || echo ""; }
+    # Resolve a secret by its canonical KV name (kairix-<scope>-<area>-<leaf>,
+    # see docs/operations/secrets-configuration.md), falling back to the
+    # pre-canonical short name so existing vaults keep working during the
+    # transition window (#479).
+    _fetch_canonical() {
+        local value
+        value=$(_fetch "$1")
+        if [[ -z "$value" ]]; then
+            value=$(_fetch "$2")
+        fi
+        echo "$value"
+    }
+    local llm_api_key llm_endpoint llm_model
+    local embed_api_key embed_endpoint embed_model neo4j_password
+    llm_api_key=$(_fetch_canonical kairix-provider-llm-api-key kairix-llm-api-key)
+    llm_endpoint=$(_fetch_canonical kairix-provider-llm-endpoint kairix-llm-endpoint)
+    llm_model=$(_fetch_canonical kairix-provider-llm-model kairix-llm-model)
+    embed_api_key=$(_fetch_canonical kairix-provider-embed-api-key kairix-embed-api-key)
+    embed_endpoint=$(_fetch_canonical kairix-provider-embed-endpoint kairix-embed-endpoint)
+    embed_model=$(_fetch_canonical kairix-provider-embed-model kairix-embed-model)
+    neo4j_password=$(_fetch_canonical kairix-infra-neo4j-password kairix-neo4j-password)
     {
-        echo "KAIRIX_LLM_API_KEY=$(_fetch kairix-llm-api-key)"
-        echo "KAIRIX_LLM_ENDPOINT=$(_fetch kairix-llm-endpoint)"
-        echo "KAIRIX_LLM_MODEL=$(_fetch kairix-llm-model)"
-        echo "KAIRIX_EMBED_API_KEY=$(_fetch kairix-embed-api-key)"
-        echo "KAIRIX_EMBED_ENDPOINT=$(_fetch kairix-embed-endpoint)"
-        echo "KAIRIX_EMBED_MODEL=$(_fetch kairix-embed-model)"
-        echo "KAIRIX_NEO4J_PASSWORD=$(_fetch kairix-neo4j-password)"
+        # Canonical env-var names (docs/operations/secrets-configuration.md).
+        echo "KAIRIX_PROVIDER_LLM_API_KEY=${llm_api_key}"
+        echo "KAIRIX_PROVIDER_LLM_ENDPOINT=${llm_endpoint}"
+        echo "KAIRIX_PROVIDER_LLM_MODEL=${llm_model}"
+        echo "KAIRIX_PROVIDER_EMBED_API_KEY=${embed_api_key}"
+        echo "KAIRIX_PROVIDER_EMBED_ENDPOINT=${embed_endpoint}"
+        echo "KAIRIX_PROVIDER_EMBED_MODEL=${embed_model}"
+        echo "KAIRIX_INFRA_NEO4J_PASSWORD=${neo4j_password}"
+        # legacy aliases — remove with #369. KAIRIX_NEO4J_PASSWORD is NOT
+        # only an alias yet: the graph layer (kairix.secrets.neo4j_password)
+        # and docker-compose interpolation still read it today.
+        echo "KAIRIX_LLM_API_KEY=${llm_api_key}"
+        echo "KAIRIX_LLM_ENDPOINT=${llm_endpoint}"
+        echo "KAIRIX_LLM_MODEL=${llm_model}"
+        echo "KAIRIX_EMBED_API_KEY=${embed_api_key}"
+        echo "KAIRIX_EMBED_ENDPOINT=${embed_endpoint}"
+        echo "KAIRIX_EMBED_MODEL=${embed_model}"
+        echo "KAIRIX_NEO4J_PASSWORD=${neo4j_password}"
     } >> "$tmpfile"
     mv -f "$tmpfile" "${SECRETS_DIR}/kairix.env"
     chmod 600 "${SECRETS_DIR}/kairix.env"

--- a/docker/vault-agent/fetch_secrets.py
+++ b/docker/vault-agent/fetch_secrets.py
@@ -18,20 +18,29 @@ Optional:
   SECRETS_DIR              Where to write the secrets file (default: /run/secrets)
   REFRESH_INTERVAL_SECONDS How often to re-fetch from KV (default: 3600)
 
-Secrets fetched (KV secret name → env var written to file):
-  kairix-llm-api-key      → KAIRIX_LLM_API_KEY
-  kairix-llm-endpoint     → KAIRIX_LLM_ENDPOINT
-  kairix-llm-model        → KAIRIX_LLM_MODEL
-  kairix-embed-api-key    → KAIRIX_EMBED_API_KEY
-  kairix-embed-endpoint   → KAIRIX_EMBED_ENDPOINT
-  kairix-embed-model      → KAIRIX_EMBED_MODEL
-  kairix-neo4j-password   → KAIRIX_NEO4J_PASSWORD
+Secrets fetched (canonical KV secret name → env vars written to file):
+  kairix-provider-llm-api-key     → KAIRIX_PROVIDER_LLM_API_KEY     (+ KAIRIX_LLM_API_KEY)
+  kairix-provider-llm-endpoint    → KAIRIX_PROVIDER_LLM_ENDPOINT    (+ KAIRIX_LLM_ENDPOINT)
+  kairix-provider-llm-model       → KAIRIX_PROVIDER_LLM_MODEL       (+ KAIRIX_LLM_MODEL)
+  kairix-provider-embed-api-key   → KAIRIX_PROVIDER_EMBED_API_KEY   (+ KAIRIX_EMBED_API_KEY)
+  kairix-provider-embed-endpoint  → KAIRIX_PROVIDER_EMBED_ENDPOINT  (+ KAIRIX_EMBED_ENDPOINT)
+  kairix-provider-embed-model     → KAIRIX_PROVIDER_EMBED_MODEL     (+ KAIRIX_EMBED_MODEL)
+  kairix-infra-neo4j-password     → KAIRIX_INFRA_NEO4J_PASSWORD     (+ KAIRIX_NEO4J_PASSWORD)
+
+Canonical names follow docs/operations/secrets-configuration.md
+(kairix-<scope>-<area>[-<instance>]-<leaf>). Vaults created before the
+canonical schema may still hold the pre-canonical short names
+(kairix-llm-api-key etc.); each spec lists those as ``kv_fallbacks`` so
+existing vaults keep working during the transition window (#479). The
+parenthesised env vars are legacy aliases — remove with #369.
 """
 
 import logging
 import os
 import sys
 import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
 from pathlib import Path
 
 logging.basicConfig(
@@ -47,16 +56,87 @@ READY_FILE = SECRETS_DIR / ".ready"
 KV_NAME = os.environ.get("KAIRIX_KV_NAME", "")
 REFRESH_INTERVAL = int(os.environ.get("REFRESH_INTERVAL_SECONDS", "3600"))
 
-# Azure Key Vault secret name → env var name
-SECRET_MAP: dict[str, str] = {
-    "kairix-llm-api-key": "KAIRIX_LLM_API_KEY",
-    "kairix-llm-endpoint": "KAIRIX_LLM_ENDPOINT",
-    "kairix-llm-model": "KAIRIX_LLM_MODEL",
-    "kairix-embed-api-key": "KAIRIX_EMBED_API_KEY",
-    "kairix-embed-endpoint": "KAIRIX_EMBED_ENDPOINT",
-    "kairix-embed-model": "KAIRIX_EMBED_MODEL",
-    "kairix-neo4j-password": "KAIRIX_NEO4J_PASSWORD",  # pragma: allowlist secret
-}
+
+@dataclass(frozen=True)
+class SecretSpec:
+    """One secret to fetch: canonical KV name, env vars to emit, KV fallbacks.
+
+    ``kv_name`` is the canonical Key Vault secret name (fetched first).
+    ``env_vars`` lists every env var the resolved value is written under —
+    canonical name first, then the legacy aliases kept for the transition
+    window (remove with #369). ``kv_fallbacks`` lists pre-canonical KV
+    names tried in order when the canonical name is absent, so existing
+    vaults keep working (#479).
+    """
+
+    kv_name: str
+    env_vars: tuple[str, ...]
+    kv_fallbacks: tuple[str, ...] = field(default=())
+
+
+SECRET_SPECS: tuple[SecretSpec, ...] = (
+    SecretSpec(
+        "kairix-provider-llm-api-key",
+        ("KAIRIX_PROVIDER_LLM_API_KEY", "KAIRIX_LLM_API_KEY"),
+        ("kairix-llm-api-key",),
+    ),
+    SecretSpec(
+        "kairix-provider-llm-endpoint",
+        ("KAIRIX_PROVIDER_LLM_ENDPOINT", "KAIRIX_LLM_ENDPOINT"),
+        ("kairix-llm-endpoint",),
+    ),
+    SecretSpec(
+        "kairix-provider-llm-model",
+        ("KAIRIX_PROVIDER_LLM_MODEL", "KAIRIX_LLM_MODEL"),
+        ("kairix-llm-model",),
+    ),
+    SecretSpec(
+        "kairix-provider-embed-api-key",
+        ("KAIRIX_PROVIDER_EMBED_API_KEY", "KAIRIX_EMBED_API_KEY"),
+        ("kairix-embed-api-key",),
+    ),
+    SecretSpec(
+        "kairix-provider-embed-endpoint",
+        ("KAIRIX_PROVIDER_EMBED_ENDPOINT", "KAIRIX_EMBED_ENDPOINT"),
+        ("kairix-embed-endpoint",),
+    ),
+    SecretSpec(
+        "kairix-provider-embed-model",
+        ("KAIRIX_PROVIDER_EMBED_MODEL", "KAIRIX_EMBED_MODEL"),
+        ("kairix-embed-model",),
+    ),
+    SecretSpec(
+        # KAIRIX_NEO4J_PASSWORD is NOT only an alias yet: the graph layer
+        # (kairix.secrets.neo4j_password) and docker-compose interpolation
+        # still read it today. Keep emitting it until #369 retires it.
+        "kairix-infra-neo4j-password",  # pragma: allowlist secret — secret NAME, not a value
+        ("KAIRIX_INFRA_NEO4J_PASSWORD", "KAIRIX_NEO4J_PASSWORD"),  # pragma: allowlist secret
+        ("kairix-neo4j-password",),  # pragma: allowlist secret — secret NAME, not a value
+    ),
+)
+
+
+def resolve_secret_env(fetch: Callable[[str], str | None]) -> dict[str, str]:
+    """Resolve every spec through ``fetch`` and fan values out to env vars.
+
+    For each :class:`SecretSpec`, the canonical KV name is tried first,
+    then each legacy fallback in order. A resolved value is emitted under
+    every env var the spec declares (canonical + legacy aliases). Specs
+    that resolve nowhere are skipped — same missing-secret semantics as
+    before.
+    """
+    fetched: dict[str, str] = {}
+    for spec in SECRET_SPECS:
+        value = fetch(spec.kv_name)
+        if value is None:
+            for legacy_name in spec.kv_fallbacks:
+                value = fetch(legacy_name)
+                if value is not None:
+                    break
+        if value is not None:
+            for env_var in spec.env_vars:
+                fetched[env_var] = value
+    return fetched
 
 
 def fetch_from_keyvault() -> dict[str, str]:
@@ -75,13 +155,13 @@ def fetch_from_keyvault() -> dict[str, str]:
     credential = DefaultAzureCredential()
     client = SecretClient(vault_url=kv_uri, credential=credential)
 
-    fetched: dict[str, str] = {}
-    for secret_name, env_var in SECRET_MAP.items():
-        resolved = _fetch_single_secret(client, secret_name)
-        if resolved is not None:
-            fetched[env_var] = resolved
+    fetched = resolve_secret_env(lambda name: _fetch_single_secret(client, name))
 
-    logger.info("Resolved %d of %d secrets from Key Vault", len(fetched), len(SECRET_MAP))
+    logger.info(
+        "Resolved %d env var(s) across %d secret spec(s) from Key Vault",
+        len(fetched),
+        len(SECRET_SPECS),
+    )
     return fetched
 
 

--- a/scripts/checks/check-fresh-install-smoke.sh
+++ b/scripts/checks/check-fresh-install-smoke.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# F81 — fresh-install smoke: prove a stranger's fresh install boots.
+#
+# Replays the README / docker-compose.yml quick start from a clean temp
+# directory: copy the shipped compose file, seed .env from .env.example,
+# copy the example config, drop a tiny sample document, `docker compose
+# up -d`, then assert the install actually works:
+#
+#   stage 1  container-healthy   /healthz/ready returns 200 (bounded wait)
+#   stage 2  mcp-handshake       POST initialize + tools/list to /mcp
+#                                returns more than zero tools
+#   stage 3  setup-wizard        with KAIRIX_FEATURE_SETUP_WIZARD_WEB=1,
+#                                GET /setup/ returns 200 (in-container
+#                                loopback curl — the wizard's operator-token
+#                                guard intentionally skips loopback peers)
+#   stage 4  bm25-search         `kairix embed` ingests the sample doc into
+#                                the BM25 index, `kairix search` finds it
+#
+# SCOPE (first cut): CI has no provider secrets, so the embedding /
+# vector legs are EXCLUDED. The .env keeps .env.example's placeholder
+# provider values; `kairix embed` ingests documents + builds the FTS
+# index BEFORE the embed leg fails, and `kairix search` degrades to
+# BM25-only. A follow-up cut adds the vector leg behind a CI secret.
+#
+# Parameters (env):
+#   KAIRIX_IMAGE_TAG   image tag for ghcr.io/three-cubes/kairix (default:
+#                      main). CI builds the candidate image locally and
+#                      tags it ghcr.io/three-cubes/kairix:fresh-smoke.
+#   KAIRIX_HOST_PORT   host port for the kairix container (default: 8080).
+#
+# Usage:
+#   KAIRIX_IMAGE_TAG=fresh-smoke bash scripts/checks/check-fresh-install-smoke.sh
+#
+# Cleanup (compose down -v + temp-dir removal) always runs via the EXIT
+# trap, pass or fail.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+IMAGE_TAG="${KAIRIX_IMAGE_TAG:-main}"
+HOST_PORT="${KAIRIX_HOST_PORT:-8080}"
+BASE_URL="http://127.0.0.1:${HOST_PORT}"
+PROBE_TERM="quokka-lighthouse-cadence"
+SAMPLE_DOC="fresh-install-sample.md"
+HEALTHY_WAIT_SECONDS=420
+COMPOSE_PROJECT="kairix-fresh-smoke"
+
+WORKDIR=""
+COMPOSE_STARTED=0
+
+compose() {
+    docker compose --project-name "$COMPOSE_PROJECT" "$@"
+}
+
+cleanup() {
+    local rc=$?
+    if [[ "$COMPOSE_STARTED" == "1" && -n "$WORKDIR" ]]; then
+        (cd "$WORKDIR" && compose down -v --remove-orphans) || true
+    fi
+    if [[ -n "$WORKDIR" ]]; then
+        rm -rf "$WORKDIR" || true
+    fi
+    exit "$rc"
+}
+trap cleanup EXIT
+
+# Bounded execution — `timeout` ships on the Linux CI runners; fall back
+# to unbounded on hosts without it (macOS without coreutils).
+run_bounded() {
+    local secs="$1"
+    shift
+    if command -v timeout >/dev/null 2>&1; then
+        timeout "$secs" "$@"
+    else
+        "$@"
+    fi
+}
+
+# F21-shaped stage failure: named stage, fix:/next: markers, container
+# diagnostics, non-zero exit (cleanup still runs via the EXIT trap).
+fail_stage() {
+    local stage="$1" fix_msg="$2" next_msg="$3"
+    echo "FAIL [fresh-install-smoke:${stage}]"
+    echo "fix: ${fix_msg}"
+    echo "next: ${next_msg}"
+    if [[ "$COMPOSE_STARTED" == "1" && -n "$WORKDIR" ]]; then
+        (
+            cd "$WORKDIR" || exit 0
+            echo "----- docker compose ps -----"
+            compose ps || true
+            echo "----- kairix logs (last 100 lines) -----"
+            compose logs --tail 100 kairix || true
+            echo "----- neo4j logs (last 30 lines) -----"
+            compose logs --tail 30 neo4j || true
+        )
+    fi
+    exit 1
+}
+
+echo "=== F81 fresh-install smoke (image tag: ${IMAGE_TAG}, port: ${HOST_PORT}) ==="
+
+# ── stage 0: preflight ───────────────────────────────────────────────────────
+for tool in docker curl python3; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        fail_stage "preflight" \
+            "install ${tool} — the smoke drives the shipped docker-compose stack with it." \
+            "re-run: KAIRIX_IMAGE_TAG=${IMAGE_TAG} bash scripts/checks/check-fresh-install-smoke.sh"
+    fi
+done
+if ! docker compose version >/dev/null 2>&1; then
+    fail_stage "preflight" \
+        "install the docker compose v2 plugin (docker compose version must succeed)." \
+        "re-run: KAIRIX_IMAGE_TAG=${IMAGE_TAG} bash scripts/checks/check-fresh-install-smoke.sh"
+fi
+
+# ── stage 0b: assemble the stranger's fresh directory ────────────────────────
+WORKDIR="$(mktemp -d)"
+echo "workdir: ${WORKDIR}"
+cp "${REPO_ROOT}/docker-compose.yml" "${WORKDIR}/docker-compose.yml"
+cp "${REPO_ROOT}/.env.example" "${WORKDIR}/.env"
+cp "${REPO_ROOT}/kairix.config.example.yaml" "${WORKDIR}/kairix.config.yaml"
+{
+    echo ""
+    echo "# fresh-install smoke overrides"
+    echo "KAIRIX_IMAGE_TAG=${IMAGE_TAG}"
+    echo "KAIRIX_HOST_PORT=${HOST_PORT}"
+    echo "KAIRIX_FEATURE_SETUP_WIZARD_WEB=1"
+} >> "${WORKDIR}/.env"
+mkdir -p "${WORKDIR}/documents/04-Agent-Knowledge"
+cat > "${WORKDIR}/documents/${SAMPLE_DOC}" <<EOF
+# Fresh install sample
+
+This sample document proves the BM25 search leg on a fresh install.
+Unique probe term: ${PROBE_TERM}.
+EOF
+
+# ── stage 0c: up ─────────────────────────────────────────────────────────────
+cd "$WORKDIR"
+COMPOSE_STARTED=1
+if ! compose up -d --quiet-pull; then
+    fail_stage "compose-up" \
+        "read the compose error above — the shipped docker-compose.yml failed to start from a clean directory with only .env.example defaults." \
+        "reproduce locally: copy docker-compose.yml + .env.example into an empty dir and run docker compose up -d"
+fi
+
+# ── stage 1: container reaches healthy ───────────────────────────────────────
+echo -n "stage 1 container-healthy: waiting for ${BASE_URL}/healthz/ready "
+deadline=$((SECONDS + HEALTHY_WAIT_SECONDS))
+ready=0
+while [[ $SECONDS -lt $deadline ]]; do
+    code=$(curl -s -o /dev/null -w '%{http_code}' "${BASE_URL}/healthz/ready" || true)
+    if [[ "$code" == "200" ]]; then
+        ready=1
+        break
+    fi
+    echo -n "."
+    sleep 5
+done
+echo ""
+if [[ "$ready" != "1" ]]; then
+    fail_stage "container-healthy" \
+        "the kairix container never served /healthz/ready=200 within ${HEALTHY_WAIT_SECONDS}s — read the kairix logs below for the boot failure (s6 init, first-boot kairix init, or the api process)." \
+        "reproduce: docker compose up -d, then curl -v ${BASE_URL}/healthz/ready"
+fi
+echo "stage 1 container-healthy: OK"
+
+# ── stage 2: MCP handshake ───────────────────────────────────────────────────
+mcp_post() {
+    curl -fsS -L -X POST "${BASE_URL}/mcp" \
+        -H 'Content-Type: application/json' \
+        -H 'Accept: application/json, text/event-stream' \
+        -d "$1"
+}
+# Tolerates both plain-JSON and SSE-framed (data: {...}) responses.
+extract_tool_count() {
+    python3 -c '
+import json
+import sys
+
+raw = sys.stdin.read().strip()
+if "data:" in raw:
+    for line in raw.splitlines():
+        if line.startswith("data:"):
+            raw = line[len("data:"):].strip()
+            break
+obj = json.loads(raw)
+print(len(obj["result"]["tools"]))
+'
+}
+
+INIT_BODY='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"fresh-install-smoke","version":"0.0.0"}}}'
+INIT_RESP=$(mcp_post "$INIT_BODY" || true)
+if ! echo "$INIT_RESP" | grep -q '"serverInfo"'; then
+    echo "initialize response: ${INIT_RESP}"
+    fail_stage "mcp-handshake" \
+        "POST /mcp initialize did not return a serverInfo result — the MCP transport is not serving on the published port." \
+        "reproduce: curl -X POST ${BASE_URL}/mcp -H 'Content-Type: application/json' -d '${INIT_BODY}'"
+fi
+
+LIST_BODY='{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+LIST_RESP=$(mcp_post "$LIST_BODY" || true)
+TOOL_COUNT=$(echo "$LIST_RESP" | extract_tool_count 2>/dev/null || echo "0")
+if [[ "$TOOL_COUNT" -lt 1 ]]; then
+    echo "tools/list response: ${LIST_RESP}"
+    fail_stage "mcp-handshake" \
+        "tools/list returned ${TOOL_COUNT} tools — an agent connecting to this fresh install would see no kairix capabilities." \
+        "reproduce: curl -X POST ${BASE_URL}/mcp -H 'Content-Type: application/json' -d '${LIST_BODY}'"
+fi
+echo "stage 2 mcp-handshake: OK (${TOOL_COUNT} tools)"
+
+# ── stage 3: setup wizard answers with the flag ON ───────────────────────────
+# In-container loopback curl: the wizard's operator-token guard skips
+# loopback peers by design (host-side requests arrive from the docker
+# bridge gateway and would need the kairix-infra-operator-token secret).
+WIZARD_CODE=$(compose exec -T kairix curl -s -o /dev/null -w '%{http_code}' \
+    "http://127.0.0.1:8080/setup/" || true)
+if [[ "$WIZARD_CODE" != "200" ]]; then
+    fail_stage "setup-wizard" \
+        "GET /setup/ returned ${WIZARD_CODE} (expected 200) with KAIRIX_FEATURE_SETUP_WIZARD_WEB=1 — the in-box wizard is not reachable on a fresh install." \
+        "reproduce: docker compose exec kairix curl -v http://127.0.0.1:8080/setup/"
+fi
+echo "stage 3 setup-wizard: OK (200)"
+
+# ── stage 4: BM25 search path ────────────────────────────────────────────────
+# `kairix embed` scans the document root and (re)builds the FTS index
+# BEFORE the embedding leg runs; with .env.example's placeholder provider
+# credentials the embed leg fails, which is expected here (no provider
+# secrets in CI) — the `|| true` scopes this cut to the BM25 leg.
+echo "stage 4 bm25-search: ingesting (embed leg expected to fail without provider key)"
+run_bounded 600 compose exec -T kairix kairix embed >/dev/null 2>&1 || true
+
+SEARCH_OUT=$(run_bounded 300 compose exec -T kairix \
+    kairix search "$PROBE_TERM" --no-entity-card 2>&1 || true)
+if ! echo "$SEARCH_OUT" | grep -q "$SAMPLE_DOC"; then
+    echo "search output:"
+    echo "$SEARCH_OUT" | tail -30
+    fail_stage "bm25-search" \
+        "kairix search '${PROBE_TERM}' did not return ${SAMPLE_DOC} — the fresh install cannot retrieve a document it just ingested over the BM25 leg." \
+        "reproduce: docker compose exec kairix kairix embed; docker compose exec kairix kairix search '${PROBE_TERM}'"
+fi
+echo "stage 4 bm25-search: OK (${SAMPLE_DOC} found)"
+
+echo "=== F81 fresh-install smoke: ALL STAGES PASSED ==="

--- a/scripts/checks/run-all.sh
+++ b/scripts/checks/run-all.sh
@@ -13,7 +13,7 @@ set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-cd "$REPO_ROOT"
+cd "$REPO_ROOT" || exit 1
 
 skip_coverage=0
 for arg in "$@"; do
@@ -264,12 +264,16 @@ python3 "${SCRIPT_DIR}/check_go_no_panic_outside_main.py" || overall=1
 # G8 — logging via log/slog only (no fmt.Print* / log.Print* in prod)
 python3 "${SCRIPT_DIR}/check_go_logging_discipline.py" || overall=1
 
-# F7 — needs coverage.xml. Skip if not present or skip flag set.
+# F7 — needs a coverage XML report. Callers running per-invocation
+# coverage artifacts (safe-commit.sh, #483) pass the path via
+# KAIRIX_COVERAGE_XML; standalone runs default to coverage.xml in the
+# repo root. Skip if not present or skip flag set.
 if [[ "$skip_coverage" -eq 0 ]]; then
-    if [[ -f "${REPO_ROOT}/coverage.xml" ]]; then
-        python3 "${SCRIPT_DIR}/check_per_file_coverage.py" "${REPO_ROOT}/coverage.xml" || overall=1
+    coverage_xml="${KAIRIX_COVERAGE_XML:-${REPO_ROOT}/coverage.xml}"
+    if [[ -f "$coverage_xml" ]]; then
+        python3 "${SCRIPT_DIR}/check_per_file_coverage.py" "$coverage_xml" || overall=1
     else
-        printf '\033[0;33mskip [arch:per-file-coverage-floor]\033[0m — coverage.xml not found.\n'
+        printf '\033[0;33mskip [arch:per-file-coverage-floor]\033[0m — coverage report not found at %s.\n' "$coverage_xml"
         printf '   Run: pytest --cov=kairix --cov-report=xml first, then re-run this check.\n'
     fi
 fi

--- a/scripts/safe-commit.sh
+++ b/scripts/safe-commit.sh
@@ -8,7 +8,8 @@
 #   1. ruff lint (includes isort import ordering via I rules)
 #   2. ruff format (black-compatible formatting)
 #   3. mypy --strict type checking
-#   4. pytest (unit + bdd + contract) with coverage.xml generation
+#   4. pytest (unit + bdd + contract) with per-invocation coverage XML
+#      generation (coverage.safe-commit.<pid>.xml, removed on exit)
 #   5. architecture fitness functions (F1-F30, including F7 per-file coverage
 #      floor — mirrors CI's Stage 2 invocation exactly so the historical
 #      safe-commit ↔ CI parity gap on F7 is closed)
@@ -48,6 +49,45 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m'
 
+# ── #483 guard: command substitution under `set -e` ──────────────────────────
+# `VAR=$(cmd)` kills the whole script AT THE ASSIGNMENT when cmd exits
+# non-zero — no FAIL line, no captured output; the log just ends at the
+# stage's "..." prefix. Every gate that captures output into a variable
+# MUST run through run_gate so the exit code lands in GATE_RC for
+# explicit handling instead of tripping `set -e`.
+GATE_OUT=""
+GATE_RC=0
+run_gate() {
+    GATE_RC=0
+    GATE_OUT=$("$@" 2>&1) || GATE_RC=$?
+}
+
+# Named-stage death report. Prints the tail of the captured output, a
+# FAIL line carrying the stage name + exit code, and fix:/next: action
+# markers, then exits non-zero. Used when a gate exits non-zero WITHOUT
+# producing the failure shape its stage handler knows how to summarise
+# (crash, collection error, coverage floor, concurrent-run collision).
+gate_died() {
+    local stage="$1" rc="$2" rerun="$3"
+    echo -e "${RED}FAIL${NC} (${stage} stage died, rc=${rc})"
+    echo "----- last 50 lines of ${stage} output -----"
+    echo "$GATE_OUT" | tail -50
+    echo "----- end ${stage} output -----"
+    echo "fix: read the ${stage} tail above — the stage exited before producing a verdict (crash, collection error, coverage floor, or a concurrent safe-commit run colliding on shared artifacts)."
+    echo "next: re-run the stage standalone: ${rerun}"
+    exit "$rc"
+}
+
+# ── #483 concurrency hardening: per-invocation coverage artifacts ────────────
+# Two concurrent safe-commit runs used to collide on coverage.xml and the
+# .coverage data file, killing pytest mid-write with no visible error.
+# Each invocation now writes its own pair and removes them on exit;
+# run-all.sh receives the per-invocation XML path via KAIRIX_COVERAGE_XML.
+COVERAGE_XML="coverage.safe-commit.$$.xml"
+COVERAGE_DATA=".coverage.safe-commit.$$"
+cleanup_coverage_artifacts() { rm -f "$COVERAGE_XML" "$COVERAGE_DATA"; }
+trap cleanup_coverage_artifacts EXIT
+
 # 0. Empty-stage guard. safe-commit.sh does not auto-stage; running it
 # without `git add` produced silent no-op "commits" that masked real
 # failures (#208 side-finding). Fail loud here instead.
@@ -84,10 +124,11 @@ if command -v gofmt >/dev/null 2>&1; then
     while IFS= read -r gomod; do
         svc_dir="$(dirname "$gomod")"
         echo -n "  gofmt -s ($svc_dir)... "
-        unformatted=$(gofmt -s -l "$svc_dir" 2>&1)
-        if [[ -n "$unformatted" ]]; then
+        run_gate gofmt -s -l "$svc_dir"
+        unformatted="$GATE_OUT"
+        if [[ -n "$unformatted" || "$GATE_RC" -ne 0 ]]; then
             echo -e "${RED}FAIL${NC}"
-            echo "$unformatted" | sed 's/^/  /'
+            echo "  ${unformatted//$'\n'/$'\n'  }"
             echo "Run: gofmt -s -w $svc_dir"
             exit 1
         fi
@@ -102,12 +143,18 @@ echo -n "  mypy strict... "
 # Without `uv run`, system mypy can't see types for kairix.connectors.obsidian
 # (FileSystemEventHandler) or kairix.extractors.markitdown (MarkItDown) and
 # fires false-positive `[misc]` / `[no-any-return]` errors. CI uses uv run mypy.
-MYPY_OUT=$(uv run mypy kairix/ --strict 2>&1)
+run_gate uv run mypy kairix/ --strict
+MYPY_OUT="$GATE_OUT"
 if echo "$MYPY_OUT" | grep -q "error"; then
     echo -e "${RED}FAIL${NC}"
     echo "$MYPY_OUT" | grep "error" | head -10
     echo "Run: uv run mypy kairix/ --strict"
     exit 1
+fi
+if [[ "$GATE_RC" -ne 0 ]]; then
+    # Non-zero without an "error" line: mypy itself crashed (bad config,
+    # missing venv, usage error) — previously a silent set -e death.
+    gate_died "mypy" "$GATE_RC" "uv run mypy kairix/ --strict"
 fi
 echo -e "${GREEN}OK${NC}"
 
@@ -116,8 +163,9 @@ echo -e "${GREEN}OK${NC}"
 # Invocation mirrors CI's Stage 2 exactly (.github/workflows/ci.yml: "Unit +
 # BDD + Contract tests with coverage") so the safe-commit ↔ CI parity gap
 # that historically hid F7 failures from agents (KAIRIX_TRACE memory:
-# feedback_ci_parity_checklist) is closed. The coverage.xml emitted here
-# is consumed by run-all.sh's F7 check below.
+# feedback_ci_parity_checklist) is closed. The per-invocation coverage XML
+# emitted here is consumed by run-all.sh's F7 check below (#483: a shared
+# coverage.xml made concurrent safe-commit runs corrupt each other).
 #
 # To temporarily skip the per-file coverage floor during a focused refactor
 # (e.g. between commits in a coverage-lift series), set KAIRIX_SKIP_COVERAGE=1.
@@ -132,6 +180,7 @@ if [[ "$FAST_MODE" == "1" ]]; then
     if [[ -z "$STAGED_KAIRIX" ]]; then
         echo -e "${GREEN}OK${NC} (no staged kairix/*.py — skipping product tests)"
         TEST_OUT="--fast: no kairix source touched, no tests to run"
+        TEST_RC=0
         COVERAGE_SKIPPED=1
     else
         # Map kairix/foo/bar.py → kairix.foo.bar for import-grep
@@ -147,29 +196,47 @@ if [[ "$FAST_MODE" == "1" ]]; then
         if [[ -z "$UNIQ_TESTS" ]]; then
             echo -e "${GREEN}OK${NC} (no tests import the staged modules)"
             TEST_OUT="--fast: no tests import the staged modules"
+            TEST_RC=0
             COVERAGE_SKIPPED=1
         else
-            COUNT=$(echo "$UNIQ_TESTS" | wc -l | tr -d ' ')
-            # shellcheck disable=SC2086 # word-split intentional for pytest argv
-            TEST_OUT=$(uv run python -m pytest $UNIQ_TESTS -x --timeout=30 \
-                -m "unit or bdd or contract" --no-cov 2>&1)
+            mapfile -t TEST_FILE_ARGS <<< "$UNIQ_TESTS"
+            run_gate uv run python -m pytest "${TEST_FILE_ARGS[@]}" -x --timeout=30 \
+                -m "unit or bdd or contract" --no-cov
+            TEST_OUT="$GATE_OUT"
+            TEST_RC="$GATE_RC"
             COVERAGE_SKIPPED=1
         fi
     fi
 elif [[ "${KAIRIX_SKIP_COVERAGE:-0}" == "1" ]]; then
-    TEST_OUT=$(uv run python -m pytest tests/ -x --timeout=30 -m "unit or bdd or contract" 2>&1)
+    run_gate uv run python -m pytest tests/ -x --timeout=30 -m "unit or bdd or contract"
+    TEST_OUT="$GATE_OUT"
+    TEST_RC="$GATE_RC"
     COVERAGE_SKIPPED=1
 else
-    TEST_OUT=$(uv run python -m pytest tests/ -x --timeout=30 \
+    # COVERAGE_FILE points the .coverage data file at the per-invocation
+    # path so concurrent safe-commit runs never collide (#483).
+    run_gate env COVERAGE_FILE="$COVERAGE_DATA" \
+        uv run python -m pytest tests/ -x --timeout=30 \
         -m "unit or bdd or contract" \
-        --cov=kairix --cov-report=xml:coverage.xml \
-        --cov-fail-under=80 2>&1)
+        --cov=kairix "--cov-report=xml:${COVERAGE_XML}" \
+        --cov-fail-under=80
+    TEST_OUT="$GATE_OUT"
+    TEST_RC="$GATE_RC"
     COVERAGE_SKIPPED=0
 fi
 if echo "$TEST_OUT" | grep -qE "[0-9]+ failed"; then
     echo -e "${RED}FAIL${NC}"
     echo "$TEST_OUT" | grep -E "FAILED|passed|failed" | tail -10
+    echo "fix: the failing tests are listed above."
+    echo "next: re-run standalone: uv run python -m pytest tests/ -m 'unit or bdd or contract'"
     exit 1
+fi
+if [[ "${TEST_RC:-0}" -ne 0 ]]; then
+    # Non-zero without a "N failed" summary: pytest died before producing
+    # a verdict (collection error, INTERNALERROR, coverage floor breach,
+    # concurrent-run artifact collision) — previously a silent set -e
+    # death with the log ending at "tests + coverage...".
+    gate_died "tests + coverage" "$TEST_RC" "uv run python -m pytest tests/ -m 'unit or bdd or contract'"
 fi
 # --fast may legitimately collect 0 tests (no kairix/*.py touched, or no
 # tests import the staged modules); skip the no-tests-collected check then.
@@ -199,9 +266,11 @@ if [[ "$FAST_MODE" == "1" ]]; then
 fi
 
 # 5. Architecture fitness functions (F1-F30)
-# F7 (per-file coverage floor) runs against the coverage.xml produced in step 4,
-# closing the historical safe-commit ↔ CI parity gap. Falls back to skip-mode
-# when KAIRIX_SKIP_COVERAGE=1 was set in step 4.
+# F7 (per-file coverage floor) runs against the per-invocation coverage XML
+# produced in step 4 (passed via KAIRIX_COVERAGE_XML so concurrent
+# safe-commit runs never collide on a shared coverage.xml — #483), closing
+# the historical safe-commit ↔ CI parity gap. Falls back to skip-mode when
+# KAIRIX_SKIP_COVERAGE=1 was set in step 4.
 echo -n "  arch fitness... "
 if [[ "${COVERAGE_SKIPPED:-0}" == "1" ]]; then
     ARCH_OUT=$(bash scripts/checks/run-all.sh --skip-coverage 2>&1) || {
@@ -211,7 +280,7 @@ if [[ "${COVERAGE_SKIPPED:-0}" == "1" ]]; then
         exit 1
     }
 else
-    ARCH_OUT=$(bash scripts/checks/run-all.sh 2>&1) || {
+    ARCH_OUT=$(KAIRIX_COVERAGE_XML="$COVERAGE_XML" bash scripts/checks/run-all.sh 2>&1) || {
         echo -e "${RED}FAIL${NC}"
         echo "$ARCH_OUT" | tail -30
         echo "See docs/architecture/fitness-functions.md for remediation."

--- a/tests/unit/test_vault_agent_secret_names.py
+++ b/tests/unit/test_vault_agent_secret_names.py
@@ -1,0 +1,138 @@
+"""Vault-agent sidecar secret-name mapping (#479).
+
+The sidecar at ``docker/vault-agent/fetch_secrets.py`` must emit the
+canonical env-var names from ``docs/operations/secrets-configuration.md``
+(``KAIRIX_PROVIDER_LLM_API_KEY`` etc.) AND keep the legacy aliases
+(``KAIRIX_LLM_API_KEY`` etc.) during the transition window, resolving
+canonical KV secret names (``kairix-provider-*`` / ``kairix-infra-*``)
+first with fallback to the pre-canonical short names so existing vaults
+keep working.
+
+The module is loaded by file path — it is a Docker sidecar script, not
+part of the kairix package (same mechanism as
+``tests/plugins/test_kairix_memory_prompt.py``). Resolution is driven
+through the pure ``resolve_secret_env`` seam with a dict-backed fake
+fetch callable — no Azure SDK, no monkeypatching.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_MODULE_PATH = Path(__file__).resolve().parents[2] / "docker" / "vault-agent" / "fetch_secrets.py"
+
+_CANONICAL_ENV_VARS = (
+    "KAIRIX_PROVIDER_LLM_API_KEY",
+    "KAIRIX_PROVIDER_LLM_ENDPOINT",
+    "KAIRIX_PROVIDER_LLM_MODEL",
+    "KAIRIX_PROVIDER_EMBED_API_KEY",
+    "KAIRIX_PROVIDER_EMBED_ENDPOINT",
+    "KAIRIX_PROVIDER_EMBED_MODEL",
+    "KAIRIX_INFRA_NEO4J_PASSWORD",  # pragma: allowlist secret — env-var NAME, not a value
+)
+
+# Legacy aliases kept for the transition window — remove with #369.
+_LEGACY_ENV_VARS = (
+    "KAIRIX_LLM_API_KEY",
+    "KAIRIX_LLM_ENDPOINT",
+    "KAIRIX_LLM_MODEL",
+    "KAIRIX_EMBED_API_KEY",
+    "KAIRIX_EMBED_ENDPOINT",
+    "KAIRIX_EMBED_MODEL",
+    "KAIRIX_NEO4J_PASSWORD",  # pragma: allowlist secret — env-var NAME, not a value
+)
+
+_CANONICAL_VAULT = {
+    "kairix-provider-llm-api-key": "llm-key-canonical",
+    "kairix-provider-llm-endpoint": "llm-endpoint-canonical",
+    "kairix-provider-llm-model": "llm-model-canonical",
+    "kairix-provider-embed-api-key": "embed-key-canonical",
+    "kairix-provider-embed-endpoint": "embed-endpoint-canonical",
+    "kairix-provider-embed-model": "embed-model-canonical",
+    "kairix-infra-neo4j-password": "neo4j-pass-canonical",  # pragma: allowlist secret — fixture value
+}
+
+_LEGACY_VAULT = {
+    "kairix-llm-api-key": "llm-key-legacy",
+    "kairix-llm-endpoint": "llm-endpoint-legacy",
+    "kairix-llm-model": "llm-model-legacy",
+    "kairix-embed-api-key": "embed-key-legacy",
+    "kairix-embed-endpoint": "embed-endpoint-legacy",
+    "kairix-embed-model": "embed-model-legacy",
+    "kairix-neo4j-password": "neo4j-pass-legacy",  # pragma: allowlist secret — fixture value
+}
+
+
+@pytest.fixture(scope="module")
+def fetch_secrets_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("vault_agent_fetch_secrets", _MODULE_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_canonical_vault_emits_canonical_and_legacy_env_vars(
+    fetch_secrets_module: ModuleType,
+) -> None:
+    """A vault holding only canonical names fans out to both env-var sets."""
+    resolved = fetch_secrets_module.resolve_secret_env(_CANONICAL_VAULT.get)
+
+    assert set(resolved) == set(_CANONICAL_ENV_VARS) | set(_LEGACY_ENV_VARS)
+    assert resolved["KAIRIX_PROVIDER_LLM_API_KEY"] == "llm-key-canonical"  # pragma: allowlist secret — fixture value
+    assert resolved["KAIRIX_LLM_API_KEY"] == "llm-key-canonical"  # pragma: allowlist secret — fixture value
+    assert resolved["KAIRIX_INFRA_NEO4J_PASSWORD"] == "neo4j-pass-canonical"  # pragma: allowlist secret
+    assert resolved["KAIRIX_NEO4J_PASSWORD"] == "neo4j-pass-canonical"  # pragma: allowlist secret
+
+
+def test_legacy_vault_resolves_via_fallback_names(
+    fetch_secrets_module: ModuleType,
+) -> None:
+    """A pre-canonical vault (short KV names only) still resolves everything."""
+    resolved = fetch_secrets_module.resolve_secret_env(_LEGACY_VAULT.get)
+
+    assert set(resolved) == set(_CANONICAL_ENV_VARS) | set(_LEGACY_ENV_VARS)
+    assert resolved["KAIRIX_PROVIDER_EMBED_ENDPOINT"] == "embed-endpoint-legacy"
+    assert resolved["KAIRIX_EMBED_ENDPOINT"] == "embed-endpoint-legacy"
+    assert resolved["KAIRIX_INFRA_NEO4J_PASSWORD"] == "neo4j-pass-legacy"  # pragma: allowlist secret
+
+
+def test_canonical_kv_name_wins_over_legacy_fallback(
+    fetch_secrets_module: ModuleType,
+) -> None:
+    """When both KV generations hold a secret, the canonical name wins."""
+    both = {**_LEGACY_VAULT, **_CANONICAL_VAULT}
+
+    resolved = fetch_secrets_module.resolve_secret_env(both.get)
+
+    assert resolved["KAIRIX_PROVIDER_LLM_API_KEY"] == "llm-key-canonical"  # pragma: allowlist secret — fixture value
+    assert resolved["KAIRIX_LLM_API_KEY"] == "llm-key-canonical"  # pragma: allowlist secret — fixture value
+
+
+def test_empty_vault_resolves_nothing(fetch_secrets_module: ModuleType) -> None:
+    """Missing secrets are skipped — same semantics the sidecar always had."""
+    resolved = fetch_secrets_module.resolve_secret_env(lambda _name: None)
+
+    assert resolved == {}
+
+
+def test_every_spec_lists_canonical_env_var_first(
+    fetch_secrets_module: ModuleType,
+) -> None:
+    """Spec shape contract: canonical env var leads, KV name is canonical.
+
+    The first env var of every spec must be the canonical
+    ``KAIRIX_<SCOPE>_...`` form derived from its KV name (uppercase,
+    hyphens → underscores) per docs/operations/secrets-configuration.md.
+    """
+    for spec in fetch_secrets_module.SECRET_SPECS:
+        derived = spec.kv_name.replace("-", "_").upper()
+        assert spec.env_vars[0] == derived
+        assert spec.kv_name.startswith(("kairix-provider-", "kairix-infra-"))


### PR DESCRIPTION
Tranche 3 of the onboarding work: turn the wizard from "works" into "wins". Builds in waves on `feat/onboarding-tranche-3`; this PR accumulates wave-by-wave and goes ready-for-review after the final wave + fresh-VM walkthrough.

## Landed (Wave 1, partial — more commits incoming)

- **#483** — safe-commit.sh test-stage failures are no longer silent: every output-capturing gate prints a stage-named FAIL with the last 50 lines and fix:/next: markers; coverage artifacts are per-invocation so concurrent gates can't collide.
- **#479** — vault-agent sidecar emits canonical secret names (`KAIRIX_PROVIDER_*`, `KAIRIX_INFRA_NEO4J_PASSWORD`) with legacy aliases kept for the transition window (remove with #369); KV fetch falls back to pre-canonical names so existing vaults keep working.
- **F81 first cut** — `scripts/checks/check-fresh-install-smoke.sh` + non-required `fresh-install-smoke.yml`: clean-dir compose boot → healthz ready → MCP handshake → wizard 200 (flag on) → BM25 search hit, no provider secrets needed. This workflow run on this PR is the script's end-to-end verification (Docker unavailable in the authoring sandbox; statically verified + parser unit-exercised).

## Still to come in this PR

- **#488** wizard layout primitive (no element moves when async results render)
- **#484 #485 #486 #487** demo-debt: Azure deployment names, overlay config writes (read-only mount fix), container-aware folder step, per-client transport matrix
- **#489** OAuth source connect (Slack/GitHub/Google) via the wizard-origin callback route (decision recorded on #489)
- **#490** capability-tour finale (search → prep → remember-then-find → brief → timeline)
- Sonar: main carries 7 open new-code findings from tranche-2 (backends.py S5754, routes.py S3776/S7503, 4 template accessibility) — fixed in an integration commit here after the wizard-file waves land; in-flight commits use the documented `KAIRIX_SKIP_SONAR_PARITY=1` with disclosure in their bodies.

## Orchestration notes

Parallel worktree agents per CLAUDE.md; every cherry-pick passed the review-gate checklist (scope ✓ sabotage-proofs-executed ✓ baselines-untouched ✓ worktree-isolation ✓ F21 affordance ✓). Sabotage proofs for #483 (forced collection error → named FAIL + tail) and #479 (dropped alias → 3 failed → restored → 5 passed) were executed and pasted in agent reports.