### PR TITLE
feat(fitness): rules.py paved-road query surface (#499 Phase 2)

### DIFF
--- a/scripts/checks/_rule_catalogue.py
+++ b/scripts/checks/_rule_catalogue.py
@@ -77,6 +77,33 @@ Status = Literal[
     "superseded",
 ]
 
+# ── paved-road task-type vocabulary (#499 Phase 2) ──────────────────────
+#
+# A CLOSED set of agent-facing "I'm about to do X" tasks. ``rules.py
+# --task <t>`` answers "what pattern do I follow for X?" by listing every
+# RuleEntry tagged with that task. The set is intentionally small and
+# capability-shaped — the tasks an agent hits when BUILDING something, not
+# every concern a rule protects. A member that isn't in this tuple is a
+# typo; ``tests/architecture/test_rules_query.py`` guards that forever.
+TASK_TYPES: tuple[str, ...] = (
+    "adding-a-cli-subcommand",
+    "adding-an-mcp-tool",
+    "adding-a-connector",
+    "adding-an-extractor",
+    "adding-a-provider",
+    "adding-a-feature-flag",
+    "writing-a-test",
+    "writing-a-bdd-feature",
+    "a-schema-change",
+    "editing-a-gate-script",
+)
+"""The closed task-type vocabulary for ``RuleEntry.task_type``.
+
+Frozen membership: every ``task_type`` tag on every entry MUST be a
+member. New tasks are added here deliberately (and only here)."""
+
+_TASK_TYPES_FROZEN: frozenset[str] = frozenset(TASK_TYPES)
+
 
 @dataclass(frozen=True)
 class RuleEntry:
@@ -112,6 +139,26 @@ class RuleEntry:
       ``sonar-new-code`` in the security stage; ``worktree-isolation``
       and ``paydown-doc-currency`` invoked out-of-band) so the runner
       reproduces exactly the set ``run-all.sh`` ran before this change.
+
+    Paved-road query surface (#499 Phase 2 — ``rules.py``)
+    -----------------------------------------------------
+    Two OPTIONAL agent-affordance fields answer "what pattern do I copy
+    for task X?" BEFORE an agent writes code, and link a failing gate
+    back to the exemplar:
+
+    * ``exemplar`` — a repo-relative path to a canonical PASSING file
+      that demonstrates the pattern an agent should copy to satisfy the
+      rule. ``None`` (the default) means no curated exemplar yet — only
+      the high-traffic capability-building rules carry one. When a rule
+      with an ``exemplar`` FAILS, ``run_checks.py`` prints a
+      ``paved-road:`` footer pointing at ``rules.py --rule <id>``.
+
+    * ``task_type`` — zero-or-more tags from the closed
+      :data:`TASK_TYPES` vocabulary. Tags the agent-facing tasks ("I'm
+      adding a connector") whose pattern this rule governs, so
+      ``rules.py --task <t>`` can list every rule an agent must satisfy
+      for that task. Empty (the default) for rules an agent doesn't hit
+      while building a capability.
     """
 
     id: str
@@ -125,6 +172,8 @@ class RuleEntry:
     tags: tuple[str, ...] = field(default_factory=tuple)
     script: str | None = None
     run_all: bool = True
+    exemplar: str | None = None
+    task_type: tuple[str, ...] = field(default_factory=tuple)
 
 
 _ENTRIES: tuple[RuleEntry, ...] = (
@@ -154,6 +203,8 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         scope="per-file",
         summary="kairix/core/connectors/** may not import kairix/connectors/** or kairix/extractors/**",
         adr_origin="docs/architecture/connector-ingestion-architecture.md",
+        exemplar="kairix/connectors/obsidian/connector.py",
+        task_type=("adding-a-connector",),
     ),
     RuleEntry(
         id="F35",
@@ -162,6 +213,8 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         category="layering",
         scope="per-file",
         summary="kairix/connectors/<a>/ may not import another connector or any extractor",
+        exemplar="kairix/connectors/obsidian/connector.py",
+        task_type=("adding-a-connector",),
     ),
     RuleEntry(
         id="F37",
@@ -250,6 +303,8 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         category="test-discipline",
         scope="per-test",
         summary="every test_* carries a category marker (unit/bdd/contract/integration/e2e/slow/soak/invariant)",
+        exemplar="tests/test_credentials.py",
+        task_type=("writing-a-test",),
     ),
     RuleEntry(
         id="F9",
@@ -276,6 +331,8 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         scope="per-file",
         summary="every BDD feature has a happy-path scenario",
         tags=("bdd",),
+        exemplar="tests/bdd/features/bootstrap.feature",
+        task_type=("writing-a-bdd-feature",),
     ),
     RuleEntry(
         id="F13",
@@ -285,6 +342,8 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         scope="per-file",
         summary="BDD scenarios reject implementation symbols (Mock, kairix.<pkg>.<symbol>)",
         tags=("bdd",),
+        exemplar="tests/bdd/features/cli_connect_github_app.feature",
+        task_type=("writing-a-bdd-feature",),
     ),
     RuleEntry(
         id="F45",
@@ -295,6 +354,15 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         summary="every new CLI/MCP/provider/connector/extractor adds a BDD feature in the same commit",
         adr_origin="docs/architecture/test-discipline-hardening.md",
         script="check-f45-new-capability-bdd.sh",
+        exemplar="tests/bdd/features/bootstrap.feature",
+        task_type=(
+            "adding-a-cli-subcommand",
+            "adding-an-mcp-tool",
+            "adding-a-connector",
+            "adding-an-extractor",
+            "adding-a-provider",
+            "writing-a-bdd-feature",
+        ),
     ),
     RuleEntry(
         id="F46",
@@ -304,6 +372,8 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         scope="per-file",
         summary="BDD step impls compose via CLI/MCP/factory — no direct *Pipeline(...) construction",
         script="check-f46-bdd-step-composition.sh",
+        exemplar="tests/integration/test_vec_index_lifecycle.py",
+        task_type=("writing-a-bdd-feature", "writing-a-test"),
     ),
     RuleEntry(
         id="F47",
@@ -312,6 +382,8 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         category="test-discipline",
         scope="per-file",
         summary="integration tests construct multi-component pipelines via kairix.core.factory.build_*",
+        exemplar="tests/integration/test_vec_index_lifecycle.py",
+        task_type=("writing-a-test",),
     ),
     RuleEntry(
         id="F48",
@@ -321,6 +393,8 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         scope="cross-cutting",
         summary="tests/e2e/test_composed_production_path.py exists, runs in CI Stage 4.5",
         script="check-f48-e2e-present.sh",
+        exemplar="tests/e2e/test_composed_production_path.py",
+        task_type=("writing-a-test",),
     ),
     RuleEntry(
         id="F54",
@@ -333,6 +407,8 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         ),
         tags=("test-discipline",),
         script="check-f54-flag-both-branch-tested.sh",
+        exemplar="tests/bdd/features/feature_flag_connector_github.feature",
+        task_type=("adding-a-feature-flag",),
     ),
     RuleEntry(
         id="F62",
@@ -409,6 +485,8 @@ _ENTRIES: tuple[RuleEntry, ...] = (
             "round-trip test through the canonical layered reader (#492 overlay split-brain class)"
         ),
         adr_origin="EPIC #499 Phase 1 — #492 overlay split-brain (H1)",
+        exemplar="tests/integration/test_wizard_config_overlay_split_brain.py",
+        task_type=("a-schema-change", "writing-a-test"),
     ),
     RuleEntry(
         id="F88",
@@ -422,6 +500,8 @@ _ENTRIES: tuple[RuleEntry, ...] = (
             "render-tested under tests/platform/setup (session-escape-5 raw-500 class)"
         ),
         adr_origin="EPIC #499 Phase 1 — session-escape-5 (save_source ValueError surfaced as 500)",
+        exemplar="tests/platform/setup/test_setup_service.py",
+        task_type=("writing-a-test",),
     ),
     RuleEntry(
         id="F87",
@@ -436,6 +516,8 @@ _ENTRIES: tuple[RuleEntry, ...] = (
             "(the GitHub-PEM consent-failure class)"
         ),
         adr_origin="EPIC #499 Phase 1 — GitHub-PEM multi-line secret round-trip (session escape 2)",
+        exemplar="tests/integration/test_secrets_pem_round_trip.py",
+        task_type=("writing-a-test",),
     ),
     RuleEntry(
         id="F86",
@@ -479,6 +561,8 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         scope="per-plugin",
         summary="every connector + extractor plugin has matching BDD feature + Examples-table row",
         script="check-f36-connector-bdd-parity.sh",
+        exemplar="tests/bdd/features/e2e_connector_sync.feature",
+        task_type=("adding-a-connector", "adding-an-extractor", "writing-a-bdd-feature"),
     ),
     RuleEntry(
         id="F40",
@@ -487,6 +571,8 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         category="plugin-contract",
         scope="per-plugin",
         summary="every Extractor plugin declares module-level version: str + make_extractor factory",
+        exemplar="kairix/extractors/docx/__init__.py",
+        task_type=("adding-an-extractor",),
     ),
     RuleEntry(
         id="F41",
@@ -495,6 +581,8 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         category="plugin-contract",
         scope="per-plugin",
         summary="every plugin tree has py.typed marker + no unjustified # type: ignore",
+        exemplar="kairix/connectors/obsidian/__init__.py",
+        task_type=("adding-a-connector", "adding-an-extractor", "adding-a-provider"),
     ),
     RuleEntry(
         id="F42",
@@ -569,6 +657,8 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         category="production-safety",
         scope="per-method",
         summary="every Chunk(...) constructor call passes source_uri + source_modified_at + sensitivity explicitly",
+        exemplar="kairix/core/connectors/silver.py",
+        task_type=("adding-a-connector",),
     ),
     RuleEntry(
         id="F50",
@@ -878,6 +968,8 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         category="test-discipline",
         scope="cross-cutting",
         summary="every CLI subcommand + every MCP tool has an outcome test (subprocess or direct handler)",
+        exemplar="tests/test_worker_cli_maintenance.py",
+        task_type=("adding-a-cli-subcommand", "adding-an-mcp-tool", "writing-a-test"),
     ),
     RuleEntry(
         id="F32",

--- a/scripts/checks/check_path_naming.py
+++ b/scripts/checks/check_path_naming.py
@@ -70,7 +70,8 @@ _TEST_PY = re.compile(r"^(__init__|conftest|fakes|test_[a-z0-9_]+|_?[a-z][a-z0-9
 _SNAKE_FEATURE = re.compile(r"^[a-z][a-z0-9_]*\.feature$")
 _CHECK_SCRIPT_PY = re.compile(
     r"^(check_[a-z0-9_]+|_fitness_rule|_rule_catalogue|_integrity_invariants_registry"
-    r"|audit_baselines|merge_coverage_xml|run_checks|generate_catalogue_docs|mutation_parity)\.py$"
+    r"|audit_baselines|merge_coverage_xml|run_checks|generate_catalogue_docs|mutation_parity"
+    r"|rules)\.py$"
 )
 _CHECK_SCRIPT_SH = re.compile(r"^(check[-_][a-z0-9-]+|_lib|run-all)\.sh$")
 _RUNBOOK_MD = re.compile(r"^(INDEX|README|[a-z][a-z0-9-]*)\.md$")

--- a/scripts/checks/rules.py
+++ b/scripts/checks/rules.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Paved-road query surface for the fitness catalogue (#499 Phase 2).
+
+This is TOOLING under ``scripts/checks/`` — NOT a ``kairix.cli``
+subcommand and NOT an MCP tool, so the capability-discipline rules
+(F45 new-capability-BDD, F30 operator-outcome-test) do not apply. It
+sits next to its siblings ``run_checks.py`` and
+``generate_catalogue_docs.py``, which the F22 path-naming allow-list
+already names; ``rules`` is added to that same allow-list.
+
+Why it exists
+-------------
+The catalogue (:mod:`_rule_catalogue`) already answers "which rules
+exist and what do they protect?". This surface answers the agent's
+*forward* question — "I'm about to do task X; what pattern do I copy,
+and which gates will judge me?" — BEFORE any code is written. It reads
+the ``exemplar`` + ``task_type`` metadata each high-traffic RuleEntry
+carries and turns it into three plain-text views:
+
+* ``rules.py --task <task>`` — every rule tagged with that task, each
+  with its F-id, one-line summary, the exemplar to copy, and the
+  ``run:`` command that judges it.
+* ``rules.py --rule <Fid>`` — one rule's summary, exemplar, task tags,
+  and remediation (the ``run:`` command).
+* ``rules.py --list-tasks`` — the closed task-type vocabulary with a
+  per-task rule count.
+
+Output is plain text in the F21 affordance style: every actionable
+line is prefixed so an agent (or human) reading it knows the next move.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _rule_catalogue import ALL_ENTRIES, TASK_TYPES, RuleEntry
+from run_checks import is_dispatchable
+
+
+def _run_command(entry: RuleEntry) -> str:
+    """The command an agent runs to make ``entry``'s gate judge their
+    work. Every cataloged rule dispatches through the single runner
+    (``run_checks.py --gate <id>``); proposed rules have no runnable
+    check yet."""
+    if not is_dispatchable(entry):
+        return "(no runnable check yet — rule is proposed)"
+    return f"python3 scripts/checks/run_checks.py --gate {entry.id}"
+
+
+def _entries_for_task(task: str) -> list[RuleEntry]:
+    """Every catalogue entry tagged with ``task``, in catalogue order."""
+    return [e for e in ALL_ENTRIES if task in e.task_type]
+
+
+def _entry_by_id(rule_id: str) -> RuleEntry | None:
+    """The first catalogue entry whose id matches ``rule_id``
+    (case-insensitive), or ``None``."""
+    for entry in ALL_ENTRIES:
+        if entry.id.lower() == rule_id.lower():
+            return entry
+    return None
+
+
+def render_task(task: str) -> str:
+    """The ``--task`` view: every rule governing ``task``, each with its
+    F-id, summary, exemplar, and run command."""
+    if task not in TASK_TYPES:
+        valid = ", ".join(TASK_TYPES)
+        return (
+            f"unknown task-type: {task!r}\n"
+            f"fix: pass one of the closed vocabulary — {valid}\n"
+            f"run: python3 scripts/checks/rules.py --list-tasks"
+        )
+    entries = _entries_for_task(task)
+    lines: list[str] = [f"=== Paved road for task: {task} ==="]
+    if not entries:
+        lines.append("(no rules tagged with this task yet)")
+        return "\n".join(lines)
+    lines.append(f"{len(entries)} rule(s) govern this task — follow each exemplar:")
+    lines.append("")
+    for entry in entries:
+        lines.append(f"{entry.id}  {entry.summary}")
+        exemplar = entry.exemplar if entry.exemplar else "(no curated exemplar — read the rule's remediation)"
+        lines.append(f"  copy: {exemplar}")
+        lines.append(f"  run:  {_run_command(entry)}")
+        lines.append("")
+    lines.append("next: read each `copy:` file, mirror its shape, then run each `run:` command.")
+    return "\n".join(lines)
+
+
+def render_rule(rule_id: str) -> str:
+    """The ``--rule`` view: one rule's summary, exemplar, task tags, and
+    remediation command."""
+    entry = _entry_by_id(rule_id)
+    if entry is None:
+        return (
+            f"unknown rule id: {rule_id!r}\n"
+            f"fix: pass a real catalogue id (e.g. F46) — see scripts/checks/_rule_catalogue.py\n"
+            f"run: python3 scripts/checks/rules.py --list-tasks"
+        )
+    lines: list[str] = [f"=== {entry.id} ==="]
+    lines.append(f"summary:   {entry.summary}")
+    exemplar = entry.exemplar if entry.exemplar else "(none — no curated exemplar for this rule)"
+    lines.append(f"exemplar:  {exemplar}")
+    tasks = ", ".join(entry.task_type) if entry.task_type else "(none)"
+    lines.append(f"tasks:     {tasks}")
+    lines.append(f"category:  {entry.category}")
+    lines.append(f"status:    {entry.status}")
+    lines.append("")
+    if entry.exemplar:
+        lines.append("fix:  copy the pattern in the exemplar file named above")
+    else:
+        lines.append("fix:  follow the rule summary above; this rule has no curated exemplar yet")
+    lines.append("run:  " + _run_command(entry))
+    return "\n".join(lines)
+
+
+def render_list_tasks() -> str:
+    """The ``--list-tasks`` view: the closed task vocabulary with a
+    per-task rule count."""
+    lines: list[str] = ["=== Paved-road task types (closed vocabulary) ==="]
+    lines.append("Each task names a thing an agent BUILDS; the count is how many")
+    lines.append("rules judge that task. Query one with --task <name>.")
+    lines.append("")
+    for task in TASK_TYPES:
+        count = len(_entries_for_task(task))
+        lines.append(f"  {task:24} {count} rule(s)")
+    lines.append("")
+    lines.append("run: python3 scripts/checks/rules.py --task <name>")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse the query mode and print the corresponding view."""
+    parser = argparse.ArgumentParser(
+        prog="rules.py",
+        description="Paved-road query surface for the fitness catalogue (#499 Phase 2).",
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--task", metavar="TASK", help="list rules governing a task-type (e.g. adding-a-connector)")
+    group.add_argument("--rule", metavar="ID", help="show one rule's summary, exemplar, tasks, remediation")
+    group.add_argument("--list-tasks", action="store_true", help="list the task-type vocabulary with rule counts")
+    args = parser.parse_args(argv)
+
+    if args.list_tasks:
+        print(render_list_tasks())
+        return 0
+    if args.task is not None:
+        out = render_task(args.task)
+        print(out)
+        return 0 if not out.startswith("unknown task-type") else 2
+    out = render_rule(args.rule)
+    print(out)
+    return 0 if not out.startswith("unknown rule id") else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/checks/run_checks.py
+++ b/scripts/checks/run_checks.py
@@ -207,6 +207,12 @@ def _run_one(entry: RuleEntry, *, skip_coverage: bool) -> int | None:
         print(f"{_GREEN}PASS [{entry.id}]{_RESET} {entry.summary[:88]}")
         return 0
     print(f"{_RED}FAIL [{entry.id}]{_RESET} {entry.summary[:88]} (exit {rc})")
+    # Paved-road footer (#499 Phase 2): when a FAILING rule carries a
+    # curated exemplar, point the agent straight at the query surface
+    # that surfaces it. Only the existing FAIL verdict line is the F83
+    # named verdict; this is an ADDED affordance line, not a replacement.
+    if entry.exemplar:
+        print(f"  paved-road: python3 scripts/checks/rules.py --rule {entry.id}")
     return 1
 
 

--- a/tests/architecture/test_rules_query.py
+++ b/tests/architecture/test_rules_query.py
@@ -1,0 +1,224 @@
+"""Unit tests for the paved-road query surface (#499 Phase 2).
+
+Covers three pieces of the catalogue-driven paved road:
+
+  1. ``RuleEntry`` round-trips the two new optional fields
+     (``exemplar`` + ``task_type``).
+  2. Every ``task_type`` tag used anywhere in the catalogue is a member
+     of the closed :data:`TASK_TYPES` vocabulary — the typo guard that
+     keeps the query surface honest forever.
+  3. ``scripts/checks/rules.py`` filters by ``--task`` and surfaces a
+     rule's exemplar via ``--rule``.
+  4. ``scripts/checks/run_checks.py`` prints the ``paved-road:`` footer
+     for a FAILING rule that carries an exemplar, and omits it for a
+     failing rule that does not.
+
+Surface discipline: items 1-3 drive the public catalogue helpers and
+the ``rules.py`` render functions / ``main``. Item 4 drives the runner's
+per-rule output-contract function ``_run_one`` — the documented "Output
+contract (F83)" boundary in ``run_checks.py`` — against REAL throwaway
+check scripts (a real subprocess, no monkeypatch, no production-behaviour
+mutation). The footer branch is only reachable when a check actually
+exits non-zero, so the test stages a script that does exactly that.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_CHECKS_DIR = _REPO_ROOT / "scripts" / "checks"
+sys.path.insert(0, str(_CHECKS_DIR))
+
+import rules  # noqa: E402
+import run_checks  # noqa: E402
+from _rule_catalogue import ALL_ENTRIES, TASK_TYPES, RuleEntry  # noqa: E402
+
+# ── 1. RuleEntry round-trips the new optional fields ───────────────────
+
+
+def test_rule_entry_round_trips_exemplar_and_task_type() -> None:
+    """A constructed ``RuleEntry`` preserves ``exemplar`` and
+    ``task_type`` exactly, and defaults them when omitted."""
+    explicit = RuleEntry(
+        id="FX",
+        gate="fx",
+        check="fx",
+        category="test-discipline",
+        scope="per-file",
+        summary="example rule",
+        exemplar="tests/example/test_example.py",
+        task_type=("writing-a-test", "adding-a-connector"),
+    )
+    assert explicit.exemplar == "tests/example/test_example.py"
+    assert explicit.task_type == ("writing-a-test", "adding-a-connector")
+
+    defaulted = RuleEntry(
+        id="FY",
+        gate="fy",
+        check="fy",
+        category="test-discipline",
+        scope="per-file",
+        summary="example rule with no paved-road metadata",
+    )
+    assert defaulted.exemplar is None
+    assert defaulted.task_type == ()
+
+
+# ── 2. every task_type tag is in the closed vocabulary ─────────────────
+
+
+def test_every_catalogue_task_type_is_in_the_closed_vocabulary() -> None:
+    """No catalogue entry may tag a task-type outside :data:`TASK_TYPES`.
+
+    This is the typo guard: a misspelled tag (``writing-a-tset``) would
+    silently make ``rules.py --task writing-a-test`` miss the rule. The
+    closed vocabulary plus this assertion makes that impossible.
+    """
+    vocab = set(TASK_TYPES)
+    offenders: list[tuple[str, str]] = []
+    for entry in ALL_ENTRIES:
+        for tag in entry.task_type:
+            if tag not in vocab:
+                offenders.append((entry.id, tag))
+    assert not offenders, (
+        f"catalogue entries tag a task-type outside TASK_TYPES: {offenders!r}. "
+        f"Use one of {sorted(vocab)!r}, or add the new task to TASK_TYPES first."
+    )
+
+
+def test_at_least_one_rule_is_tagged_per_used_task() -> None:
+    """The high-traffic backfill is real: at least the connector-build
+    and test-writing tasks resolve to rules (guards an empty backfill)."""
+    connector_rules = [e for e in ALL_ENTRIES if "adding-a-connector" in e.task_type]
+    test_rules = [e for e in ALL_ENTRIES if "writing-a-test" in e.task_type]
+    assert connector_rules, "no rule tagged adding-a-connector — backfill missing"
+    assert test_rules, "no rule tagged writing-a-test — backfill missing"
+
+
+# ── 3. rules.py query surface ──────────────────────────────────────────
+
+
+def test_rules_task_lists_only_rules_tagged_with_that_task() -> None:
+    """``rules.py --task <t>`` lists exactly the rules tagged ``t`` — and
+    none tagged with a different task."""
+    out = rules.render_task("adding-a-connector")
+    tagged = [e for e in ALL_ENTRIES if "adding-a-connector" in e.task_type]
+    untagged_only = [
+        e for e in ALL_ENTRIES if "adding-a-feature-flag" in e.task_type and "adding-a-connector" not in e.task_type
+    ]
+    assert tagged, "fixture precondition: expected at least one connector rule"
+    for entry in tagged:
+        assert entry.id in out, f"{entry.id} (tagged adding-a-connector) missing from --task output"
+    for entry in untagged_only:
+        assert entry.id not in out, f"{entry.id} (NOT a connector rule) leaked into --task adding-a-connector"
+
+
+def test_rules_task_rejects_unknown_task() -> None:
+    """An unknown task-type yields an actionable error, not a crash or a
+    silent empty listing."""
+    out = rules.render_task("not-a-real-task")
+    assert out.startswith("unknown task-type")
+    assert "--list-tasks" in out
+
+
+def test_rules_rule_shows_the_exemplar() -> None:
+    """``rules.py --rule <Fid>`` surfaces that rule's curated exemplar
+    path so an agent knows which file to copy."""
+    out = rules.render_rule("F46")
+    entry = next(e for e in ALL_ENTRIES if e.id == "F46")
+    assert entry.exemplar is not None, "fixture precondition: F46 should carry an exemplar"
+    assert entry.exemplar in out
+    assert "F46" in out
+
+
+def test_rules_rule_rejects_unknown_id() -> None:
+    """An unknown rule id yields an actionable error."""
+    out = rules.render_rule("F9999")
+    assert out.startswith("unknown rule id")
+
+
+def test_rules_list_tasks_covers_the_whole_vocabulary() -> None:
+    """``--list-tasks`` names every member of the closed vocabulary."""
+    out = rules.render_list_tasks()
+    for task in TASK_TYPES:
+        assert task in out, f"task {task!r} missing from --list-tasks output"
+
+
+def test_rules_main_requires_a_mode() -> None:
+    """Calling ``rules.py`` with no mode flag is a usage error (argparse
+    exits non-zero) — the surface never runs an undefined query."""
+    with pytest.raises(SystemExit) as excinfo:
+        rules.main([])
+    assert excinfo.value.code != 0
+
+
+# ── 4. run_checks.py paved-road footer ─────────────────────────────────
+
+
+def _failing_check_script(tmp_path: Path, name: str) -> Path:
+    """Stage a real check script under ``scripts/checks/`` that exits
+    non-zero. Returned for cleanup by the caller. ``tmp_path`` only
+    keys the unique name so parallel tests don't collide."""
+    script = _CHECKS_DIR / name
+    script.write_text("import sys\nsys.exit(1)\n", encoding="utf-8")
+    return script
+
+
+def _run_one_capture(entry: RuleEntry) -> str:
+    """Dispatch ``entry`` through the runner's per-rule output-contract
+    function and capture everything it prints."""
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        run_checks._run_one(entry, skip_coverage=True)
+    return buffer.getvalue()
+
+
+def test_footer_present_for_failing_rule_with_exemplar(tmp_path: Path) -> None:
+    """A FAILING rule that carries an exemplar prints the ``paved-road:``
+    footer pointing at ``rules.py --rule <id>``."""
+    name = "check__pavedroad_fail_with_exemplar.py"
+    script = _failing_check_script(tmp_path, name)
+    try:
+        entry = RuleEntry(
+            id="FXFAIL",
+            gate="fxfail",
+            check="_pavedroad_fail_with_exemplar",
+            category="test-discipline",
+            scope="per-file",
+            summary="synthetic failing rule with an exemplar",
+            exemplar="tests/example/test_example.py",
+        )
+        out = _run_one_capture(entry)
+        assert "FAIL [FXFAIL]" in out
+        assert "paved-road: python3 scripts/checks/rules.py --rule FXFAIL" in out
+    finally:
+        script.unlink()
+
+
+def test_footer_absent_for_failing_rule_without_exemplar(tmp_path: Path) -> None:
+    """A FAILING rule with NO exemplar prints its verdict but NO
+    ``paved-road:`` footer — the footer is opt-in via the exemplar."""
+    name = "check__pavedroad_fail_no_exemplar.py"
+    script = _failing_check_script(tmp_path, name)
+    try:
+        entry = RuleEntry(
+            id="FXBARE",
+            gate="fxbare",
+            check="_pavedroad_fail_no_exemplar",
+            category="test-discipline",
+            scope="per-file",
+            summary="synthetic failing rule with no exemplar",
+        )
+        out = _run_one_capture(entry)
+        assert "FAIL [FXBARE]" in out
+        assert "paved-road:" not in out
+    finally:
+        script.unlink()


### PR DESCRIPTION
First of the #499 Phase 2 simplifications — the **agent-affordance** one.

Makes the fitness catalogue answer *"what pattern do I follow for task X?"* BEFORE an agent writes code, and links failing gates back to the exemplar.

## What
- Two **optional** `RuleEntry` fields (`exemplar`, `task_type`), defaulted so all ~90 rows + every F-id/baseline/F92 invariant stay byte-untouched. `task_type` is validated against a closed 10-member vocabulary (a test guards typos forever).
- Backfilled the 18 high-traffic rules (F30/F45/F46/F47/F48/F39/F34/F35/F36/F40/F41/F54/F84/F87/F88/F13/F12/F8) with real passing-file exemplars.
- `scripts/checks/rules.py` — query CLI: `--task <type>`, `--rule <Fid>`, `--list-tasks` (tooling, not a kairix.cli subcommand — F45/F30 N/A).
- Paved-road footer (kairix-local, in `run_checks.py`, **not** the shared `tc_fitness`): a failing rule with an exemplar prints `paved-road: python3 scripts/checks/rules.py --rule <Fid>`.

## Verification
- 88/88 fitness functions pass under venv; **F92 green with no doc regen needed** (metadata not surfaced in published regions).
- 11 new tests, **every one sabotage-proven** (mutate→fail→restore, executed). Full `safe-commit.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)