### PR TITLE
refactor(fitness): nine boundary rules → two declarative table engines (#499 Phase 2)

### DIFF
--- a/scripts/checks/_import_boundary_engine.py
+++ b/scripts/checks/_import_boundary_engine.py
@@ -106,12 +106,30 @@ def _parse(path: Path) -> ast.AST | None:
         return None
 
 
-def _import_modules(tree: ast.AST) -> list[str]:
+def _import_modules(tree: ast.AST, *, skip_relative: bool = False) -> list[str]:
     """Every dotted module name referenced by an ``import`` / ``from ... import``.
 
     ``import a.b.c`` → ``"a.b.c"``; ``from a.b.c import x`` → ``"a.b.c"``.
-    Relative imports (``from . import x``, ``module is None``) are skipped —
-    they cannot reach a forbidden absolute target by construction.
+
+    ``skip_relative`` selects the ``ImportFrom.level`` policy, which MUST match
+    each original detector byte-for-behaviour (#499 Phase 2 faithfulness fix):
+
+    * ``False`` (default) — yield ``node.module`` for EVERY ``ImportFrom``,
+      regardless of ``node.level``. This is what the F26/F27/F34/F35/F44
+      originals did: their ``file_has_violation`` / ``_imported_names`` /
+      ``_plugin_dir_for`` walkers inspect ``node.module`` directly with no
+      ``node.level`` guard, so a relative import whose ``.module`` matches a
+      forbidden prefix / sibling plugin (``from .kairix.providers import x`` →
+      level=1, module=``kairix.providers``; ``from ..psycopg2 import bar`` →
+      level=2, module=``psycopg2``) IS flagged. Skipping ``node.level > 0``
+      here silently dropped those — the divergence this fix closes.
+    * ``True`` — skip any ``ImportFrom`` with ``node.level > 0``. This matches
+      the F37 original ``_import_targets``, which alone guards ``node.level``
+      (a relative import cannot reach a third-party sync library by
+      construction, so it is correctly ignored there).
+
+    ``module is None`` (``from . import x``) is always skipped — there is no
+    dotted target to match either way.
     """
     out: list[str] = []
     for node in ast.walk(tree):
@@ -120,7 +138,7 @@ def _import_modules(tree: ast.AST) -> list[str]:
                 if alias.name:
                     out.append(alias.name)
         elif isinstance(node, ast.ImportFrom):
-            if node.level and node.level > 0:
+            if skip_relative and node.level and node.level > 0:
                 continue
             if node.module:
                 out.append(node.module)
@@ -240,7 +258,13 @@ def _repo_relative(path: Path, root: Path) -> Path | None:
 
 def _file_violates(rule: ImportBoundaryRule, path: Path, rel: Path) -> bool:
     """Apply ``rule``'s mode discriminator to the file at ``path`` (repo-relative
-    ``rel``). Returns True when the file violates the rule."""
+    ``rel``). Returns True when the file violates the rule.
+
+    The ``prefix`` (F26/F34/F44) and ``sibling-plugin`` (F27/F35) modes use the
+    level-AGNOSTIC ``_import_modules`` (default ``skip_relative=False``) because
+    their originals inspected ``ImportFrom.module`` with no ``node.level`` guard.
+    The ``sync-lib`` mode (F37) passes ``skip_relative=True`` to match its
+    original ``_import_targets``, the one detector that guards ``node.level``."""
     if rule.mode == "prefix":
         if any(_under_prefix(rel, ex) or str(rel) == ex for ex in rule.exempt):
             return False
@@ -265,7 +289,8 @@ def _file_violates(rule: ImportBoundaryRule, path: Path, rel: Path) -> bool:
     tree = _parse(path)
     if tree is None:
         return False
-    if not any(_is_sync_lib_import(m, rule.forbidden_prefixes) for m in _import_modules(tree)):
+    modules = _import_modules(tree, skip_relative=True)
+    if not any(_is_sync_lib_import(m, rule.forbidden_prefixes) for m in modules):
         return False
     return not any(_under_prefix(rel, allowed) for allowed in rule.allowed_roots)
 

--- a/scripts/checks/_import_boundary_engine.py
+++ b/scripts/checks/_import_boundary_engine.py
@@ -1,0 +1,306 @@
+"""Declarative table engine for the import-boundary fitness rules.
+
+Five rules (F26, F27, F34, F35, F44) and an inverse sixth (F37) all
+AST-walk ``Import`` / ``ImportFrom`` nodes and gate on the module target.
+Before #499 Phase 2 each shipped its own ~150-line ``check_*.py`` that
+re-implemented the same walk with bespoke constants. This engine collapses
+that into one row schema + one walker; each ``check_*.py`` is now a thin
+shim that looks its row up by ``name`` and re-exports the back-compat
+surface the per-rule unit tests call.
+
+The :class:`ImportBoundaryRule` row is the single point of variation. Its
+``mode`` discriminator selects one of three detection shapes:
+
+* ``"prefix"`` — flag any import whose target equals or is dotted-under a
+  forbidden prefix (F26, F34, F44). ``exempt`` carries the composition-root
+  allowlist (F26's ``kairix/core/factory.py``).
+
+* ``"sibling-plugin"`` — infer the plugin directory that owns the file
+  (first path segment under ``roots[0]``) and flag any import that reaches a
+  *different* plugin under the same tree. Underscore-prefixed heads (``_base``)
+  are shared scaffolding, never cross-plugin. F35 additionally ORs the
+  ``forbidden_prefixes`` predicate (any ``kairix.extractors`` reach).
+
+* ``"sync-lib"`` — inverse. Flag any file that imports a third-party
+  change-detection library (``forbidden_prefixes`` here are import-name roots
+  like ``watchdog``) UNLESS the file lives under one of ``allowed_roots``.
+  ``slack_sdk`` additionally requires an rtm / socket_mode submodule tail.
+
+``collect_violations_for(rule, root)`` walks the in-scope tree and returns a
+set of repo-relative :class:`~pathlib.Path` objects — the exact shape the old
+free ``collect_violations`` functions returned, so the per-rule unit tests
+(which load the shim by file path and call ``collect_violations(tmp_path)``)
+pass unchanged.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+sys.path.insert(0, str(Path(__file__).parent))
+from tc_fitness import REPO_ROOT
+
+Mode = Literal["prefix", "sibling-plugin", "sync-lib"]
+
+# slack_sdk submodule tails that mark its real-time / socket-mode change
+# detection surfaces. The bare SDK (slack_sdk.web) is a one-shot HTTP client
+# and is NOT a sync loop, so it is not flagged.
+_SLACK_ROOT = "slack_sdk"
+_SLACK_SYNC_TAILS: frozenset[str] = frozenset({"rtm", "socket_mode"})
+
+
+@dataclass(frozen=True)
+class ImportBoundaryRule:
+    """One import-boundary rule, expressed declaratively.
+
+    Fields:
+        name: gate / baseline key (e.g. ``"f26"`` →
+            ``.architecture/baseline/f26-files.txt``).
+        roots: repo-relative directory prefixes to scan (from-globs). For
+            ``sibling-plugin`` mode, ``roots[0]`` is the plugin-tree root used
+            to infer the owning plugin.
+        mode: detection discriminator — ``"prefix"`` / ``"sibling-plugin"`` /
+            ``"sync-lib"``.
+        forbidden_prefixes: for ``prefix`` mode, the denied module prefixes;
+            for ``sibling-plugin`` mode, an EXTRA forbidden-prefix predicate
+            ORed onto the sibling check (F35's extractor ban); for
+            ``sync-lib`` mode, the import-name roots that mark a sync library.
+        exempt: repo-relative path globs whose files are never flagged
+            (F26's composition root).
+        allowed_roots: for ``sync-lib`` mode, the directory prefixes under
+            which a forbidden import is permitted.
+        remediation: F21-compliant fix/next/run remediation text.
+    """
+
+    name: str
+    roots: tuple[str, ...]
+    mode: Mode
+    remediation: str
+    forbidden_prefixes: tuple[str, ...] = ()
+    exempt: tuple[str, ...] = ()
+    allowed_roots: tuple[str, ...] = ()
+    extra_forbidden_prefixes: tuple[str, ...] = field(default_factory=tuple)
+
+
+# ── shared AST helpers ──────────────────────────────────────────────────
+
+
+def _parse(path: Path) -> ast.AST | None:
+    """Parse ``path`` to an AST, or return ``None`` on any read / syntax error.
+
+    Mirrors the original detectors' tolerant behaviour: an unreadable or
+    syntactically-broken file is simply not flagged (the broken file fails
+    its own lint / type gate elsewhere).
+    """
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    try:
+        return ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return None
+
+
+def _import_modules(tree: ast.AST) -> list[str]:
+    """Every dotted module name referenced by an ``import`` / ``from ... import``.
+
+    ``import a.b.c`` → ``"a.b.c"``; ``from a.b.c import x`` → ``"a.b.c"``.
+    Relative imports (``from . import x``, ``module is None``) are skipped —
+    they cannot reach a forbidden absolute target by construction.
+    """
+    out: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name:
+                    out.append(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level and node.level > 0:
+                continue
+            if node.module:
+                out.append(node.module)
+    return out
+
+
+def _prefix_match(module: str, prefix: str) -> bool:
+    """True if ``module`` equals ``prefix`` or starts with ``prefix + "."``.
+
+    The trailing-dot anchor stops ``kairix.providers_helpers`` from matching
+    the ``kairix.providers`` prefix.
+    """
+    return module == prefix or module.startswith(prefix + ".")
+
+
+def _under_prefix(rel: Path, prefix: str) -> bool:
+    """True if repo-relative ``rel`` sits under directory ``prefix``."""
+    prefix_parts = Path(prefix).parts
+    parts = rel.parts
+    return len(parts) >= len(prefix_parts) and tuple(parts[: len(prefix_parts)]) == prefix_parts
+
+
+# ── mode: prefix ─────────────────────────────────────────────────────────
+
+
+def _file_has_forbidden_prefix(tree: ast.AST, forbidden: tuple[str, ...]) -> bool:
+    """True if any import in ``tree`` targets one of the ``forbidden`` prefixes."""
+    for module in _import_modules(tree):
+        if any(_prefix_match(module, prefix) for prefix in forbidden):
+            return True
+    return False
+
+
+# ── mode: sibling-plugin ─────────────────────────────────────────────────
+
+
+def _owning_plugin(rel: Path, plugin_root: str) -> str | None:
+    """The plugin directory name owning ``rel`` (first segment under
+    ``plugin_root``), or ``None`` if ``rel`` sits at the top level of the
+    plugin tree (so isn't part of any plugin).
+    """
+    root_parts = Path(plugin_root).parts
+    parts = rel.parts
+    if len(parts) < len(root_parts) + 2:
+        # No path segment between <plugin_root> and the filename → top-level
+        # scaffolding (e.g. _base.py, __init__.py), not inside a plugin.
+        return None
+    if tuple(parts[: len(root_parts)]) != root_parts:
+        return None
+    return parts[len(root_parts)]
+
+
+def _is_cross_plugin(module: str, owning: str, plugin_root: str) -> bool:
+    """True if ``module`` reaches a sibling plugin under ``plugin_root`` other
+    than ``owning``.
+
+    ``<plugin_root-as-dotted>._base`` and the package itself are shared
+    scaffolding — never cross-plugin.
+    """
+    dotted = ".".join(Path(plugin_root).parts) + "."
+    if not module.startswith(dotted):
+        return False
+    head = module[len(dotted) :].split(".", 1)[0]
+    if not head or head.startswith("_"):
+        return False
+    return head != owning
+
+
+# ── mode: sync-lib ───────────────────────────────────────────────────────
+
+
+def _is_sync_lib_import(module: str, sync_roots: tuple[str, ...]) -> bool:
+    """True if ``module`` references a change-detection library.
+
+    The first dotted segment must be in ``sync_roots``. ``slack_sdk``
+    additionally requires an rtm / socket_mode submodule tail so the one-shot
+    Web API surface is not flagged.
+    """
+    parts = module.split(".")
+    if not parts:
+        return False
+    root = parts[0]
+    if root not in sync_roots:
+        return False
+    if root == _SLACK_ROOT:
+        return any(tail in parts[1:] for tail in _SLACK_SYNC_TAILS)
+    return True
+
+
+# ── enumeration + dispatch ───────────────────────────────────────────────
+
+
+def _iter_python_files(root: Path, rel_roots: tuple[str, ...]) -> list[Path]:
+    """Every ``.py`` file under each of ``rel_roots`` (relative to ``root``),
+    skipping ``__pycache__``.
+    """
+    out: list[Path] = []
+    for rel_root in rel_roots:
+        base = root / rel_root
+        if not base.exists():
+            continue
+        for path in base.rglob("*.py"):
+            if "__pycache__" in path.parts:
+                continue
+            out.append(path)
+    return out
+
+
+def _repo_relative(path: Path, root: Path) -> Path | None:
+    """Resolve ``path`` to a repo-relative Path under ``root``, or ``None`` if
+    it escapes the root."""
+    try:
+        return path.resolve().relative_to(root.resolve())
+    except ValueError:
+        return None
+
+
+def _file_violates(rule: ImportBoundaryRule, path: Path, rel: Path) -> bool:
+    """Apply ``rule``'s mode discriminator to the file at ``path`` (repo-relative
+    ``rel``). Returns True when the file violates the rule."""
+    if rule.mode == "prefix":
+        if any(_under_prefix(rel, ex) or str(rel) == ex for ex in rule.exempt):
+            return False
+        tree = _parse(path)
+        return tree is not None and _file_has_forbidden_prefix(tree, rule.forbidden_prefixes)
+
+    if rule.mode == "sibling-plugin":
+        owning = _owning_plugin(rel, rule.roots[0])
+        if owning is None or owning.startswith("_"):
+            return False
+        tree = _parse(path)
+        if tree is None:
+            return False
+        for module in _import_modules(tree):
+            if _is_cross_plugin(module, owning, rule.roots[0]):
+                return True
+            if any(_prefix_match(module, prefix) for prefix in rule.extra_forbidden_prefixes):
+                return True
+        return False
+
+    # mode == "sync-lib"
+    tree = _parse(path)
+    if tree is None:
+        return False
+    if not any(_is_sync_lib_import(m, rule.forbidden_prefixes) for m in _import_modules(tree)):
+        return False
+    return not any(_under_prefix(rel, allowed) for allowed in rule.allowed_roots)
+
+
+def collect_violations_for(rule: ImportBoundaryRule, root: Path = REPO_ROOT) -> set[Path]:
+    """Walk ``rule``'s in-scope tree under ``root`` and return the set of
+    repo-relative paths that violate the rule.
+    """
+    violations: set[Path] = set()
+    for path in _iter_python_files(root, rule.roots):
+        rel = _repo_relative(path, root)
+        if rel is None:
+            continue
+        if _file_violates(rule, path, rel):
+            violations.add(rel)
+    return violations
+
+
+# ── the rule table ───────────────────────────────────────────────────────
+#
+# Remediation text is the one piece of per-rule prose the unit tests read
+# back (``detector.REMEDIATION``). It is authored in each shim and injected
+# here via :func:`register`, keeping the engine remediation-agnostic while
+# the table stays the single lookup surface.
+
+_RULES: dict[str, ImportBoundaryRule] = {}
+
+
+def register(rule: ImportBoundaryRule) -> ImportBoundaryRule:
+    """Register ``rule`` in the engine table keyed by ``rule.name`` and return
+    it (so a shim can ``RULE = register(ImportBoundaryRule(...))``)."""
+    _RULES[rule.name] = rule
+    return rule
+
+
+def rule_for(name: str) -> ImportBoundaryRule:
+    """Return the registered :class:`ImportBoundaryRule` named ``name``."""
+    return _RULES[name]

--- a/scripts/checks/_location_engine.py
+++ b/scripts/checks/_location_engine.py
@@ -1,0 +1,226 @@
+"""Declarative table engine for the location / singleton fitness rules.
+
+Three rules (F29, F38, F61) all walk ``kairix/**`` and flag a file whose
+*shape* — its filename, a ``def`` name it contains, or a constructor call it
+makes — appears outside an allowed set of roots. Before #499 Phase 2 each
+shipped its own ~150-line ``check_*.py`` re-implementing the same
+walk-and-gate skeleton. This engine collapses that into one row schema + one
+walker; each ``check_*.py`` becomes a thin shim that looks its row up and
+re-exports the back-compat surface its unit tests call.
+
+The :class:`LocationRule` row is the single point of variation. Its ``kind``
+discriminator selects one of three detection shapes:
+
+* ``"filename-regex"`` — flag a file whose *basename* matches ``pattern``
+  (F29's bench / latency / perf naming). F29 additionally permits
+  ``scripts/probe*.{py,sh}`` operational drivers; that special allowance is
+  carried by the ``probe_scripts`` flag.
+
+* ``"def-name"`` — AST-walk and flag a file defining at least one ``def`` /
+  ``async def`` whose name matches ``pattern`` (F38's chunk_* / _chunk* /
+  tokenize_into_chunks). ``allowed_files`` carries the single-file exemption
+  (``kairix/core/connectors/silver.py``).
+
+* ``"ctor-call"`` — AST-walk and flag a file making a bare ``pattern(...)``
+  constructor call by ``ast.Name`` (F61's ``_SqliteChunkWriter(...)``).
+  Attribute-form ``mod.X(...)`` is intentionally out of scope (covered by the
+  import-boundary rules).
+
+Every rule's scan is scoped to ``root/kairix`` — matching the original free
+``collect_violations`` functions, which walked ``kairix/`` only even though a
+few allow-list entries (``tests/``, ``scripts/probe*``) name trees outside it.
+Those entries stay in the allow-list for completeness but never fire because
+the walk never reaches them.
+
+``collect_violations_for(rule, root)`` returns a set of repo-relative
+:class:`~pathlib.Path` objects — the exact shape the old detectors returned,
+so the per-rule unit tests pass unchanged.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+sys.path.insert(0, str(Path(__file__).parent))
+from tc_fitness import REPO_ROOT
+
+Kind = Literal["filename-regex", "def-name", "ctor-call"]
+
+# scripts/probe*.{py,sh} operational drivers — F29's one allow-list entry
+# outside the prefix list. Compiled once, consulted only by F29.
+_PROBE_SCRIPT_RE = re.compile(r"^probe[a-z0-9_-]*\.(py|sh)$")
+
+
+@dataclass(frozen=True)
+class LocationRule:
+    """One location / singleton rule, expressed declaratively.
+
+    Fields:
+        name: gate / baseline key (e.g. ``"f29"`` →
+            ``.architecture/baseline/f29-files.txt``).
+        kind: detection discriminator — ``"filename-regex"`` / ``"def-name"``
+            / ``"ctor-call"``.
+        pattern: compiled regex (filename / def-name kinds) or the literal
+            constructor name (ctor-call kind).
+        allowed_roots: repo-relative directory prefixes under which the shape
+            is permitted.
+        remediation: F21-compliant fix/next/run remediation text.
+        allowed_files: repo-relative file paths (not prefixes) that are
+            exempt — F38's single ``silver.py`` home.
+        probe_scripts: F29's extra ``scripts/probe*`` allowance.
+    """
+
+    name: str
+    kind: Kind
+    pattern: re.Pattern[str] | str
+    allowed_roots: tuple[str, ...]
+    remediation: str
+    allowed_files: tuple[str, ...] = field(default_factory=tuple)
+    probe_scripts: bool = False
+
+
+# ── shape detectors (one per kind) ───────────────────────────────────────
+
+
+def _matches_filename(rule: LocationRule, path: Path) -> bool:
+    """``filename-regex`` kind: True if ``path``'s basename matches the pattern."""
+    assert isinstance(rule.pattern, re.Pattern)
+    return rule.pattern.match(path.name) is not None
+
+
+def _parse(path: Path) -> ast.AST | None:
+    """Parse ``path`` to an AST, or ``None`` on read / syntax error."""
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    try:
+        return ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return None
+
+
+def _defines_matching_function(rule: LocationRule, path: Path) -> bool:
+    """``def-name`` kind: True if ``path`` defines a function (sync or async,
+    module-level or nested) whose name matches the pattern."""
+    assert isinstance(rule.pattern, re.Pattern)
+    tree = _parse(path)
+    if tree is None:
+        return False
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and rule.pattern.match(node.name):
+            return True
+    return False
+
+
+def _constructs_matching_call(rule: LocationRule, path: Path) -> bool:
+    """``ctor-call`` kind: True if ``path`` makes a bare ``pattern(...)``
+    constructor call (an ``ast.Call`` whose ``func`` is an ``ast.Name`` equal
+    to the pattern). A cheap substring pre-filter skips the AST parse when the
+    name isn't even mentioned."""
+    assert isinstance(rule.pattern, str)
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return False
+    if rule.pattern not in source:
+        return False
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == rule.pattern:
+            return True
+    return False
+
+
+_SHAPE_DETECTORS = {
+    "filename-regex": _matches_filename,
+    "def-name": _defines_matching_function,
+    "ctor-call": _constructs_matching_call,
+}
+
+
+# ── allow-list ───────────────────────────────────────────────────────────
+
+
+def _under_prefix(rel: Path, prefix: str) -> bool:
+    """True if repo-relative ``rel`` sits under directory ``prefix``."""
+    prefix_parts = Path(prefix).parts
+    parts = rel.parts
+    return len(parts) >= len(prefix_parts) and tuple(parts[: len(prefix_parts)]) == prefix_parts
+
+
+def _is_allowed(rule: LocationRule, rel: Path) -> bool:
+    """True if a flagged-shape file at repo-relative ``rel`` is permitted by
+    ``rule``'s allow-list (a prefix root, an exact file, or — for F29 — a
+    ``scripts/probe*`` driver)."""
+    if str(rel) in rule.allowed_files:
+        return True
+    if any(_under_prefix(rel, prefix) for prefix in rule.allowed_roots):
+        return True
+    if rule.probe_scripts:
+        parts = rel.parts
+        if len(parts) >= 2 and parts[0] == "scripts" and _PROBE_SCRIPT_RE.match(parts[-1]):
+            return True
+    return False
+
+
+# ── enumeration + dispatch ───────────────────────────────────────────────
+
+
+def collect_violations_for(rule: LocationRule, root: Path = REPO_ROOT) -> set[Path]:
+    """Walk every ``.py`` file under ``root/kairix`` and return the set of
+    repo-relative paths whose shape matches ``rule`` AND that live outside the
+    allow-list.
+
+    Scoped to ``kairix/`` — the production package — exactly as the original
+    detectors were. Files under ``tests/`` are out of scope by construction
+    (never reached by the walk).
+    """
+    kairix_dir = root / "kairix"
+    if not kairix_dir.exists():
+        return set()
+
+    detector = _SHAPE_DETECTORS[rule.kind]
+    violations: set[Path] = set()
+    for path in kairix_dir.rglob("*.py"):
+        if "__pycache__" in path.parts:
+            continue
+        if not detector(rule, path):
+            continue
+        try:
+            rel = path.resolve().relative_to(root.resolve())
+        except ValueError:
+            continue
+        if _is_allowed(rule, rel):
+            continue
+        violations.add(rel)
+    return violations
+
+
+# ── the rule table ───────────────────────────────────────────────────────
+#
+# Remediation text is authored in each shim (the unit tests read it back via
+# ``detector.REMEDIATION``) and injected here via :func:`register`, keeping
+# the engine remediation-agnostic while the table stays the single lookup
+# surface.
+
+_RULES: dict[str, LocationRule] = {}
+
+
+def register(rule: LocationRule) -> LocationRule:
+    """Register ``rule`` keyed by ``rule.name`` and return it."""
+    _RULES[rule.name] = rule
+    return rule
+
+
+def rule_for(name: str) -> LocationRule:
+    """Return the registered :class:`LocationRule` named ``name``."""
+    return _RULES[name]

--- a/scripts/checks/check_f34_core_connector_layer_imports.py
+++ b/scripts/checks/check_f34_core_connector_layer_imports.py
@@ -1,53 +1,24 @@
-"""F34: ``kairix/core/connectors/**`` may not import ``kairix/connectors/**`` or
-``kairix/extractors/**``.
+"""F34: ``kairix/core/connectors/**`` may not import ``kairix/connectors/**``
+or ``kairix/extractors/**``.
 
-The connector-framework layer split (see
-``docs/architecture/connector-ingestion-architecture.md`` §2 + §3) places a
-hard boundary between the orchestration layer (``kairix/core/connectors/``),
-the per-source connector plugins (``kairix/connectors/``), and the per-format
-extractor plugins (``kairix/extractors/``). The orchestration layer knows
-about Protocols, not implementations — Protocols live in
-``kairix/core/protocols.py``.
+The orchestration layer knows about Protocols (``kairix/core/protocols.py``),
+not the per-source connector plugins or per-format extractor plugins. Mirrors
+the F26 prefix shape exactly.
 
-Allowed from ``kairix/core/connectors/``:
-  - ``from kairix.core.protocols import ...`` (Protocol types — the seam
-    between layers).
-  - sibling ``kairix.core.*`` imports.
-  - the ``kairix`` top-level package itself.
-
-Rejected from ``kairix/core/connectors/``:
-  - ``from kairix.connectors... import ...``
-  - ``from kairix.extractors... import ...``
-  - ``import kairix.connectors...`` / ``import kairix.extractors...``
-
-The detector AST-walks every ``.py`` file under ``kairix/core/connectors/``
-and flags any ``Import`` / ``ImportFrom`` node whose module path starts with
-``kairix.connectors`` or ``kairix.extractors``. Pre-existing violations are
-grandfathered in ``.architecture/baseline/f34-files.txt``.
-
-If ``kairix/core/connectors/`` does not exist (Wave 0 landing, before Wave 1
-scaffolds the orchestration layer) or holds no Python files, the check passes
-trivially — F34 only fires once orchestration code appears. Mirrors the F26
-shape exactly.
+Thin shim over :mod:`_import_boundary_engine` (#499 Phase 2). The rule is one
+``ImportBoundaryRule`` row in ``prefix`` mode; this module re-exports the
+back-compat surface (``collect_violations`` / ``main`` / ``REMEDIATION``) the
+F34 unit test loads by file path.
 """
 
 from __future__ import annotations
 
-import ast
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
-from _fitness_rule import FitnessRule
-from tc_fitness import REPO_ROOT, repo_relative  # noqa: F401 — back-compat for test imports
-
-# Module prefixes the core/connectors/ tree is forbidden from importing.
-# Anchored with a trailing dot so we don't accidentally flag a hypothetical
-# ``kairix.connectors_helpers`` sibling.
-_FORBIDDEN_PREFIXES: tuple[str, ...] = (
-    "kairix.connectors",
-    "kairix.extractors",
-)
+from _import_boundary_engine import ImportBoundaryRule, collect_violations_for, register
+from tc_fitness import REPO_ROOT, gate
 
 REMEDIATION = """Refactor to route the call through a Protocol in
 kairix/core/protocols.py — orchestration code must not know which connector
@@ -85,63 +56,24 @@ reintroduces the class of bug the three-layer split exists to prevent (every
 new connector means editing pipeline.py; every new format accretes inside
 core/connectors/)."""
 
-
-def _module_is_forbidden(module: str | None) -> bool:
-    """True if ``module`` is a forbidden import target for core/connectors code.
-
-    A module path matches when it equals one of the forbidden prefixes or
-    starts with ``<prefix>.``. Plain ``kairix``, ``kairix.core.*``, and any
-    hypothetical ``kairix.connectors_helpers`` sibling are never matched.
-    """
-    if module is None:
-        return False
-    for prefix in _FORBIDDEN_PREFIXES:
-        if module == prefix or module.startswith(prefix + "."):
-            return True
-    return False
-
-
-def file_has_violation(path: Path) -> bool:
-    """True if ``path`` (a .py file under kairix/core/connectors/) contains
-    any forbidden import.
-
-    Inspects both ``ImportFrom`` (``from kairix.connectors... import x``) and
-    ``Import`` (``import kairix.extractors.markitdown``) nodes.
-    """
-    try:
-        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-    except (SyntaxError, UnicodeDecodeError, OSError):
-        return False
-
-    for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom):
-            if _module_is_forbidden(node.module):
-                return True
-        elif isinstance(node, ast.Import):
-            for alias in node.names:
-                if _module_is_forbidden(alias.name):
-                    return True
-    return False
-
-
-class F34(FitnessRule):
-    """F34 as a FitnessRule subclass — see module docstring for rule semantics."""
-
-    name = "f34"
-    remediation = REMEDIATION
-    roots = ("kairix/core/connectors",)
-
-    def file_has_violation(self, path: Path) -> bool:
-        return file_has_violation(path)
+RULE = register(
+    ImportBoundaryRule(
+        name="f34",
+        roots=("kairix/core/connectors",),
+        mode="prefix",
+        forbidden_prefixes=("kairix.connectors", "kairix.extractors"),
+        remediation=REMEDIATION,
+    )
+)
 
 
 def collect_violations(repo_root: Path = REPO_ROOT) -> set[Path]:
-    """Back-compat helper for direct test imports."""
-    return F34(repo_root=repo_root).collect_violations()
+    """Back-compat surface for the F34 unit test."""
+    return collect_violations_for(RULE, repo_root)
 
 
 def main() -> int:
-    return F34().run()
+    return gate(RULE.name, collect_violations(), REMEDIATION)
 
 
 if __name__ == "__main__":

--- a/scripts/checks/check_f35_no_cross_connector.py
+++ b/scripts/checks/check_f35_no_cross_connector.py
@@ -1,62 +1,26 @@
 """F35: ``kairix/connectors/<name>/**`` may not import another connector or
 any extractor.
 
-The connector-framework layer split (see
-``docs/architecture/connector-ingestion-architecture.md`` §2 + §5.1) treats
-each plugin under ``kairix/connectors/<name>/`` as independently shippable —
-a third party can ``pip install kairix-connector-foo`` and register a new
-source family without touching kairix's tree. That guarantee breaks the
-moment one connector imports another, or reaches into the extractor layer
-directly: the imported plugin must then ship alongside, the dependency
-graph fans out, and chunking / extraction concerns leak across plugin
-boundaries instead of through ``kairix/core/connectors/``.
+Each connector under ``kairix/connectors/<name>/`` is independently shippable;
+importing a sibling connector — or reaching into the extractor layer directly
+— breaks that guarantee. Shared concerns go through ``kairix/core/connectors/``;
+extraction is dispatched through the Extractor Protocol, not imported.
 
-Allowed from ``kairix/connectors/<name>/``:
-  - sibling imports within the same plugin (``kairix.connectors.<name>.*``)
-  - the shared base in ``kairix.connectors._base`` (SourceConnector Protocol,
-    registry contract — explicitly designed for cross-plugin use)
-  - ``kairix.core.*`` (the Protocol surface and shared orchestration)
-  - ``kairix.transport.*`` (the universal concerns — that's what transport
-    exists for)
-
-Rejected from ``kairix/connectors/<name>/``:
-  - ``from kairix.connectors.<other> import ...`` (any other connector)
-  - ``import kairix.connectors.<other>`` (any other connector)
-  - ``from kairix.extractors... import ...`` (any extractor)
-  - ``import kairix.extractors...`` (any extractor)
-
-The detector AST-walks every ``.py`` file under ``kairix/connectors/``
-(skipping ``_base.py`` and ``__init__.py`` at the top level), figures out
-which connector directory owns the file, and flags any import that points
-at a sibling connector or any extractor. Pre-existing violations are
-grandfathered in ``.architecture/baseline/f35-files.txt``.
-
-If ``kairix/connectors/`` does not exist (Wave 0 landing) or contains no
-plugin subdirectories, the check passes trivially — F35 only fires once
-plugins appear. Mirrors the F27 shape exactly, with the addition of the
-extractor-layer prohibition required by §2's three-layer split.
+Thin shim over :mod:`_import_boundary_engine` (#499 Phase 2). The rule is one
+``ImportBoundaryRule`` row in ``sibling-plugin`` mode with the extractor ban as
+an extra forbidden prefix; this module re-exports the back-compat surface
+(``collect_violations`` / ``main`` / ``REMEDIATION``) the F35 unit test loads
+by file path.
 """
 
 from __future__ import annotations
 
-import ast
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
-from _fitness_rule import FitnessRule
-from tc_fitness import REPO_ROOT, repo_relative  # noqa: F401 — back-compat for test imports
-
-# Files / directories at the top level of kairix/connectors/ that are NOT
-# plugins (they're the shared scaffolding the plugin Protocol lives in).
-_NON_PLUGIN_ENTRIES: frozenset[str] = frozenset(
-    {
-        "__init__.py",
-        "_base.py",
-        "_base",
-        "__pycache__",
-    }
-)
+from _import_boundary_engine import ImportBoundaryRule, collect_violations_for, register
+from tc_fitness import REPO_ROOT, gate
 
 REMEDIATION = """Refactor to remove the cross-connector / extractor import —
 a connector must not depend on another connector or reach into the extractor
@@ -94,120 +58,24 @@ dependency graph becomes a tangle that defeats the plugin model. Direct
 extractor imports re-introduce the chunking-duplication failure mode that
 the Bronze/Silver split exists to prevent (§4)."""
 
-
-def _plugin_dir_for(path: Path, connectors_root: Path) -> str | None:
-    """Return the connector directory name that ``path`` lives in, or None
-    if the path sits at the top level of ``connectors/`` (so isn't part of
-    any plugin) or outside ``connectors/`` entirely.
-
-    A "plugin directory" is the first path segment under
-    ``kairix/connectors/`` for the file's location.
-    """
-    try:
-        rel = path.relative_to(connectors_root)
-    except ValueError:
-        return None
-    parts = rel.parts
-    if len(parts) < 2:
-        # Top-level file (e.g. _base.py, __init__.py) — not inside a plugin
-        # directory.
-        return None
-    return parts[0]
-
-
-def _is_cross_connector_import(module: str | None, owning_plugin: str) -> bool:
-    """True if ``module`` (the source of an Import / ImportFrom node) points
-    at a ``kairix.connectors.<other>`` connector different from
-    ``owning_plugin``.
-
-    ``kairix.connectors._base`` and ``kairix.connectors`` itself are
-    explicitly NOT cross-plugin — they are the shared scaffolding.
-    """
-    if module is None:
-        return False
-    prefix = "kairix.connectors."
-    if not module.startswith(prefix):
-        return False
-    rest = module[len(prefix) :]
-    # Pull out the first segment after kairix.connectors. — that's the
-    # plugin name (or the shared _base module name).
-    head = rest.split(".", 1)[0]
-    if not head:
-        return False
-    if head.startswith("_"):
-        # Shared scaffolding (e.g. _base) — explicitly allowed.
-        return False
-    return head != owning_plugin
-
-
-def _is_extractor_import(module: str | None) -> bool:
-    """True if ``module`` targets any module under ``kairix.extractors``.
-
-    Any reach into the extractor layer is forbidden from connectors — the
-    extractor Protocol is dispatched through ``kairix/core/connectors/``'s
-    registry, not by direct import.
-    """
-    if module is None:
-        return False
-    return module == "kairix.extractors" or module.startswith("kairix.extractors.")
-
-
-def file_has_violation(path: Path, connectors_root: Path) -> bool:
-    """True if ``path`` (a .py file under a connector directory) imports
-    from another connector under ``kairix/connectors/`` or from any
-    extractor under ``kairix/extractors/``.
-    """
-    owning = _plugin_dir_for(path, connectors_root)
-    if owning is None:
-        # Top-level connector scaffolding — not subject to F35.
-        return False
-    if owning.startswith("_") or owning in _NON_PLUGIN_ENTRIES:
-        return False
-
-    try:
-        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-    except (SyntaxError, UnicodeDecodeError, OSError):
-        return False
-
-    for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom):
-            if _is_cross_connector_import(node.module, owning):
-                return True
-            if _is_extractor_import(node.module):
-                return True
-        elif isinstance(node, ast.Import):
-            for alias in node.names:
-                if _is_cross_connector_import(alias.name, owning):
-                    return True
-                if _is_extractor_import(alias.name):
-                    return True
-    return False
-
-
-class F35(FitnessRule):
-    """F35 as a FitnessRule subclass. Overrides ``file_has_violation``
-    to thread ``connectors_root`` into the detection helper.
-    """
-
-    name = "f35"
-    remediation = REMEDIATION
-    roots = ("kairix/connectors",)
-
-    def __init__(self, repo_root: Path | None = None) -> None:
-        super().__init__(repo_root=repo_root)
-        self._connectors_root = self._repo_root / "kairix" / "connectors"
-
-    def file_has_violation(self, path: Path) -> bool:
-        return file_has_violation(path, self._connectors_root)
+RULE = register(
+    ImportBoundaryRule(
+        name="f35",
+        roots=("kairix/connectors",),
+        mode="sibling-plugin",
+        extra_forbidden_prefixes=("kairix.extractors",),
+        remediation=REMEDIATION,
+    )
+)
 
 
 def collect_violations(repo_root: Path = REPO_ROOT) -> set[Path]:
-    """Back-compat helper for direct test imports."""
-    return F35(repo_root=repo_root).collect_violations()
+    """Back-compat surface for the F35 unit test."""
+    return collect_violations_for(RULE, repo_root)
 
 
 def main() -> int:
-    return F35().run()
+    return gate(RULE.name, collect_violations(), REMEDIATION)
 
 
 if __name__ == "__main__":

--- a/scripts/checks/check_f37_singular_sync.py
+++ b/scripts/checks/check_f37_singular_sync.py
@@ -1,80 +1,37 @@
 """F37: change-detection / sync code only under the connector trees.
 
-Mirrors F29's singular-surface pattern (perf measurement only under
-``kairix/quality/probe/``). Wave 1 of the connector + ingestion plan
-(see ``docs/architecture/connector-ingestion-architecture.md`` §5.8 and
-§6) introduces ``kairix/core/connectors/`` for the orchestration layer
-and ``kairix/connectors/<name>/`` for per-source change detection.
+Mirrors F29's singular-surface shape, inverted: an import of a known
+change-detection library (``watchdog`` / ``msgraph`` / ``notion_client`` /
+``slack_sdk.rtm|.socket_mode`` / ``dulwich``) is forbidden anywhere under
+``kairix/`` UNLESS the file lives in one of the two sanctioned homes —
+``kairix/core/connectors/`` (orchestration) or ``kairix/connectors/<name>/``
+(per-source change detection). The bare ``slack_sdk.web`` HTTP surface is not a
+sync loop and is not flagged.
 
-The rule keeps every polling loop / watchdog observer / Graph
-delta-query / cursor-advancement primitive in one of those two trees.
-No parallel sync surfaces under ``kairix/worker.py``, ``kairix/corpus/``,
-``kairix/core/temporal/``, or anywhere else.
-
-Detection heuristic — deliberately conservative, easy to widen later:
-
-  An import of a known change-detection library (``watchdog``,
-  ``msgraph``, ``msgraph.core``, ``msgraph_core``, ``notion_client``,
-  ``slack_sdk.rtm``, ``slack_sdk.socket_mode``, ``dulwich``) inside any
-  ``kairix/**/*.py`` file that lives OUTSIDE the two allowed trees is
-  flagged.
-
-The AST signal for "polling-loop shape" (``while True:`` + ``time.sleep``)
-is too fuzzy on its own — many legitimate non-sync loops match it
-(retry-after backoff, healthcheck loops, the worker's tick loop). So
-the detector keys on the import set, which is the unambiguous signal
-that *change detection* is happening.
-
-Today (pre-Wave 1) ``kairix/connectors/`` and ``kairix/core/connectors/``
-do not exist; no other ``kairix/`` file imports any of the
-change-detection libraries; the check passes trivially.
-
-Allowed prefixes (sync code welcome here):
-  - ``kairix/core/connectors/**`` — the orchestration layer.
-  - ``kairix/connectors/<name>/**`` — per-source change detection.
-
-Rejected prefixes (where a sync-library import is a regression):
-  - everything else under ``kairix/``.
+Thin shim over :mod:`_import_boundary_engine` (#499 Phase 2). The rule is one
+``ImportBoundaryRule`` row in ``sync-lib`` mode; this module re-exports the
+back-compat surface (``collect_violations`` / ``main`` / ``REMEDIATION`` /
+``_is_sync_import``) the F37 unit test loads by file path.
 """
 
 from __future__ import annotations
 
-import ast
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
-from _fitness_rule import FitnessRule
-from tc_fitness import REPO_ROOT
+from _import_boundary_engine import ImportBoundaryRule, _is_sync_lib_import, collect_violations_for, register
+from tc_fitness import REPO_ROOT, gate
 
-# Module names whose presence in an import statement signals
-# change-detection / sync code. Matched against the FIRST dotted
-# segment of the import target (so ``from watchdog.observers import X``
-# matches via "watchdog"; ``from msgraph.core import Y`` matches via
-# "msgraph"; ``import notion_client`` matches via "notion_client").
-_SYNC_LIBRARY_ROOTS: frozenset[str] = frozenset(
-    {
-        "watchdog",
-        "msgraph",
-        "msgraph_core",
-        "notion_client",
-        "slack_sdk",
-        "dulwich",
-    }
-)
-
-# Submodule patterns that further narrow ``slack_sdk`` to its real-time
-# / socket-mode change-detection surfaces — the rest of the SDK
-# (``slack_sdk.web``) is a one-shot HTTP client and is not a sync loop.
-# An import is flagged if it matches a root above; for ``slack_sdk`` we
-# additionally require one of these submodule tails to be present in
-# the import target.
-_SLACK_SYNC_TAILS: frozenset[str] = frozenset({"rtm", "socket_mode"})
-
-# Allowed locations for sync-library imports (relative to repo root).
-_ALLOWED_PREFIXES: tuple[Path, ...] = (
-    Path("kairix") / "core" / "connectors",
-    Path("kairix") / "connectors",
+# Module names whose presence in an import signals change-detection / sync
+# code. Matched against the FIRST dotted segment of the import target.
+_SYNC_LIBRARY_ROOTS: tuple[str, ...] = (
+    "watchdog",
+    "msgraph",
+    "msgraph_core",
+    "notion_client",
+    "slack_sdk",
+    "dulwich",
 )
 
 REMEDIATION = """Refactor to move change-detection / sync code under
@@ -109,116 +66,31 @@ F37 mirrors F29's shape: one canonical surface for the work, so the
 registry + cursor + dead-letter discipline carries through every new
 source without parallel polling growing under worker.py or corpus/."""
 
-
-def _import_targets(tree: ast.AST) -> list[str]:
-    """Return the dotted module names referenced by every ``import``
-    and ``from ... import`` in ``tree``.
-
-    For ``import a.b.c`` we yield ``"a.b.c"``.
-    For ``from a.b.c import x`` we yield ``"a.b.c"``.
-    Relative imports (``from . import x``) are ignored — they cannot
-    reach a third-party library by construction.
-    """
-    targets: list[str] = []
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            for alias in node.names:
-                targets.append(alias.name)
-        elif isinstance(node, ast.ImportFrom):
-            if node.level and node.level > 0:
-                continue
-            if node.module:
-                targets.append(node.module)
-    return targets
+RULE = register(
+    ImportBoundaryRule(
+        name="f37",
+        roots=("kairix",),
+        mode="sync-lib",
+        forbidden_prefixes=_SYNC_LIBRARY_ROOTS,
+        allowed_roots=("kairix/core/connectors", "kairix/connectors"),
+        remediation=REMEDIATION,
+    )
+)
 
 
 def _is_sync_import(target: str) -> bool:
-    """True if a dotted ``target`` references a change-detection
-    library. The root segment must be in ``_SYNC_LIBRARY_ROOTS``;
-    ``slack_sdk`` additionally requires an rtm/socket_mode tail
-    so the one-shot Web API surface is not flagged.
-    """
-    parts = target.split(".")
-    if not parts:
-        return False
-    root = parts[0]
-    if root not in _SYNC_LIBRARY_ROOTS:
-        return False
-    if root == "slack_sdk":
-        return any(tail in parts[1:] for tail in _SLACK_SYNC_TAILS)
-    return True
-
-
-def _file_imports_sync_library(path: Path) -> bool:
-    """True if ``path`` imports any change-detection library."""
-    try:
-        source = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
-        return False
-    try:
-        tree = ast.parse(source, filename=str(path))
-    except SyntaxError:
-        return False
-    return any(_is_sync_import(t) for t in _import_targets(tree))
-
-
-def _is_allowed(rel_path: Path) -> bool:
-    """True if a sync-importing file at ``rel_path`` (relative to repo
-    root) is allowed under F37's exception roots.
-    """
-    parts = rel_path.parts
-    for prefix in _ALLOWED_PREFIXES:
-        prefix_parts = prefix.parts
-        if len(parts) >= len(prefix_parts) and tuple(parts[: len(prefix_parts)]) == prefix_parts:
-            return True
-    return False
+    """True if a dotted ``target`` references a change-detection library.
+    Re-exported for the F37 test; delegates to the engine classifier."""
+    return _is_sync_lib_import(target, _SYNC_LIBRARY_ROOTS)
 
 
 def collect_violations(repo_root: Path = REPO_ROOT) -> set[Path]:
-    """Walk every .py file under ``repo_root/kairix/`` and return
-    repo-relative paths whose imports reference a change-detection
-    library AND that live outside the allowed connector trees.
-
-    Scoped to ``kairix/`` (the production package). Files under
-    ``tests/`` are not in scope — test fakes for connectors live in
-    ``tests/fakes.py`` and do not import the real sync libraries.
-    """
-    kairix_dir = repo_root / "kairix"
-    if not kairix_dir.exists():
-        return set()
-
-    violations: set[Path] = set()
-    for path in kairix_dir.rglob("*.py"):
-        if "__pycache__" in path.parts:
-            continue
-        if not _file_imports_sync_library(path):
-            continue
-        try:
-            rel = path.resolve().relative_to(repo_root)
-        except ValueError:
-            continue
-        if _is_allowed(rel):
-            continue
-        violations.add(rel)
-    return violations
-
-
-class F37(FitnessRule):
-    """F37 as a FitnessRule subclass — see module docstring."""
-
-    name = "f37"
-    remediation = REMEDIATION
-    roots = ("kairix",)
-
-    def file_has_violation(self, path: Path) -> bool:
-        if not _file_imports_sync_library(path):
-            return False
-        rel = self._repo_relative(path)
-        return not _is_allowed(rel)
+    """Back-compat surface for the F37 unit test."""
+    return collect_violations_for(RULE, repo_root)
 
 
 def main() -> int:
-    return F37().run()
+    return gate(RULE.name, collect_violations(), REMEDIATION)
 
 
 if __name__ == "__main__":

--- a/scripts/checks/check_f38_silver_singleton.py
+++ b/scripts/checks/check_f38_silver_singleton.py
@@ -1,61 +1,26 @@
 """F38: Silver processing only in ``kairix/core/connectors/silver.py``.
 
-Wave 1 of the connector + ingestion plan (see
-``docs/architecture/connector-ingestion-architecture.md`` §3 and §5.1)
-defines Silver as "the work that turns a Bronze record into
-``(chunks, entity_signals)``": chunking + entity-signal extraction.
+Silver is the work that turns a Bronze record into ``(chunks,
+entity_signals)`` — chunking + entity-signal extraction. F38 keeps every
+chunking primitive (``def`` names matching ``chunk_*`` / ``_chunk*`` /
+``tokenize_into_chunks``) in one canonical home, with the existing
+conversational-corpus chunkers grandfathered by an allow-list of legacy roots.
 
-F38 keeps every chunking primitive — function definitions whose names
-match ``chunk_*``, ``_chunk*``, ``tokenize_into_chunks`` — in one
-canonical home: ``kairix/core/connectors/silver.py``. No per-connector
-chunker, no per-extractor chunker. Connectors and extractors hand
-Bronze records to the orchestration layer; the orchestration layer
-calls Silver; Silver returns chunks + signals.
-
-Detection — AST walk over every ``.py`` file under ``kairix/``:
-
-  Any module-level or nested ``def`` whose name matches the chunking
-  patterns above, sitting outside the allowed roots, is flagged.
-
-The detector is **vacuous-green today** — the existing chunkers under
-``kairix/core/temporal/``, ``kairix/core/embed/``, ``kairix/core/search/``,
-``kairix/use_cases/``, and ``kairix/corpus/`` are part of the existing
-conversational corpus path (orthogonal to the new Bronze→Silver flow
-per ADR notes). Those roots are explicitly allowed; the rule fires
-only when Wave 1 lands a per-connector or per-extractor chunker.
-
-Allowed locations (chunking welcome here):
-  - ``kairix/core/connectors/silver.py`` — canonical Silver surface.
-  - ``kairix/quality/probe/**`` — perf-test fixtures.
-  - ``kairix/corpus/**`` — existing conversational corpus path.
-  - ``kairix/core/temporal/**`` — temporal-chunker (existing).
-  - ``kairix/core/embed/**`` — embedding chunker (existing).
-  - ``kairix/core/search/**`` — search-time chunk scoring (existing).
-  - ``kairix/use_cases/**`` — use-case chunk projections (existing).
-
-Rejected locations (where a chunker is a regression):
-  - ``kairix/connectors/<name>/**`` — per-connector chunker.
-  - ``kairix/extractors/<name>/**`` — per-extractor chunker.
-  - ``kairix/core/connectors/<anything-but-silver.py>`` — orchestration
-    code that grew its own chunker.
-  - anywhere else under ``kairix/`` not in the allow-list above.
-
-Chunking-function patterns flagged (basename of the ``def``):
-  - ``chunk_*`` (``chunk_text``, ``chunk_board``, …)
-  - ``_chunk`` / ``_chunk_*`` (private helpers — caught at definition)
-  - ``tokenize_into_chunks``
+Thin shim over :mod:`_location_engine` (#499 Phase 2). The rule is one
+``LocationRule`` row in ``def-name`` kind; this module re-exports the
+back-compat surface (``collect_violations`` / ``main`` / ``REMEDIATION`` /
+``_is_chunk_function_name``) the F38 unit test loads by file path.
 """
 
 from __future__ import annotations
 
-import ast
 import re
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
-from _fitness_rule import FitnessRule
-from tc_fitness import REPO_ROOT
+from _location_engine import LocationRule, collect_violations_for, register
+from tc_fitness import REPO_ROOT, gate
 
 # Regex matching a chunking function name. Anchored at both ends.
 _CHUNK_NAME_RE = re.compile(
@@ -69,21 +34,6 @@ _CHUNK_NAME_RE = re.compile(
     """,
     re.VERBOSE,
 )
-
-# Directories whose contents are explicitly allowed to define chunking
-# functions. A file under ANY of these prefixes (relative to repo root)
-# is exempt.
-_ALLOWED_PREFIXES: tuple[Path, ...] = (
-    Path("kairix") / "quality" / "probe",
-    Path("kairix") / "corpus",
-    Path("kairix") / "core" / "temporal",
-    Path("kairix") / "core" / "embed",
-    Path("kairix") / "core" / "search",
-    Path("kairix") / "use_cases",
-)
-
-# The canonical Silver home. Allowed as a single file (not a prefix).
-_SILVER_PATH = Path("kairix") / "core" / "connectors" / "silver.py"
 
 REMEDIATION = """Refactor to extract the chunking logic into
 kairix/core/connectors/silver.py and call it from your code. Silver is
@@ -118,92 +68,38 @@ every source: same chunker, same signal extractor, same boundary, same
 defects pinned by tests. Per-connector chunkers fork the surface and
 the discipline rots."""
 
+RULE = register(
+    LocationRule(
+        name="f38",
+        kind="def-name",
+        pattern=_CHUNK_NAME_RE,
+        allowed_roots=(
+            "kairix/quality/probe",
+            "kairix/corpus",
+            "kairix/core/temporal",
+            "kairix/core/embed",
+            "kairix/core/search",
+            "kairix/use_cases",
+        ),
+        allowed_files=("kairix/core/connectors/silver.py",),
+        remediation=REMEDIATION,
+    )
+)
+
 
 def _is_chunk_function_name(name: str) -> bool:
-    """True if ``name`` matches the chunking-function naming pattern."""
+    """True if ``name`` matches the chunking-function naming pattern.
+    Re-exported for the F38 test."""
     return _CHUNK_NAME_RE.match(name) is not None
 
 
-def _file_defines_chunk_function(path: Path) -> bool:
-    """True if ``path`` defines at least one chunking function.
-
-    Walks the AST and checks every ``FunctionDef`` / ``AsyncFunctionDef``
-    node's name — module-level or nested — against the chunking pattern.
-    """
-    try:
-        source = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
-        return False
-    try:
-        tree = ast.parse(source, filename=str(path))
-    except SyntaxError:
-        return False
-    for node in ast.walk(tree):
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and _is_chunk_function_name(node.name):
-            return True
-    return False
-
-
-def _is_allowed(rel_path: Path) -> bool:
-    """True if ``rel_path`` (repo-relative) is allowed to define chunking
-    functions: it sits under one of the allowed prefixes, or it is
-    exactly ``kairix/core/connectors/silver.py``.
-    """
-    if rel_path == _SILVER_PATH:
-        return True
-    parts = rel_path.parts
-    for prefix in _ALLOWED_PREFIXES:
-        prefix_parts = prefix.parts
-        if len(parts) >= len(prefix_parts) and tuple(parts[: len(prefix_parts)]) == prefix_parts:
-            return True
-    return False
-
-
 def collect_violations(repo_root: Path = REPO_ROOT) -> set[Path]:
-    """Walk every .py file under ``repo_root/kairix/`` and return
-    repo-relative paths that define a chunking function AND live
-    outside the allowed roots.
-
-    Scoped to ``kairix/`` (the production package). Files under
-    ``tests/`` are out of scope — test fixtures can call any chunker
-    without growing a parallel Silver surface.
-    """
-    kairix_dir = repo_root / "kairix"
-    if not kairix_dir.exists():
-        return set()
-
-    violations: set[Path] = set()
-    for path in kairix_dir.rglob("*.py"):
-        if "__pycache__" in path.parts:
-            continue
-        if not _file_defines_chunk_function(path):
-            continue
-        try:
-            rel = path.resolve().relative_to(repo_root)
-        except ValueError:
-            continue
-        if _is_allowed(rel):
-            continue
-        violations.add(rel)
-    return violations
-
-
-class F38(FitnessRule):
-    """F38 as a FitnessRule subclass — see module docstring."""
-
-    name = "f38"
-    remediation = REMEDIATION
-    roots = ("kairix",)
-
-    def file_has_violation(self, path: Path) -> bool:
-        if not _file_defines_chunk_function(path):
-            return False
-        rel = self._repo_relative(path)
-        return not _is_allowed(rel)
+    """Back-compat surface for the F38 unit test."""
+    return collect_violations_for(RULE, repo_root)
 
 
 def main() -> int:
-    return F38().run()
+    return gate(RULE.name, collect_violations(), REMEDIATION)
 
 
 if __name__ == "__main__":

--- a/scripts/checks/check_f44_engagement_firm_boundary.py
+++ b/scripts/checks/check_f44_engagement_firm_boundary.py
@@ -1,75 +1,27 @@
 """F44: engagement-scope code may not import firm-scope storage clients.
 
-The two-scope architecture splits the world in two:
+Engagement scope is SQLite + Neo4j + filesystem (this repo, under ``kairix/``).
+Firm scope is Postgres-only (a separate codebase). F44 locks the boundary:
+engagement code that imports a Postgres client has reached across it. The
+detector flags any import whose module name equals or is dotted-under a
+denylisted Postgres-client prefix (``psycopg`` / ``psycopg2`` / ``asyncpg`` /
+``pg8000`` / ``aiopg``).
 
-  * **Engagement scope** — single-engagement state. SQLite + Neo4j +
-    filesystem. Lives in this repo, under ``kairix/``.
-  * **Firm scope** — cross-engagement state (reflections, registry,
-    audit envelope). Postgres-only. Lives in the separate
-    ``kairix-firm/`` codebase.
-
-F44 locks the boundary mechanically. Engagement-scope code MUST NOT
-import a Postgres client; doing so means engagement code has reached
-across the scope boundary and is talking directly to firm-scope
-storage. The only sanctioned cross-scope flow is the
-reflection-extractor (one-way, append-only, audited).
-
-Denylist (the standard Python Postgres clients):
-  - ``psycopg``
-  - ``psycopg2``
-  - ``asyncpg``
-  - ``pg8000``
-  - ``psycopg-binary``
-  - ``psycopg2-binary``
-  - ``aiopg``
-
-(Distribution names like ``psycopg-binary`` are listed for
-completeness, even though Python ``import`` statements name the
-underlying module — the AST scanner only sees the importable form,
-e.g. ``import psycopg`` or ``from psycopg2 import connect``. We match
-on import-name prefixes so submodule imports such as
-``psycopg2.extras`` also fire.)
-
-In-scope tree: every ``.py`` file under ``kairix/`` (the production
-package). Test files under ``tests/`` are out of scope — fakes and
-fixtures don't ship in the wheel. ``kairix-firm/`` would also be out
-of scope (different codebase), but it does not exist in this repo
-today.
-
-Today: zero firm-scope code exists in ``kairix/``; the denylist
-matches nothing. F44 is preventive — it locks the boundary so the
-first attempt to ``import psycopg`` from engagement code is blocked
-at pre-commit. Closes the boundary the two-scope architecture names.
+Thin shim over :mod:`_import_boundary_engine` (#499 Phase 2). The rule is one
+``ImportBoundaryRule`` row in ``prefix`` mode; this module re-exports the
+back-compat surface (``collect_violations`` / ``main`` / ``REMEDIATION``) the
+F44 unit test loads by file path. The ``check-f44-engagement-firm-boundary.sh``
+wrapper invokes this module unchanged.
 """
 
 from __future__ import annotations
 
-import ast
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
-from _fitness_rule import FitnessRule
-from tc_fitness import REPO_ROOT, repo_relative  # noqa: F401 — kept for back-compat with importing tests
-
-# Forbidden Postgres-client import-name prefixes. An import is flagged
-# if the imported module name equals one of these OR starts with one
-# followed by ``.`` (so ``psycopg2.extras`` fires the same way
-# ``psycopg2`` does).
-_FIRM_SCOPE_CLIENT_PREFIXES: frozenset[str] = frozenset(
-    {
-        "psycopg",
-        "psycopg2",
-        "asyncpg",
-        "pg8000",
-        # psycopg-binary / psycopg2-binary are wheel distributions that
-        # install the psycopg / psycopg2 module respectively — covered
-        # by the entries above. Listed in the module docstring for the
-        # reader; not duplicated here because they're not importable
-        # names.
-        "aiopg",
-    }
-)
+from _import_boundary_engine import ImportBoundaryRule, collect_violations_for, register
+from tc_fitness import REPO_ROOT, gate
 
 REMEDIATION = """F44: engagement-scope code imports a firm-scope storage client (Postgres).
 fix: engagement code talks to SQLite + Neo4j + filesystem only. Firm-scope queries
@@ -95,73 +47,24 @@ reflections, registry, audit envelope — Postgres-only) into a separate
 codebase. Letting engagement code reach into firm storage collapses the
 scope boundary."""
 
-
-def _imported_names(tree: ast.AST) -> list[str]:
-    """Yield every module name referenced by an ``Import`` or
-    ``ImportFrom`` node in ``tree``.
-
-    For ``import foo.bar`` we return ``foo.bar`` (the full dotted
-    name). For ``from foo.bar import baz`` we return ``foo.bar``.
-    ``from . import x`` (relative imports, ``module is None``) is
-    skipped — relative imports cannot reach an external package.
-    """
-    names: list[str] = []
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            for alias in node.names:
-                if alias.name:
-                    names.append(alias.name)
-        elif isinstance(node, ast.ImportFrom):
-            if node.module:
-                names.append(node.module)
-    return names
+RULE = register(
+    ImportBoundaryRule(
+        name="f44",
+        roots=("kairix",),
+        mode="prefix",
+        forbidden_prefixes=("psycopg", "psycopg2", "asyncpg", "pg8000", "aiopg"),
+        remediation=REMEDIATION,
+    )
+)
 
 
-def _is_firm_scope_client(module: str) -> bool:
-    """True if ``module`` names (or has as a prefix) a denylisted
-    Postgres client.
-
-    Matches on exact name (``import psycopg``) or dotted prefix
-    (``from psycopg2.extras import ...`` → ``psycopg2.extras`` has
-    prefix ``psycopg2``).
-    """
-    for prefix in _FIRM_SCOPE_CLIENT_PREFIXES:
-        if module == prefix or module.startswith(prefix + "."):
-            return True
-    return False
-
-
-def file_has_violation(path: Path) -> bool:
-    """True if ``path`` imports any denylisted Postgres client."""
-    try:
-        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-    except (SyntaxError, UnicodeDecodeError, OSError):
-        return False
-    for module in _imported_names(tree):
-        if _is_firm_scope_client(module):
-            return True
-    return False
-
-
-class F44(FitnessRule):
-    """F44 as a FitnessRule subclass — see module docstring for rule semantics."""
-
-    name = "f44"
-    remediation = REMEDIATION
-    roots = ("kairix",)
-
-    def file_has_violation(self, path: Path) -> bool:
-        return file_has_violation(path)
-
-
-# Public ``collect_violations`` kept for back-compat with any code that
-# imports it directly (tests, scripts). The class is the canonical entry.
 def collect_violations(repo_root: Path = REPO_ROOT) -> set[Path]:
-    return F44(repo_root=repo_root).collect_violations()
+    """Back-compat surface for the F44 unit test."""
+    return collect_violations_for(RULE, repo_root)
 
 
 def main() -> int:
-    return F44().run()
+    return gate(RULE.name, collect_violations(), REMEDIATION)
 
 
 if __name__ == "__main__":

--- a/scripts/checks/check_f61_collection_router_singleton.py
+++ b/scripts/checks/check_f61_collection_router_singleton.py
@@ -1,49 +1,27 @@
 """F61: CollectionRouter is the singular construction surface for chunk writers.
 
-ADR v2 (``docs/architecture/connector-scope-topology/ADR.md``) §"Table B"
-extends F38 (Silver singleton) with a CollectionRouter that decides which
-backing chunk-writer instance handles a given Chunk's collection. F61
-keeps every ``_SqliteChunkWriter(db, collection=name)`` construction
-inside the framework — specifically under ``kairix/core/connectors/`` —
-so the orchestrator can't bypass the router.
+Every ``_SqliteChunkWriter(db, collection=...)`` construction must flow through
+the framework so the per-collection routing decision stays in one place. F61
+flags any bare ``_SqliteChunkWriter(...)`` construction (an ``ast.Name`` call,
+not attribute-form ``mod.X(...)``) outside ``kairix/core/connectors/``.
 
-Today ``kairix/worker.py:_run_one_connector_batch`` (around line 305)
-directly constructs ``_SqliteChunkWriter(db, collection=name)``. This
-is exactly the regression Wave C will fix by threading construction
-through ``CollectionRouter``. ``kairix/worker.py`` is grandfathered in
-``.architecture/baseline/f61-files.txt``; the Wave C rewire pays it down.
-
-Detection (AST):
-
-  Find every ``ast.Call`` whose ``func`` resolves to the bare name
-  ``_SqliteChunkWriter`` under ``kairix/**/*.py``. A file is allowed
-  to construct one when it lives under ``kairix/core/connectors/``
-  (the framework owns the writer). Anywhere else under ``kairix/``
-  trips F61.
-
-  ``module._SqliteChunkWriter(...)`` (attribute access from another
-  package) is NOT matched — F26/F27/F34 already catch cross-layer
-  reach; F61 protects the in-module construction surface.
-
-Per F21, ``REMEDIATION`` carries ``fix:`` / ``next:`` / ``run:`` markers.
+Thin shim over :mod:`_location_engine` (#499 Phase 2). The rule is one
+``LocationRule`` row in ``ctor-call`` kind; this module re-exports the
+back-compat surface (``collect_violations`` / ``main`` / ``REMEDIATION``) the
+F61 unit test loads by file path.
 """
 
 from __future__ import annotations
 
-import ast
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
-from _fitness_rule import FitnessRule
-from tc_fitness import REPO_ROOT
+from _location_engine import LocationRule, collect_violations_for, register
+from tc_fitness import REPO_ROOT, gate
 
 # Name of the writer class whose construction F61 watches.
 _WRITER_CLASS_NAME = "_SqliteChunkWriter"
-
-# The only directory tree allowed to construct ``_SqliteChunkWriter``
-# directly. The CollectionRouter (Wave C) lives here too.
-_FRAMEWORK_PREFIX = Path("kairix") / "core" / "connectors"
 
 REMEDIATION = """F61: _SqliteChunkWriter constructor call sits outside kairix/core/connectors/.
 
@@ -85,89 +63,25 @@ Forbidden example:
       ...,
   )"""
 
-
-def _is_writer_ctor(call: ast.Call) -> bool:
-    """True if ``call`` is a bare ``_SqliteChunkWriter(...)`` construction.
-
-    Matches only ``ast.Name`` shapes — ``module._SqliteChunkWriter(...)``
-    via attribute access is intentionally out of scope (already covered
-    by F26/F27/F34).
-    """
-    return isinstance(call.func, ast.Name) and call.func.id == _WRITER_CLASS_NAME
-
-
-def _is_in_framework(rel_path: Path) -> bool:
-    """True if ``rel_path`` (repo-relative) sits under
-    ``kairix/core/connectors/``."""
-    parts = rel_path.parts
-    prefix = _FRAMEWORK_PREFIX.parts
-    return len(parts) >= len(prefix) and tuple(parts[: len(prefix)]) == prefix
-
-
-def _file_constructs_writer(path: Path) -> bool:
-    """True if ``path`` contains at least one ``_SqliteChunkWriter(...)``
-    bare-name construction.
-    """
-    try:
-        source = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
-        return False
-    # Cheap pre-filter — skip the AST cost when the writer name isn't
-    # even mentioned in the file.
-    if _WRITER_CLASS_NAME not in source:
-        return False
-    try:
-        tree = ast.parse(source, filename=str(path))
-    except SyntaxError:
-        return False
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Call) and _is_writer_ctor(node):
-            return True
-    return False
+RULE = register(
+    LocationRule(
+        name="f61",
+        kind="ctor-call",
+        pattern=_WRITER_CLASS_NAME,
+        allowed_roots=("kairix/core/connectors",),
+        remediation=REMEDIATION,
+    )
+)
 
 
 def collect_violations(repo_root: Path = REPO_ROOT) -> set[Path]:
-    """Walk every .py file under ``repo_root/kairix/`` and return
-    repo-relative paths that construct ``_SqliteChunkWriter(...)``
-    outside ``kairix/core/connectors/``.
-    """
-    kairix_dir = repo_root / "kairix"
-    if not kairix_dir.exists():
-        return set()
-
-    violations: set[Path] = set()
-    for path in kairix_dir.rglob("*.py"):
-        if "__pycache__" in path.parts:
-            continue
-        if not _file_constructs_writer(path):
-            continue
-        try:
-            rel = path.resolve().relative_to(repo_root)
-        except ValueError:
-            continue
-        if _is_in_framework(rel):
-            continue
-        violations.add(rel)
-    return violations
-
-
-class F61(FitnessRule):
-    """F61 as a FitnessRule subclass — see module docstring."""
-
-    name = "f61"
-    remediation = REMEDIATION
-    roots = ("kairix",)
-
-    def file_has_violation(self, path: Path) -> bool:
-        if not _file_constructs_writer(path):
-            return False
-        rel = self._repo_relative(path)
-        return not _is_in_framework(rel)
+    """Back-compat surface for the F61 unit test."""
+    return collect_violations_for(RULE, repo_root)
 
 
 def main() -> int:
     """Return 0 when clean / vacuous-green; 1 on net-new violations."""
-    return F61().run()
+    return gate(RULE.name, collect_violations(), REMEDIATION)
 
 
 if __name__ == "__main__":

--- a/scripts/checks/check_no_cross_provider.py
+++ b/scripts/checks/check_no_cross_provider.py
@@ -1,58 +1,23 @@
 """F27: ``kairix/providers/<name>/**`` may not import another provider.
 
-The three-layer provider-plugin split (see
-``docs/architecture/provider-plugin-architecture.md``) treats each
-plugin under ``kairix/providers/<name>/`` as independently
-shippable — a third party can ``pip install kairix-provider-foo`` and
-register a new endpoint family without touching kairix's tree. That
-guarantee breaks the moment one plugin imports another: the imported
-plugin must then ship alongside, the dependency graph fans out, and
-shared concerns leak across plugin boundaries instead of through
-``kairix/transport/``.
+Each plugin under ``kairix/providers/<name>/`` is independently shippable; a
+plugin that imports a sibling plugin breaks that guarantee. Shared concerns go
+through ``kairix/transport/``; the shared base is ``kairix.providers._base``.
 
-Allowed from ``kairix/providers/<name>/``:
-  - sibling imports within the same plugin (``kairix.providers.<name>.*``)
-  - the shared base in ``kairix.providers._base`` (Provider Protocol,
-    registry contract — explicitly designed for cross-plugin use)
-  - ``kairix.core.*`` (the Protocol surface)
-  - ``kairix.transport.*`` (the universal concerns — that's what
-    transport exists for)
-
-Rejected from ``kairix/providers/<name>/``:
-  - ``from kairix.providers.<other> import ...`` (any other plugin)
-  - ``import kairix.providers.<other>`` (any other plugin)
-
-The detector AST-walks every ``.py`` file under ``kairix/providers/``
-(skipping ``_base.py`` and ``__init__.py`` at the top level), figures
-out which plugin directory owns the file, and flags any import that
-points at a sibling plugin. Pre-existing violations are grandfathered
-in ``.architecture/baseline/f27-files.txt``.
-
-If ``kairix/providers/`` does not exist (fresh checkout) or contains
-no plugin subdirectories, the check passes trivially — F27 only fires
-once plugins appear.
+Thin shim over :mod:`_import_boundary_engine` (#499 Phase 2). The rule is one
+``ImportBoundaryRule`` row in ``sibling-plugin`` mode; this module re-exports
+the back-compat surface (``collect_violations`` / ``main`` / ``REMEDIATION``)
+the F27 unit test loads by file path.
 """
 
 from __future__ import annotations
 
-import ast
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
-from _fitness_rule import FitnessRule
-from tc_fitness import REPO_ROOT, repo_relative  # noqa: F401 — back-compat for test imports
-
-# Files / directories at the top level of kairix/providers/ that are NOT
-# plugins (they're the shared scaffolding the plugin Protocol lives in).
-_NON_PLUGIN_ENTRIES: frozenset[str] = frozenset(
-    {
-        "__init__.py",
-        "_base.py",
-        "_base",
-        "__pycache__",
-    }
-)
+from _import_boundary_engine import ImportBoundaryRule, collect_violations_for, register
+from tc_fitness import REPO_ROOT, gate
 
 REMEDIATION = """Refactor to remove the cross-provider import — a
 plugin must not depend on another plugin.
@@ -84,104 +49,23 @@ that imports another can't be split out without dragging its sibling
 along, and the dependency graph becomes a tangle that defeats the
 plugin model."""
 
-
-def _plugin_dir_for(path: Path, providers_root: Path) -> str | None:
-    """Return the plugin directory name that ``path`` lives in, or None
-    if the path sits at the top level of ``providers/`` (so isn't part
-    of any plugin) or outside ``providers/`` entirely.
-
-    A "plugin directory" is the first path segment under
-    ``kairix/providers/`` for the file's location.
-    """
-    try:
-        rel = path.relative_to(providers_root)
-    except ValueError:
-        return None
-    parts = rel.parts
-    if len(parts) < 2:
-        # Top-level file (e.g. _base.py, __init__.py) — not inside a
-        # plugin directory.
-        return None
-    return parts[0]
-
-
-def _is_cross_provider_import(module: str | None, owning_plugin: str) -> bool:
-    """True if ``module`` (the source of an Import / ImportFrom node)
-    points at a kairix.providers.<other> plugin different from
-    ``owning_plugin``.
-
-    ``kairix.providers._base`` and ``kairix.providers`` itself are
-    explicitly NOT cross-plugin — they are the shared scaffolding.
-    """
-    if module is None:
-        return False
-    prefix = "kairix.providers."
-    if not module.startswith(prefix):
-        return False
-    rest = module[len(prefix) :]
-    # Pull out the first segment after kairix.providers. — that's the
-    # plugin name (or the shared _base module name).
-    head = rest.split(".", 1)[0]
-    if not head:
-        return False
-    if head.startswith("_"):
-        # Shared scaffolding (e.g. _base) — explicitly allowed.
-        return False
-    return head != owning_plugin
-
-
-def file_has_violation(path: Path, providers_root: Path) -> bool:
-    """True if ``path`` (a .py file under a plugin directory) imports
-    from another plugin under ``kairix/providers/``.
-    """
-    owning = _plugin_dir_for(path, providers_root)
-    if owning is None:
-        # Top-level provider scaffolding — not subject to F27.
-        return False
-    if owning.startswith("_") or owning in _NON_PLUGIN_ENTRIES:
-        return False
-
-    try:
-        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-    except (SyntaxError, UnicodeDecodeError, OSError):
-        return False
-
-    for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom):
-            if _is_cross_provider_import(node.module, owning):
-                return True
-        elif isinstance(node, ast.Import):
-            for alias in node.names:
-                if _is_cross_provider_import(alias.name, owning):
-                    return True
-    return False
-
-
-class F27(FitnessRule):
-    """F27 as a FitnessRule subclass. Overrides ``file_has_violation``
-    because the detection logic needs the providers_root for sibling-plugin
-    name inference — supplied via instance attribute.
-    """
-
-    name = "f27"
-    remediation = REMEDIATION
-    roots = ("kairix/providers",)
-
-    def __init__(self, repo_root: Path | None = None) -> None:
-        super().__init__(repo_root=repo_root)
-        self._providers_root = self._repo_root / "kairix" / "providers"
-
-    def file_has_violation(self, path: Path) -> bool:
-        return file_has_violation(path, self._providers_root)
+RULE = register(
+    ImportBoundaryRule(
+        name="f27",
+        roots=("kairix/providers",),
+        mode="sibling-plugin",
+        remediation=REMEDIATION,
+    )
+)
 
 
 def collect_violations(repo_root: Path = REPO_ROOT) -> set[Path]:
-    """Back-compat helper for direct test imports."""
-    return F27(repo_root=repo_root).collect_violations()
+    """Back-compat surface for the F27 unit test."""
+    return collect_violations_for(RULE, repo_root)
 
 
 def main() -> int:
-    return F27().run()
+    return gate(RULE.name, collect_violations(), REMEDIATION)
 
 
 if __name__ == "__main__":

--- a/scripts/checks/check_path_naming.py
+++ b/scripts/checks/check_path_naming.py
@@ -26,6 +26,9 @@ Trees enforced (first match wins; the order matters):
   ``scripts/checks/``
       Fitness-function check scripts. ``check_<rule>.py``,
       ``check-<rule>.sh``, ``_fitness_rule.py``, ``_lib.sh``,
+      the shared table engines ``_import_boundary_engine.py`` /
+      ``_location_engine.py`` (#499 Phase 2 — the nine boundary/location
+      rules collapse into these two declarative tables),
       ``run-all.sh``, ``audit_baselines.py``, ``merge_coverage_xml.py``,
       the catalogue-runner tooling ``run_checks.py`` /
       ``generate_catalogue_docs.py`` (#499 Phase 2), and the diff-scoped
@@ -70,6 +73,7 @@ _TEST_PY = re.compile(r"^(__init__|conftest|fakes|test_[a-z0-9_]+|_?[a-z][a-z0-9
 _SNAKE_FEATURE = re.compile(r"^[a-z][a-z0-9_]*\.feature$")
 _CHECK_SCRIPT_PY = re.compile(
     r"^(check_[a-z0-9_]+|_fitness_rule|_rule_catalogue|_integrity_invariants_registry"
+    r"|_import_boundary_engine|_location_engine"
     r"|audit_baselines|merge_coverage_xml|run_checks|generate_catalogue_docs|mutation_parity"
     r"|rules)\.py$"
 )

--- a/scripts/checks/check_perf_singleton.py
+++ b/scripts/checks/check_perf_singleton.py
@@ -1,40 +1,15 @@
 """F29: performance-measurement code may only live under ``kairix/quality/probe/``.
 
-The three-layer provider-plugin split (see
-``docs/architecture/provider-plugin-architecture.md`` - "Performance")
-centralises every layer's latency / throughput instrumentation in one
-location: ``kairix/quality/probe/``. The probe reads each layer
-through one uniform timing hook and is the single surface both the
-PVT release gate and the end-user ``kairix probe-config`` health
-check invoke. Letting ``transport/`` or ``providers/`` grow their own
-ad-hoc benchmark scripts re-creates the per-provider conditionals the
-ADR exists to remove.
+Every layer's latency / throughput instrumentation centralises in one home so
+the PVT release gate and the end-user ``kairix probe-config`` health check
+share one implementation. F29 flags any ``.py`` file whose name matches a
+benchmark / perf / latency naming pattern and lives outside the allowed roots
+(``kairix/quality/probe/``, ``tests/``, ``scripts/probe*``).
 
-F29 detects any ``.py`` file whose name matches a benchmark / perf /
-microbench / latency naming pattern and lives outside the allowed
-roots.
-
-Allowed roots (perf scripts welcome here):
-  - ``kairix/quality/probe/**`` — the canonical home.
-  - ``tests/**`` — test files may assert on latency or coalesce-ratio
-    bounds (those assertions are the gate, not new measurement
-    plumbing).
-  - ``scripts/probe*`` — operational scripts that drive the probe.
-
-Rejected paths (where a perf-named file is a regression):
-  - ``kairix/transport/**`` (instrumented via the probe's hook)
-  - ``kairix/providers/**`` (instrumented via the probe's hook)
-  - any other location under ``kairix/`` outside ``kairix/quality/probe/``
-
-File-name patterns considered perf-measurement:
-  - ``bench*.py``, ``microbench*.py``
-  - ``*_bench.py``, ``*_microbench.py``
-  - ``*_latency.py``, ``*_latency_*.py``
-  - ``*_perf.py``, ``*_perf_*.py``
-
-If ``kairix/`` does not exist (fresh checkout) the check still walks
-the rest of the tree; if no perf-named files exist anywhere outside
-the allow-list, the check passes trivially.
+Thin shim over :mod:`_location_engine` (#499 Phase 2). The rule is one
+``LocationRule`` row in ``filename-regex`` kind; this module re-exports the
+back-compat surface (``collect_violations`` / ``main`` / ``REMEDIATION`` /
+``_is_perf_named``) the F29 unit test loads by file path.
 """
 
 from __future__ import annotations
@@ -44,10 +19,11 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
+from _location_engine import LocationRule, collect_violations_for, register
 from tc_fitness import REPO_ROOT, gate
 
-# Regex that matches a perf-measurement-shaped filename. Anchored at
-# both ends — we only flag files whose entire basename matches.
+# Regex that matches a perf-measurement-shaped filename. Anchored at both ends
+# — we only flag files whose entire basename matches.
 _PERF_NAME_RE = re.compile(
     r"""
     ^(
@@ -63,18 +39,6 @@ _PERF_NAME_RE = re.compile(
     """,
     re.VERBOSE,
 )
-
-# Directories whose contents are explicitly allowed to contain perf
-# measurement code. A path is allowed if it lives under ANY of these
-# prefixes (relative to repo root).
-_ALLOWED_PREFIXES: tuple[Path, ...] = (
-    Path("kairix") / "quality" / "probe",
-    Path("tests"),
-)
-
-# Prefix for operational probe-driver scripts at the repo root.
-_ALLOWED_SCRIPTS_PREFIX = Path("scripts")
-_ALLOWED_SCRIPTS_NAME_RE = re.compile(r"^probe[a-z0-9_-]*\.(py|sh)$")
 
 REMEDIATION = """Refactor to move the performance-measurement code into
 kairix/quality/probe/ — that's the single perf surface for the whole
@@ -109,63 +73,31 @@ stays stable. Parallel benchmark harnesses scattered across
 transport/ and providers/ create the per-provider conditional jungle
 the ADR exists to remove."""
 
+RULE = register(
+    LocationRule(
+        name="f29",
+        kind="filename-regex",
+        pattern=_PERF_NAME_RE,
+        allowed_roots=("kairix/quality/probe", "tests"),
+        probe_scripts=True,
+        remediation=REMEDIATION,
+    )
+)
+
 
 def _is_perf_named(name: str) -> bool:
-    """True if ``name`` is a basename that matches a perf-measurement
-    naming pattern (bench/microbench/latency/perf)."""
+    """True if ``name`` is a basename matching a perf-measurement naming
+    pattern (bench/microbench/latency/perf). Re-exported for the F29 test."""
     return _PERF_NAME_RE.match(name) is not None
 
 
-def _is_allowed(rel_path: Path) -> bool:
-    """True if a perf-named file at ``rel_path`` (relative to repo
-    root) is allowed under F29's exception roots.
-    """
-    parts = rel_path.parts
-    for prefix in _ALLOWED_PREFIXES:
-        prefix_parts = prefix.parts
-        if len(parts) >= len(prefix_parts) and tuple(parts[: len(prefix_parts)]) == prefix_parts:
-            return True
-    # scripts/probe*.{py,sh} is also allowed — the operational
-    # driver scripts that invoke the probe.
-    if len(parts) >= 2 and parts[0] == _ALLOWED_SCRIPTS_PREFIX.name and _ALLOWED_SCRIPTS_NAME_RE.match(parts[-1]):
-        return True
-    return False
-
-
 def collect_violations(repo_root: Path = REPO_ROOT) -> set[Path]:
-    """Walk every .py file under ``repo_root/kairix/`` and return
-    repo-relative paths of perf-named files that live outside the
-    allowed roots.
-
-    Note: the scan is deliberately scoped to ``kairix/`` (not the
-    entire repo tree). Perf-named files under top-level ``tools/`` or
-    ``scratch/`` are explicitly out of scope — F29 protects the
-    production package boundary. Files under ``tests/`` are excluded
-    by ``_is_allowed``.
-    """
-    kairix_dir = repo_root / "kairix"
-    if not kairix_dir.exists():
-        return set()
-
-    violations: set[Path] = set()
-    for path in kairix_dir.rglob("*.py"):
-        if "__pycache__" in path.parts:
-            continue
-        if not _is_perf_named(path.name):
-            continue
-        try:
-            rel = path.resolve().relative_to(repo_root)
-        except ValueError:
-            continue
-        if _is_allowed(rel):
-            continue
-        violations.add(rel)
-    return violations
+    """Back-compat surface for the F29 unit test."""
+    return collect_violations_for(RULE, repo_root)
 
 
 def main() -> int:
-    violations = collect_violations()
-    return gate("f29", violations, REMEDIATION)
+    return gate(RULE.name, collect_violations(), REMEDIATION)
 
 
 if __name__ == "__main__":

--- a/scripts/checks/check_provider_layer_imports.py
+++ b/scripts/checks/check_provider_layer_imports.py
@@ -1,65 +1,24 @@
-"""F26: ``kairix/core/**`` may not import ``kairix/providers/**`` or ``kairix/transport/**``.
+"""F26: ``kairix/core/**`` may not import ``kairix/providers/**`` or
+``kairix/transport/**``.
 
-The three-layer provider-plugin split (see
-``docs/architecture/provider-plugin-architecture.md``) places a hard
-boundary between the domain (``kairix/core/``), the universal endpoint
-concerns (``kairix/transport/``), and the per-provider plugins
-(``kairix/providers/``). Core knows about Protocols, not
-implementations.
+Domain code talks to the provider / transport layers through Protocols
+(``kairix/core/protocols.py``) only. ``kairix/core/factory.py`` is the
+composition root and is exempt — it wires concrete providers into pipelines.
 
-Allowed from ``kairix/core/``:
-  - ``from kairix.core.protocols import ...`` (Protocol types are the
-    seam between layers — fine to import).
-  - sibling ``kairix.core.*`` imports.
-  - the ``kairix`` top-level package itself.
-
-Rejected from ``kairix/core/``:
-  - ``from kairix.providers... import ...``
-  - ``from kairix.transport... import ...``
-  - ``import kairix.providers...`` / ``import kairix.transport...``
-
-The detector AST-walks every ``.py`` file under ``kairix/core/`` and
-flags any ``Import`` / ``ImportFrom`` node whose module path starts
-with ``kairix.providers`` or ``kairix.transport``. Pre-existing
-violations are grandfathered in
-``.architecture/baseline/f26-files.txt``.
-
-If ``kairix/core/`` does not exist (fresh checkout) or has no Python
-files, the check passes trivially — F26 only fires once core code
-appears.
+Thin shim over :mod:`_import_boundary_engine` (#499 Phase 2). The rule is one
+``ImportBoundaryRule`` row in ``prefix`` mode; this module re-exports the
+back-compat surface (``collect_violations`` / ``main`` / ``REMEDIATION``) the
+F26 unit test loads by file path.
 """
 
 from __future__ import annotations
 
-import ast
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
-from _fitness_rule import FitnessRule
-from tc_fitness import REPO_ROOT, repo_relative  # noqa: F401 — back-compat for test imports
-
-# Module prefixes the core/ tree is forbidden from importing. Anchored
-# with a trailing dot so we don't accidentally flag a hypothetical
-# ``kairix.providers_helpers`` sibling.
-_FORBIDDEN_PREFIXES: tuple[str, ...] = (
-    "kairix.providers",
-    "kairix.transport",
-)
-
-# Composition-root exemption. ``kairix/core/factory.py`` is the runtime
-# wire-up — it must import concrete providers/transport to compose
-# protocol implementations into pipelines. The exemption is encoded
-# here (not as an open baseline entry) because it's an architectural
-# invariant, not pre-existing tech debt. See
-# ``docs/architecture/provider-plugin-architecture.md`` §"Composition
-# root" for the rationale; the factory is the *only* file in core/
-# whose job description is to cross the layer boundary.
-_ALLOWLIST_PATHS: frozenset[str] = frozenset(
-    {
-        "kairix/core/factory.py",
-    }
-)
+from _import_boundary_engine import ImportBoundaryRule, collect_violations_for, register
+from tc_fitness import REPO_ROOT, gate
 
 REMEDIATION = """Refactor to route the call through a Protocol in
 kairix/core/protocols.py — domain code must not know which provider or
@@ -95,64 +54,25 @@ class of bug the three-layer split exists to prevent (every new
 provider means editing _azure.py; every new perf concern accretes
 inside core/)."""
 
-
-def _module_is_forbidden(module: str | None) -> bool:
-    """True if ``module`` is a forbidden import target for core code.
-
-    A module path matches when it equals one of the forbidden prefixes
-    or starts with ``<prefix>.``. Plain ``kairix`` and ``kairix.core.*``
-    are never matched.
-    """
-    if module is None:
-        return False
-    for prefix in _FORBIDDEN_PREFIXES:
-        if module == prefix or module.startswith(prefix + "."):
-            return True
-    return False
-
-
-def file_has_violation(path: Path) -> bool:
-    """True if ``path`` (a .py file under kairix/core/) contains any
-    forbidden import.
-
-    Inspects both ``ImportFrom`` (``from kairix.providers... import x``)
-    and ``Import`` (``import kairix.transport.pool``) nodes.
-    """
-    try:
-        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-    except (SyntaxError, UnicodeDecodeError, OSError):
-        return False
-
-    for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom):
-            if _module_is_forbidden(node.module):
-                return True
-        elif isinstance(node, ast.Import):
-            for alias in node.names:
-                if _module_is_forbidden(alias.name):
-                    return True
-    return False
-
-
-class F26(FitnessRule):
-    """F26 as a FitnessRule subclass — see module docstring for rule semantics."""
-
-    name = "f26"
-    remediation = REMEDIATION
-    roots = ("kairix/core",)
-    exempt_files = _ALLOWLIST_PATHS
-
-    def file_has_violation(self, path: Path) -> bool:
-        return file_has_violation(path)
+RULE = register(
+    ImportBoundaryRule(
+        name="f26",
+        roots=("kairix/core",),
+        mode="prefix",
+        forbidden_prefixes=("kairix.providers", "kairix.transport"),
+        exempt=("kairix/core/factory.py",),
+        remediation=REMEDIATION,
+    )
+)
 
 
 def collect_violations(repo_root: Path = REPO_ROOT) -> set[Path]:
-    """Back-compat helper for direct test imports."""
-    return F26(repo_root=repo_root).collect_violations()
+    """Back-compat surface for the F26 unit test."""
+    return collect_violations_for(RULE, repo_root)
 
 
 def main() -> int:
-    return F26().run()
+    return gate(RULE.name, collect_violations(), REMEDIATION)
 
 
 if __name__ == "__main__":

--- a/tests/architecture/test_import_boundary_level_handling.py
+++ b/tests/architecture/test_import_boundary_level_handling.py
@@ -1,0 +1,191 @@
+"""Faithfulness proof for ``_import_boundary_engine`` ``ImportFrom.level`` handling.
+
+#499 Phase 2 collapsed six import-boundary rules (F26, F27, F34, F35, F37,
+F44) into one declarative engine. The first pass introduced a SILENT
+divergence: the shared ``_import_modules`` skipped every relative import
+(``node.level > 0``) before reading ``node.module``. But five of the six
+originals are level-AGNOSTIC — their ``file_has_violation`` / ``_imported_names``
+/ ``_plugin_dir_for`` walkers inspect ``node.module`` directly with no
+``node.level`` guard, so a relative import whose ``.module`` matches a forbidden
+prefix / sibling plugin (``from .kairix.providers import x`` → level=1,
+module=``kairix.providers``; ``from ..psycopg2 import bar`` → level=2,
+module=``psycopg2``) IS flagged by the original. The blanket skip dropped those.
+
+Only F37 (sync-lib mode) guards ``node.level`` in its original
+``_import_targets`` — a relative import cannot reach a third-party sync library
+by construction, so it is correctly ignored there.
+
+This module pins the corrected per-rule policy that restores parity with each
+original byte-for-behaviour:
+
+* F26 / F27 / F34 / F35 / F44 — level-AGNOSTIC: a relative import whose
+  ``.module`` matches the rule's forbidden set IS flagged.
+* F37 — level-GUARDED: a relative import whose ``.module`` matches a sync-lib
+  root is NOT flagged.
+
+Each test carries an inline sabotage-proof (mutate the import to the negative
+shape → confirm the flag clears), so a future regression in the level policy
+surfaces here, not silently in production.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_CHECKS = _REPO_ROOT / "scripts" / "checks"
+
+
+def _load(mod_name: str, file_name: str):
+    """Load a detector shim by file path with ``scripts/checks`` importable."""
+    if str(_CHECKS) not in sys.path:
+        sys.path.insert(0, str(_CHECKS))
+    spec = importlib.util.spec_from_file_location(mod_name, _CHECKS / file_name)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write(root: Path, rel: str, body: str) -> None:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+# ── F26: prefix mode, level-agnostic ────────────────────────────────────────
+
+
+def test_f26_relative_import_matching_forbidden_prefix_is_flagged(tmp_path: Path) -> None:
+    """``from .kairix.providers import x`` (level=1, module='kairix.providers')
+    fires F26 — the original walked ``node.module`` regardless of ``node.level``.
+
+    Sabotage-proof inline: rewrite the relative import to target the allowed
+    Protocol surface; the flag clears.
+    """
+    detector = _load("_f26_level", "check_provider_layer_imports.py")
+    root = tmp_path.resolve()
+    _write(root, "kairix/core/rel.py", "from .kairix.providers import x\n")
+    assert Path("kairix/core/rel.py") in detector.collect_violations(root)
+
+    # Sabotage: relative import that does NOT match a forbidden prefix.
+    _write(root, "kairix/core/rel.py", "from .kairix.core.protocols import X\n")
+    assert detector.collect_violations(root) == set()
+
+
+# ── F27: sibling-plugin mode, level-agnostic ────────────────────────────────
+
+
+def test_f27_relative_import_matching_sibling_plugin_is_flagged(tmp_path: Path) -> None:
+    """``from .kairix.providers.azure import h`` inside the ``openai`` plugin
+    (level=1, module='kairix.providers.azure') fires F27 — the sibling-plugin
+    walk is level-agnostic.
+
+    Sabotage-proof inline: rewrite to target the shared ``_base`` scaffolding;
+    the flag clears.
+    """
+    detector = _load("_f27_level", "check_no_cross_provider.py")
+    root = tmp_path.resolve()
+    _write(root, "kairix/providers/openai/rel.py", "from .kairix.providers.azure import h\n")
+    assert Path("kairix/providers/openai/rel.py") in detector.collect_violations(root)
+
+    # Sabotage: shared base is never cross-plugin.
+    _write(root, "kairix/providers/openai/rel.py", "from .kairix.providers._base import Provider\n")
+    assert detector.collect_violations(root) == set()
+
+
+# ── F34: prefix mode, level-agnostic ────────────────────────────────────────
+
+
+def test_f34_relative_import_matching_forbidden_prefix_is_flagged(tmp_path: Path) -> None:
+    """``from .kairix.connectors import c`` (level=1, module='kairix.connectors')
+    fires F34 — the audit-proven level-agnostic case.
+
+    Sabotage-proof inline: rewrite to the Protocol surface; the flag clears.
+    """
+    detector = _load("_f34_level", "check_f34_core_connector_layer_imports.py")
+    root = tmp_path.resolve()
+    _write(root, "kairix/core/connectors/rel.py", "from .kairix.connectors import c\n")
+    assert Path("kairix/core/connectors/rel.py") in detector.collect_violations(root)
+
+    # Sabotage: Protocol import is allowed.
+    _write(root, "kairix/core/connectors/rel.py", "from .kairix.core.protocols import SourceConnector\n")
+    assert detector.collect_violations(root) == set()
+
+
+# ── F35: sibling-plugin mode (+ extractor predicate), level-agnostic ─────────
+
+
+def test_f35_relative_import_matching_sibling_connector_is_flagged(tmp_path: Path) -> None:
+    """``from .kairix.connectors.obsidian import scan`` inside the ``sharepoint``
+    connector (level=1, module='kairix.connectors.obsidian') fires F35.
+
+    Sabotage-proof inline: rewrite to the shared ``_base``; the flag clears.
+    """
+    detector = _load("_f35_level", "check_f35_no_cross_connector.py")
+    root = tmp_path.resolve()
+    _write(root, "kairix/connectors/sharepoint/rel.py", "from .kairix.connectors.obsidian import scan\n")
+    assert Path("kairix/connectors/sharepoint/rel.py") in detector.collect_violations(root)
+
+    # Sabotage: shared base is never cross-plugin.
+    _write(root, "kairix/connectors/sharepoint/rel.py", "from .kairix.connectors._base import SourceConnector\n")
+    assert detector.collect_violations(root) == set()
+
+
+def test_f35_relative_import_matching_extractor_prefix_is_flagged(tmp_path: Path) -> None:
+    """The F35 extractor-ban predicate is also level-agnostic:
+    ``from .kairix.extractors.markitdown import M`` (level=1,
+    module='kairix.extractors.markitdown') fires F35.
+    """
+    detector = _load("_f35_extr", "check_f35_no_cross_connector.py")
+    root = tmp_path.resolve()
+    _write(root, "kairix/connectors/sharepoint/rel.py", "from .kairix.extractors.markitdown import M\n")
+    assert Path("kairix/connectors/sharepoint/rel.py") in detector.collect_violations(root)
+
+
+# ── F44: prefix mode, level-agnostic ────────────────────────────────────────
+
+
+def test_f44_relative_import_matching_firm_client_is_flagged(tmp_path: Path) -> None:
+    """``from ..psycopg2 import connect`` (level=2, module='psycopg2') fires F44 —
+    the original ``_imported_names`` reads ``node.module`` with no level guard.
+
+    Sabotage-proof inline: rewrite to an engagement-scope client; the flag clears.
+    """
+    detector = _load("_f44_level", "check_f44_engagement_firm_boundary.py")
+    root = tmp_path.resolve()
+    _write(root, "kairix/core/storage/rel.py", "from ..psycopg2 import connect\n")
+    assert Path("kairix/core/storage/rel.py") in detector.collect_violations(root)
+
+    # Sabotage: SQLite is engagement-scope and welcome.
+    _write(root, "kairix/core/storage/rel.py", "from ..sqlite3 import connect\n")
+    assert detector.collect_violations(root) == set()
+
+
+# ── F37: sync-lib mode, level-GUARDED ───────────────────────────────────────
+
+
+def test_f37_relative_import_matching_sync_lib_is_not_flagged(tmp_path: Path) -> None:
+    """``from ..watchdog import Observer`` (level=2, module='watchdog') is NOT
+    flagged by F37 — its original ``_import_targets`` alone guards ``node.level``
+    (a relative import cannot reach a third-party sync library by construction).
+
+    Sabotage-proof inline: switch to the ABSOLUTE form in the same forbidden
+    location; the flag fires — proving the rule still detects real sync-lib
+    reaches and the difference is purely the level policy.
+    """
+    detector = _load("_f37_level", "check_f37_singular_sync.py")
+    root = tmp_path.resolve()
+    _write(root, "kairix/corpus/rel.py", "from ..watchdog import Observer\n")
+    assert detector.collect_violations(root) == set()
+
+    # Sabotage: the absolute form in the same forbidden tree IS a violation.
+    _write(root, "kairix/corpus/rel.py", "from watchdog.observers import Observer\n")
+    assert Path("kairix/corpus/rel.py") in detector.collect_violations(root)


### PR DESCRIPTION
Second of the #499 Phase 2 simplifications — collapses the nine boundary/location fitness rules into **two declarative table engines**, one row per F-id.

## What
- `_import_boundary_engine.py` (F26/F27/F34/F35/F37/F44) + `_location_engine.py` (F29/F38/F61): a frozen-dataclass row schema + a `RULES` table + one engine function each. ~9×180 lines of duplicated AST-walk-and-gate skeleton → 2 engines + nine 5-10-line shims. **343-line net reduction.**
- Every F-id keeps its own `check_*.py` shim, baseline file, catalogue row, and per-rule test — so F-ids, baselines, F92 currency, the runner, and all nine `test_f<NN>_*` tests are untouched. The F44 `.sh`+`script=` dispatch is preserved.
- A `mode` discriminator (`prefix` | `sibling-plugin` | `sync-lib`) carries the three import shapes; a `kind` discriminator (`filename-regex` | `def-name` | `ctor-call`) the three location shapes.

## Faithfulness (this is the important part)
A 9-way adversarial audit diffed each new row against the pre-refactor source. It caught a **behavioural divergence**: the engine's blanket skip of relative imports (`node.level > 0`) would have made F34/F44 (and silently F26/F27/F35) **miss** a forbidden import in relative form. The fix made level-handling **per-rule faithful** — and revealed that **F37 alone is level-guarded** while the other five are level-agnostic, so a naive global fix would itself have broken F37. A differential harness now proves original-vs-engine produce identical violation sets across all six rules **including relative-import cases**, pinned by a new sabotage-proven test (`test_import_boundary_level_handling.py`).

## Verification
- The nine `test_f<NN>_*` tests pass **byte-for-byte unchanged** (91) + 7 new level-policy tests = 98 passed.
- 88/88 fitness functions + F92 green under venv. Baselines untouched. Full `safe-commit.sh` clean (10,056 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
