### PR TITLE
chore(sdlc): main ruleset (merge queue + required reviews) + CODEOWNERS canon gating

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,3 +18,10 @@
 # CI/CD and security configuration
 /.github/                       @quanyeomans
 /pyproject.toml                 @quanyeomans
+
+# Canon + security policy — lead-only; never self-approved by an agent.
+# Enforced by the main ruleset (.github/rulesets/main.json: require_code_owner_review).
+/SECURITY.md                    @quanyeomans
+/CONSTRAINTS.md                 @quanyeomans
+/CONTRIBUTING.md                @quanyeomans
+/scripts/checks/                @quanyeomans

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,0 +1,58 @@
+{
+  "_comment": "Importable ruleset for the default branch (main). Apply with: gh api repos/three-cubes/kairix/rulesets --method POST --input .github/rulesets/main.json  (requires Administration:Write — a human/admin action). kairix currently has legacy branch protection with enforce_admins=true but NO required reviews or required status checks; this ruleset adds the human-in-the-loop gate + a merge queue. CONFIRM the required_status_checks contexts below against this repo's actual gating checks before applying — add 'Go quality', 'SonarCloud analysis', '1a · Benchmark gate (retrieval loop)', or 'Fresh-install smoke (F81)' if they should gate merges. Mirrors three-cubes/tc-agent-zone; rationale: that repo's docs/standards/agent-sdlc-access-and-hitl.md.",
+  "name": "main",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "require_code_owner_review": true,
+        "dismiss_stale_reviews_on_push": true,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true,
+        "automatic_copilot_code_review_enabled": false,
+        "allowed_merge_methods": ["squash", "merge"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          { "context": "CI gate" },
+          { "context": "2 · Pre-merge PR gates (PR → main)" }
+        ]
+      }
+    },
+    {
+      "type": "merge_queue",
+      "parameters": {
+        "merge_method": "SQUASH",
+        "grouping_strategy": "ALLGREEN",
+        "max_entries_to_build": 5,
+        "max_entries_to_merge": 5,
+        "min_entries_to_merge": 1,
+        "min_entries_to_merge_wait_minutes": 5,
+        "check_response_timeout_minutes": 60
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "pull_request"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Mirrors the agent SDLC access + human-in-the-loop governance from `three-cubes/tc-agent-zone` onto kairix. Today kairix's `main` has legacy branch protection (`enforce_admins` on, no force-push/deletion) but **no required reviews and no required status checks** — so a PR can merge without CI green or a human approval. This adds the HITL gate.

**New / changed:**
- **`.github/rulesets/main.json`** (new) — importable ruleset: **1 approval + CODEOWNERS review**, required gating checks (`CI gate`, `2 · Pre-merge PR gates`), strict (up-to-date), and a **merge queue (ALLGREEN)** that re-runs checks on the combined commit so `main` can't go red from concurrent merges. Squash/merge allowed (matches repo settings); human-admin-only bypass.
- **`.github/CODEOWNERS`** (extended) — your existing file is already solid; this just pins `SECURITY.md`, `CONSTRAINTS.md`, `CONTRIBUTING.md`, and `scripts/checks/` to lead review (canon + gates).

## Needs a human (Administration:Write — by design)
- [ ] **Confirm the `required_status_checks` contexts** match kairix's actual gating checks. I used the two aggregators (`CI gate` from ci.yml, `2 · Pre-merge PR gates` from integration.yml) — add `Go quality`, `SonarCloud analysis`, `1a · Benchmark gate (retrieval loop)`, or `Fresh-install smoke (F81)` if those should gate.
- [ ] Apply: `gh api repos/three-cubes/kairix/rulesets --method POST --input .github/rulesets/main.json`

## Context
Part of standing up per-agent GitHub App identities + HITL across the platform; full rationale lives in tc-agent-zone's `docs/standards/agent-sdlc-access-and-hitl.md` (sibling PR). Worth noting kairix **already uses Codecov** (ci.yml uploads contract-test analytics) — unlike tc-agent-zone, which is Sonar-only; that's the source of the earlier "Codecov" question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)