### PR TITLE
ci: arch-fitness path-filter + F73 org-config fetch + setup-uv-cached adoption (#499 Phase 4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,18 @@ jobs:
               # no .py touched. Without this entry, project.properties edits
               # silently skip the sonarcloud job (#XXX — observed on 0b4095d9).
               - 'sonar-project.properties'
+              # The fitness machinery itself: a change to the CHECK SCRIPTS,
+              # the safe-commit driver, the grandfathering baselines, or the
+              # rule catalogue must always run Stage 0 arch-fitness (+
+              # pre-commit + contracts, which share this filter). Without
+              # these entries a scripts/checks/ change skips Stage 0 entirely
+              # — confirmed on PR #508, where a scripts/checks/ edit had
+              # Stage 0 "skipping" so the fitness rules never validated the
+              # change to the fitness rules. (#499 phase 4.)
+              - 'scripts/checks/**'
+              - 'scripts/safe-commit.sh'
+              - '.architecture/baseline/**'
+              - '**/_rule_catalogue.py'
             docker:
               - 'Dockerfile'
               - 'docker-compose*.yml'
@@ -146,19 +158,25 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      # Org-shared uv install seam (#499 phase 4, PR1). Replaces the
+      # actions/setup-python + `pip install -e ".[...]"` pair with the
+      # three-cubes/ci-workflows composite, which sets up uv (with cache)
+      # and runs `uv sync`. `--all-extras --all-groups` is the superset of
+      # the previous extras set, so the [agents] extras (starlette via
+      # mcp>=1.20) are still present and the MCP transport contract test
+      # runs here rather than being skipped by `importorskip("starlette")`.
+      # kairix is a single package (not a uv workspace) — do NOT pass
+      # --all-packages. Pinned to @main until the action repo cuts tags.
+      - uses: three-cubes/ci-workflows/actions/setup-uv-cached@main
         with:
           python-version: "3.12"
-
-      - name: Install dependencies
-        # The [agents] extras provide starlette (transitively via mcp>=1.20)
-        # so the MCP transport contract test runs here instead of being
-        # silently skipped by `pytest.importorskip("starlette")`.
-        run: pip install -e ".[dev,agents,markitdown,pdf_fallback,ocr,pptx,docx,xlsx]"
+          sync-args: "--all-extras --all-groups"
 
       - name: Contract tests (schema validation, interface agreements)
+        # `uv run` executes inside the .venv that `uv sync` populated — the
+        # composite action installs but does not activate it for later steps.
         run: |
-          pytest tests/ -m contract -v --tb=short --timeout=30 \
+          uv run pytest tests/ -m contract -v --tb=short --timeout=30 \
             --junitxml=results-contracts.xml
 
       - name: "paths-DI deprecation: count remaining monkeypatch.setenv(KAIRIX_*)"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,26 @@ pip install -e ".[dev,agents,markitdown,pdf_fallback,ocr,pptx,docx,xlsx]"
 make setup           # pre-commit hooks only
 ```
 
+### Fitness-check config (F73 private-infra patterns)
+
+The F73 token-pattern scanner loads its pattern set from org config in the
+`three-cubes` org — single-sourced for CI and local dev. CI reads the org
+secret; locally you fetch the org variable (org-member-readable) with the
+`gh` CLI:
+
+```bash
+# Export into your current shell (preferred):
+eval "$(bash scripts/fetch-fitness-config.sh)"
+
+# Or cache it to the gitignored .private-infra-patterns fallback file:
+make fitness-config
+```
+
+Without the patterns the scanner is a no-op locally, so the commit gate
+passes — CI is still the backstop. The hand-maintained
+`.private-infra-patterns` file is a last-resort fallback/cache only; the
+org variable is the canonical local source.
+
 ## Making changes
 
 Kairix is trunk-based on `main`. Routine work commits direct to `main` when `safe-commit.sh` is green.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup setup-dev setup-check lint format check test test-unit test-bdd test-contract test-integration type-check security commit clean \
+.PHONY: setup setup-dev setup-check fitness-config lint format check test test-unit test-bdd test-contract test-integration type-check security commit clean \
         go-modules go-fmt go-vet go-lint go-test go-build go-check
 
 # Developer-environment setup — wires the pre-commit hooks so first-commit
@@ -32,6 +32,16 @@ setup-dev:
 # Useful for "did I miss a prereq" troubleshooting.
 setup-check:
 	bash scripts/dev/setup.sh --check
+
+# Fetch the F73 private-infra pattern set from org config (the org VARIABLE
+# PRIVATE_INFRA_PATTERNS in the three-cubes org) and cache it to the
+# gitignored .private-infra-patterns file the check falls back to. Requires
+# the `gh` CLI authenticated as an org member. CI uses the matching org
+# SECRET; this is the org-member-readable equivalent for local dev. To
+# export into your shell instead of caching to a file:
+#   eval "$(bash scripts/fetch-fitness-config.sh)"
+fitness-config:
+	bash scripts/fetch-fitness-config.sh --write
 
 # Combined quality check — run all linting, formatting, and type checks
 lint: lint-check format-check type-check

--- a/docs/architecture/fitness-functions.md
+++ b/docs/architecture/fitness-functions.md
@@ -322,6 +322,29 @@ _Generated from `scripts/checks/_rule_catalogue.py` — do not edit by hand._
 
 <!-- END F-CATALOGUE -->
 
+### F73 pattern source — org config, not a local file
+
+F73's token-pattern set is **externalised to org config** in the
+`three-cubes` org, single-sourced for CI and local dev:
+
+- **CI** reads the org **secret** `PRIVATE_INFRA_PATTERNS` into the
+  `PRIVATE_INFRA_PATTERNS` env var (wired in `.github/workflows/ci.yml`).
+- **Local dev** reads the org **variable** `PRIVATE_INFRA_PATTERNS`
+  (org-member-readable) with the `gh` CLI:
+
+  ```bash
+  # Export into the current shell (preferred):
+  eval "$(bash scripts/fetch-fitness-config.sh)"
+
+  # Or cache it to the gitignored .private-infra-patterns fallback:
+  make fitness-config
+  ```
+
+The hand-maintained `.private-infra-patterns` file is a **last-resort
+fallback/cache only** — the org variable is the canonical local source.
+With no patterns loaded the scanner is a no-op locally (CI remains the
+backstop), so a fresh clone never hard-fails on a missing file.
+
 ---
 
 ## The rules in detail

--- a/scripts/checks/check_no_private_infra_refs.py
+++ b/scripts/checks/check_no_private_infra_refs.py
@@ -1,10 +1,23 @@
 """Token-pattern scanner with externalised pattern source.
 
-Pattern definitions are loaded at runtime from one of:
+The canonical pattern source is org config in the three-cubes org,
+single-sourced for both CI and local dev:
 
-  * ``PRIVATE_INFRA_PATTERNS`` env var (CI: injected from a repo secret).
-  * ``.private-infra-patterns`` file at repo root (local-only fallback;
-    gitignored, template at ``.private-infra-patterns.example``).
+  * CI reads the org SECRET ``PRIVATE_INFRA_PATTERNS`` into the
+    ``PRIVATE_INFRA_PATTERNS`` env var (wired in ``.github/workflows/ci.yml``).
+  * Local dev reads the org VARIABLE ``PRIVATE_INFRA_PATTERNS``
+    (org-member-readable) via ``gh variable get`` —
+    ``eval "$(bash scripts/fetch-fitness-config.sh)"`` to export it,
+    or ``make fitness-config`` to cache it to the fallback file.
+
+Pattern definitions are loaded at runtime from, in order:
+
+  * ``PRIVATE_INFRA_PATTERNS`` env var (CI secret, or local export from the
+    org variable via ``scripts/fetch-fitness-config.sh``).
+  * ``.private-infra-patterns`` file at repo root (last-resort local
+    fallback / cache; gitignored, template at
+    ``.private-infra-patterns.example``). Prefer the org-variable fetch over
+    hand-maintaining this file.
 
 Each non-blank, non-comment line is one regex pattern. Optional
 ``label:regex`` shape lets the failure message name the category.
@@ -145,7 +158,9 @@ def main() -> int:
     if not patterns:
         print(
             f"ok [arch:no-private-infra-refs] — no patterns loaded "
-            f"(set ${PATTERNS_ENV_VAR} or create {PATTERNS_FILE.name})."
+            f'(local dev: run `eval "$(bash scripts/fetch-fitness-config.sh)"` '
+            f"to export ${PATTERNS_ENV_VAR} from the org variable, "
+            f"or `make fitness-config` to cache {PATTERNS_FILE.name})."
         )
         return 0
 

--- a/scripts/fetch-fitness-config.sh
+++ b/scripts/fetch-fitness-config.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Fetch the F73 private-infra pattern set from org config for local dev.
+#
+# The canonical source of the F73 token-pattern set is org config in the
+# three-cubes org, single-sourced for both CI and local dev:
+#
+#   * CI reads the org SECRET PRIVATE_INFRA_PATTERNS into the
+#     PRIVATE_INFRA_PATTERNS env var (wired in .github/workflows/ci.yml).
+#   * Local dev reads the org VARIABLE PRIVATE_INFRA_PATTERNS, which is
+#     org-member-readable, via `gh variable get`.
+#
+# This script fetches the org variable and prints an export line you can
+# eval into your shell, OR (with --write) caches it to the gitignored
+# `.private-infra-patterns` file that the check falls back to.
+#
+# Usage:
+#   eval "$(bash scripts/fetch-fitness-config.sh)"   # export to shell
+#   bash scripts/fetch-fitness-config.sh --write     # cache to file
+#
+# Requires the `gh` CLI authenticated as a three-cubes org member.
+
+set -euo pipefail
+
+ORG="three-cubes"
+VAR_NAME="PRIVATE_INFRA_PATTERNS"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CACHE_FILE="${REPO_ROOT}/.private-infra-patterns"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "fetch-fitness-config: 'gh' CLI not found." >&2
+  echo "fix: install the GitHub CLI (https://cli.github.com) and run 'gh auth login'." >&2
+  echo "next: re-run bash scripts/fetch-fitness-config.sh" >&2
+  exit 1
+fi
+
+# `gh variable get` exits non-zero if the variable is absent or the caller
+# lacks org-member read access. Surface the actionable message rather than a
+# bare gh error.
+if ! value="$(gh variable get "${VAR_NAME}" --org "${ORG}" 2>/dev/null)"; then
+  echo "fetch-fitness-config: could not read org variable ${VAR_NAME} from ${ORG}." >&2
+  echo "fix: confirm 'gh auth status' shows you authenticated as a ${ORG} org member." >&2
+  echo "next: ask an org admin to confirm the org VARIABLE ${VAR_NAME} exists and is org-member-readable." >&2
+  echo "run: bash scripts/fetch-fitness-config.sh" >&2
+  exit 1
+fi
+
+if [ "${1:-}" = "--write" ]; then
+  printf '%s\n' "${value}" >"${CACHE_FILE}"
+  echo "fetch-fitness-config: wrote pattern set to ${CACHE_FILE} (gitignored cache)." >&2
+else
+  # Default: emit an eval-able export line. Single-quote the value and
+  # escape embedded single quotes so multi-line / special-char patterns
+  # survive the round-trip into the shell.
+  escaped="${value//\'/\'\\\'\'}"
+  printf "export %s='%s'\n" "${VAR_NAME}" "${escaped}"
+fi

--- a/tests/checks/test_no_private_infra_refs.py
+++ b/tests/checks/test_no_private_infra_refs.py
@@ -1,7 +1,9 @@
 """Tests for the F73 pattern loader, scope filter, and exempt logic.
 
 Patterns are loaded at runtime from the ``PRIVATE_INFRA_PATTERNS`` env
-var (CI) or a gitignored ``.private-infra-patterns`` file (local).
+var — populated in CI from the org secret, and locally from the org
+variable via ``scripts/fetch-fitness-config.sh`` — with a
+gitignored ``.private-infra-patterns`` file as the last-resort fallback.
 These tests use synthetic patterns so the test file carries no
 operator-specific literals.
 """


### PR DESCRIPTION
Three CI-hardening changes toward the consolidation target state:

1. **arch-fitness path-filter gap fixed** — Stage 0 (+pre-commit, contracts) now run when the fitness machinery itself changes (`scripts/checks/**`, `safe-commit.sh`, baselines, `_rule_catalogue.py`). Previously a check-script change skipped arch-fitness (confirmed on #508) — the gap that let the F73 leak through.
2. **F73 config externalization** — `scripts/fetch-fitness-config.sh` + `make fitness-config` fetch `PRIVATE_INFRA_PATTERNS` from the org variable; docs name the org secret (CI) + variable (local) as canonical, gitignored file demoted to fallback. Implements the 'config in org/repo vars, not local-excluded files' principle.
3. **setup-uv-cached adoption** — the contracts job now uses `three-cubes/ci-workflows/actions/setup-uv-cached@main` (the first kairix consumer of the shared CI). `sync-args: --all-extras --all-groups` (single-package superset); `uv run` prefix since the action doesn't activate the venv.

The contracts job's CI run here is the live proof of the uv adoption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)