### PR TITLE
fix(fitness): genericize sibling-repo reference (F73 public-repo infra-leak)

### DIFF
--- a/scripts/checks/mutation_parity.py
+++ b/scripts/checks/mutation_parity.py
@@ -10,13 +10,11 @@ a human (a cultural ritual) rather than enforced by a repeatable gate. A
 mutant survives when the tests that cover a line still PASS after the
 line's logic is changed — proof the tests assert presence, not behaviour.
 
-This runner makes the sabotage proof mechanical and diff-scoped. It mirrors
-tc-agent-zone's mutation contract (``scripts/checks/mutation_survival_ratchet.py``
-+ ``5-mutation-testing.yml``): a homegrown mutator (no mutmut/stryker
-dependency — that org's runner is homegrown too, anticipating but not
-requiring those packages) and a ratcheted survivors baseline. The
-per-commit leg is diff-scoped and hard-capped so it stays bounded; the
-nightly ``mutation-suite.yml`` runs full-scope against the ratchet.
+This runner makes the sabotage proof mechanical and diff-scoped. It follows
+the org's shared mutation contract: a homegrown mutator (no mutmut/stryker
+dependency) and a ratcheted survivors baseline. The per-commit leg is
+diff-scoped and hard-capped so it stays bounded; the nightly
+``mutation-suite.yml`` runs full-scope against the ratchet.
 
 What it does
 ------------


### PR DESCRIPTION
The mutation gate's docstring named the org sibling repo + its internal file paths literally; F73 (externalised private-infra patterns) flags it as a leak into public kairix. Replaced with a generic reference.

Escaped PR #501 CI because **F73 only enforces when its pattern source is loaded** — the local env has the pattern file, CI apparently doesn't. That CI-parity gap (and the broader 'externalise config to org/repo variables instead of local-excluded files' principle) is being addressed as part of the #499 consolidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)