### PR TITLE
feat(ci): security re-parent + F93 CI fan-in parity rule (#499 Phase 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -651,9 +651,13 @@ jobs:
   security:
     name: "Stage 4 -- Security"
     runs-on: ubuntu-latest
-    needs: [changes, unit-and-type]
+    # bandit / pip-audit / detect-secrets are import-graph-independent — they
+    # scan source + dependency manifests, not the unit test surface, so they
+    # don't need the unit matrix to pass first. Parented on `changes` alone,
+    # security now overlaps Stage 2 (#499 Phase 2) instead of waiting for it.
+    needs: [changes]
     if: needs.changes.outputs.python == 'true'
-    # Run in parallel with integration -- both depend on unit passing
+    # Run in parallel with integration + the unit matrix -- no test dependency
     permissions:
       contents: read
       security-events: write   # required to upload SARIF / security findings
@@ -733,6 +737,16 @@ jobs:
   # "SonarCloud Code Analysis" check posted by the SonarCloud GitHub App over
   # webhook can race / temporarily disagree (#269); branch protection should
   # gate on this `SonarCloud analysis` job, not the webhook-posted check.
+  # fan-in: informational — SonarCloud is advisory and intentionally NOT in
+  # the `check` (CI gate) fan-in. Branch protection requires exactly "CI gate"
+  # + "2 · Pre-merge PR gates (PR → main)"; SonarCloud is not a separately
+  # required status context (the webhook-posted "SonarCloud Code Analysis"
+  # check can race / temporarily disagree with this job — #269). The Sonar
+  # new-code parity gate is enforced locally + in the security stage via
+  # check_sonar_new_code.py, not through this job's pass/fail.
+  # TODO(#499): confirm gating intent — the job header comment below still
+  # reads "branch protection should gate on this job"; reconcile that with the
+  # current branch-protection contexts before promoting Sonar to a hard gate.
   sonarcloud:
     name: "SonarCloud analysis"
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ Mechanical, blocking checks encode rejected patterns into automation. F-numbers 
 - **F4** no os.environ.get("KAIRIX_*") outside paths.py / secrets.py. **F22** repo paths follow per-tree naming conventions. **F24** no `from tests.*` / `import tests` inside kairix/**/*.py — tests not shipped in wheel. **F29** performance-measurement code only under kairix/quality/probe/. **F32** no real names in test fixtures (use agent-alpha etc. + reference library). **F33** shellcheck disable directives require rationale. **no-hardcoded-user-paths** F31: no hardcoded /Users/ or /home/<dev>/ paths.
 
 **Observability**
-- **F74** every Stage subclass is only invoked via a StageRunner — never direct .process() call _(vacuous)_.
+- **F74** every Stage subclass is only invoked via a StageRunner — never direct .process() call _(vacuous)_. **F93** every ci.yml job is in the 'CI gate' aggregator's needs: closure (so its failure blocks the merge) or carries a # fan-in: informational marker — a green merge can't ship with an un-gated job failing.
 
 **Process**
 - **worktree-isolation** subagent worktree isolation — no shadow copies in primary checkout. **F92** catalogue currency — every check_*.{py,sh} has a RuleEntry, every RuleEntry maps to an existing check, and the generated doc regions match generate_catalogue_docs.py --check (the self-hosting guard for the catalogue-driven runner).

--- a/docs/architecture/fitness-functions.md
+++ b/docs/architecture/fitness-functions.md
@@ -304,6 +304,7 @@ _Generated from `scripts/checks/_rule_catalogue.py` — do not edit by hand._
 | F32 | repo-hygiene | per-file | shipped | no real names in test fixtures (use agent-alpha etc. + reference library) |
 | F33 | repo-hygiene | per-file | shipped | shellcheck disable directives require rationale |
 | F74 | observability | per-class | vacuous | every Stage subclass is only invoked via a StageRunner — never direct .process() call |
+| F93 | observability | cross-cutting | shipped | every ci.yml job is in the 'CI gate' aggregator's needs: closure (so its failure blocks the merge) or carries a # fan-in: informational marker — a green merge can't ship with an un-gated job failing |
 | F75 | test-discipline | cross-cutting | proposed | every CLI subcommand + MCP tool + connector appears in at least one eval-suite question |
 | F76 | production-safety | per-file | shipped | no f-string interpolation of content-like vars (raw/body/payload/markdown/...) in log/exception/dead-letter strings |
 | F77 | schema-integrity | per-file | proxy | sqlite3.connect call sites outside the allow-list (worker/factory/scripts/tests) are flagged |

--- a/scripts/checks/_rule_catalogue.py
+++ b/scripts/checks/_rule_catalogue.py
@@ -999,6 +999,19 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         status="vacuous",
     ),
     RuleEntry(
+        id="F93",
+        gate="f93-ci-fanin-parity",
+        check="f93_ci_fanin_parity",
+        category="observability",
+        scope="cross-cutting",
+        summary=(
+            "every ci.yml job is in the 'CI gate' aggregator's needs: closure (so its failure "
+            "blocks the merge) or carries a # fan-in: informational marker — a green merge can't "
+            "ship with an un-gated job failing"
+        ),
+        adr_origin="EPIC #499 Phase 2 — CI fan-in parity (dangling-job-ships-green class)",
+    ),
+    RuleEntry(
         id="F75",
         gate="f75-eval-suite-parity",
         check="(proposed)",

--- a/scripts/checks/check_f93_ci_fanin_parity.py
+++ b/scripts/checks/check_f93_ci_fanin_parity.py
@@ -1,0 +1,272 @@
+"""F93: every CI job either gates the merge or is explicitly informational.
+
+Motivation (EPIC #499 Phase 2 — the fan-in parity class)
+--------------------------------------------------------
+``main`` branch protection requires exactly one status context from this
+workflow: **"CI gate"** (the terminal ``check`` job, whose ``needs:``
+fan-in aggregates every blocking stage). A green merge is therefore only
+as safe as that fan-in is COMPLETE. If a job is defined in ``ci.yml`` but
+is NOT reachable from the ``CI gate`` aggregator's transitive ``needs:``
+closure, its failure does not block the merge — a red job ships
+silently. The class this prevents: someone adds a new stage (a license
+scan, a second security job, a schema-drift gate), wires its triggers,
+but forgets to add it to the ``check`` job's ``needs:`` list. CI shows it
+running and failing, branch protection waves the PR through anyway,
+because "CI gate" went green without ever waiting on the new job.
+
+What F93 asserts
+----------------
+Parse ``.github/workflows/ci.yml``. Identify the aggregator job — the one
+whose ``name:`` is ``CI gate``. Build the transitive ``needs:`` closure
+rooted at that aggregator. Then assert: every job defined in the workflow
+is EITHER
+
+  * in that closure (so its failure blocks the gate), OR
+  * the aggregator itself (the closure root), OR
+  * carries an explicit ``# fan-in: informational — <reason>`` marker
+    comment in the lines immediately preceding its ``<job-id>:`` key.
+
+A job that is neither in the closure nor marked informational is a
+FAILURE: its failure cannot block a merge, yet nothing in the file says
+that is intentional.
+
+The informational marker convention
+-----------------------------------
+``# fan-in: informational — <reason>``  on its own comment line in the
+block of comments directly above the job key. The reason is mandatory
+free text (F21 affordance: state WHY the job is legitimately non-gating —
+"advisory", "publishes artefacts", "posts a PR comment"). A bare
+``# fan-in: informational`` with no reason still satisfies the marker
+presence, but reviewers should push back on a missing reason.
+
+Intentionally NOT caught (precision over recall — a detector agents
+distrust is worse than no detector):
+
+  * **Whether a job SHOULD gate.** F93 cannot know intent. It only
+    proves the file is INTERNALLY HONEST: every non-gating job SAYS it is
+    non-gating. Promoting an informational job into the gate is a human
+    decision (add it to the aggregator's ``needs:`` and drop the marker).
+  * **Workflows other than ci.yml.** Sibling workflows
+    (fresh-install-smoke, soak-suite, release) have their own gating
+    story and are not aggregated by this ``CI gate`` job; F93 scopes to
+    the single workflow that produces the required context.
+  * **The aggregator's own pass/fail logic.** Whether the ``check`` job's
+    shell correctly fails on a failed dependency is F83's / the job's own
+    concern; F93 only checks the ``needs:`` graph shape.
+  * **``if:`` conditions on closure membership.** A job in the closure
+    that is path-filtered (``if: needs.changes.outputs.python``) still
+    counts as gating — when it runs and fails, the aggregator sees the
+    failure. Skipped is not failed.
+
+Binary structural check, no per-file baseline (same shape as F81's
+fresh-install-smoke presence gate and F92's catalogue currency): the
+fan-in graph is either complete or it is not.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent))
+from tc_fitness import REPO_ROOT, gate
+
+WORKFLOW_REL = Path(".github/workflows/ci.yml")
+
+# The job whose name produces the required "CI gate" status context.
+AGGREGATOR_NAME = "CI gate"
+
+# The marker that declares a job legitimately outside the gate fan-in.
+INFORMATIONAL_MARKER = "# fan-in: informational"
+
+REMEDIATION = """F93: a CI job is not reachable from the "CI gate" aggregator and is
+not marked informational — a green merge could ship with that job
+failing.
+
+Branch protection on main requires exactly the "CI gate" status context
+(the terminal `check` job). Its `needs:` fan-in is what makes that one
+green light mean "every blocking stage passed". A job outside that
+transitive closure does NOT block the merge: it can run, fail, and the
+PR still merges green.
+
+fix: decide whether the dangling job SHOULD gate the merge —
+  * If yes (it is a real blocking stage): add the job's id to the
+    `check` (CI gate) job's `needs:` list. Add it to the aggregator's
+    result-evaluation loop too so a failure actually fails the gate.
+  * If no (it is advisory — publishes artefacts, posts a PR comment,
+    races a webhook): add a marker comment on the lines directly above
+    the job's `<id>:` key:
+        # fan-in: informational — <why this job is legitimately non-gating>
+next: re-run python3 scripts/checks/check_f93_ci_fanin_parity.py to
+confirm the gate goes green.
+run: bash scripts/safe-commit.sh "ci: wire <job> into the CI-gate fan-in (or mark it informational)"
+
+Pass example: .github/workflows/ci.yml
+  # fan-in: informational — SonarCloud is advisory; not a required status
+  # context, and its webhook check can race this job (#269).
+  sonarcloud:
+    name: "SonarCloud analysis"
+    needs: [changes, unit-and-type]
+  ...
+  check:
+    name: "CI gate"
+    needs:
+      - changes
+      - unit-and-type
+      - security        # every blocking stage is listed here
+      - docker
+
+Forbidden example:
+  license-scan:          # NEW blocking job, runs + fails on a bad licence
+    name: "License scan"
+    needs: [changes]
+  check:
+    name: "CI gate"
+    needs:
+      - changes          # license-scan NOT listed, NOT marked informational
+      - docker           # → a bad licence merges green."""
+
+
+def _load_jobs(workflow_text: str) -> dict[str, dict]:
+    """Parse the workflow and return its ``jobs`` mapping ({} on failure).
+
+    PyYAML is the canonical parser already used across the checks tree.
+    A malformed workflow yields ``{}`` — the caller treats "no jobs" as
+    "nothing to assert" rather than crashing the gate.
+    """
+    try:
+        data = yaml.safe_load(workflow_text)
+    except yaml.YAMLError:
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    jobs = data.get("jobs")
+    return jobs if isinstance(jobs, dict) else {}
+
+
+def _needs_of(job_spec: object) -> list[str]:
+    """Normalise a job's ``needs:`` to a list of job-id strings.
+
+    GitHub Actions accepts both scalar (``needs: changes``) and sequence
+    (``needs: [a, b]``) forms. Anything else yields an empty list.
+    """
+    if not isinstance(job_spec, dict):
+        return []
+    needs = job_spec.get("needs")
+    if isinstance(needs, str):
+        return [needs]
+    if isinstance(needs, list):
+        return [n for n in needs if isinstance(n, str)]
+    return []
+
+
+def _find_aggregator(jobs: dict[str, dict]) -> str | None:
+    """Return the job id whose ``name:`` is the aggregator name, else None."""
+    for job_id, spec in jobs.items():
+        if isinstance(spec, dict) and spec.get("name") == AGGREGATOR_NAME:
+            return job_id
+    return None
+
+
+def _closure(jobs: dict[str, dict], root: str) -> set[str]:
+    """Transitive ``needs:`` closure rooted at ``root`` (root excluded).
+
+    Walks the dependency graph breadth-first. A ``needs:`` reference to a
+    job that does not exist is ignored (GitHub would error on it; the
+    graph walk simply has nothing to descend into).
+    """
+    seen: set[str] = set()
+    frontier = list(_needs_of(jobs.get(root)))
+    while frontier:
+        node = frontier.pop()
+        if node in seen or node not in jobs:
+            continue
+        seen.add(node)
+        frontier.extend(_needs_of(jobs.get(node)))
+    return seen
+
+
+def _jobs_marked_informational(workflow_text: str, job_ids: set[str]) -> set[str]:
+    """Return the set of job ids carrying an informational marker.
+
+    A job ``<id>:`` is marked when the contiguous block of comment lines
+    immediately preceding its key line contains
+    ``# fan-in: informational``. We scan the raw text (PyYAML discards
+    comments) and match a top-level ``<id>:`` key at two-space indent —
+    the indentation every job key sits at under ``jobs:``.
+    """
+    lines = workflow_text.splitlines()
+    marked: set[str] = set()
+    for idx, raw in enumerate(lines):
+        stripped = raw.strip()
+        # Job keys live at exactly two-space indent under `jobs:` and end
+        # in a colon with no inline value (e.g. "  sonarcloud:").
+        if not (raw.startswith("  ") and raw[2:3] != " "):
+            continue
+        if not stripped.endswith(":"):
+            continue
+        job_id = stripped[:-1].strip()
+        if job_id not in job_ids:
+            continue
+        # Walk upward over the contiguous comment block above the key.
+        cursor = idx - 1
+        while cursor >= 0:
+            above = lines[cursor].strip()
+            if above.startswith("#"):
+                if INFORMATIONAL_MARKER in lines[cursor]:
+                    marked.add(job_id)
+                    break
+                cursor -= 1
+                continue
+            break  # first non-comment line ends the block
+    return marked
+
+
+def collect_violations(repo_root: Path = REPO_ROOT) -> set[Path]:
+    """Return a synthetic repo-relative path per dangling (un-gated,
+    un-marked) job. Empty set means the fan-in is honest.
+
+    The synthetic entries name the workflow + offending job so the
+    failure output reads as an inventory (mirroring F81's
+    ``<workflow>::<problem>`` convention).
+    """
+    workflow = repo_root / WORKFLOW_REL
+    if not workflow.is_file():
+        # No ci.yml → nothing this rule governs. F81 owns presence of the
+        # smoke workflow; F93 owns the SHAPE of ci.yml when it exists.
+        return set()
+
+    text = workflow.read_text(encoding="utf-8")
+    jobs = _load_jobs(text)
+    if not jobs:
+        return set()
+
+    aggregator = _find_aggregator(jobs)
+    if aggregator is None:
+        # The required "CI gate" context has no producing job — the whole
+        # fan-in premise is broken. Surface it as a single violation.
+        return {Path(f"{WORKFLOW_REL}::no-aggregator-named-{AGGREGATOR_NAME.replace(' ', '-')}")}
+
+    gated = _closure(jobs, aggregator)
+    informational = _jobs_marked_informational(text, set(jobs))
+
+    violations: set[Path] = set()
+    for job_id in jobs:
+        if job_id == aggregator:
+            continue  # the closure root gates by definition
+        if job_id in gated:
+            continue
+        if job_id in informational:
+            continue
+        violations.add(Path(f"{WORKFLOW_REL}::{job_id}-not-in-CI-gate-fanin"))
+    return violations
+
+
+def main() -> int:
+    return gate("f93-ci-fanin-parity", collect_violations(), REMEDIATION)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/architecture/test_f93_ci_fanin_parity.py
+++ b/tests/architecture/test_f93_ci_fanin_parity.py
@@ -1,0 +1,207 @@
+"""Unit tests for F93 — the CI fan-in parity rule.
+
+F93 proves ``.github/workflows/ci.yml`` is internally honest: every job
+either sits in the ``CI gate`` aggregator's transitive ``needs:`` closure
+(so its failure blocks the merge) or carries a
+``# fan-in: informational`` marker. A job that is neither is a dangling
+job — it can run, fail, and the PR still merges green.
+
+These tests drive the public ``collect_violations(repo_root=...)``
+surface against synthetic workflow files in a tmp dir, plus a sanity
+assertion that the real shipped ci.yml is clean.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "scripts" / "checks"))
+import check_f93_ci_fanin_parity as f93
+
+pytestmark = pytest.mark.unit
+
+
+def _write_ci(repo_root: Path, text: str) -> None:
+    """Write ``text`` to ``<repo_root>/.github/workflows/ci.yml``."""
+    workflow = repo_root / ".github" / "workflows" / "ci.yml"
+    workflow.parent.mkdir(parents=True, exist_ok=True)
+    workflow.write_text(text, encoding="utf-8")
+
+
+# A minimal but realistic workflow: a `changes` root, one stage, and the
+# `check` aggregator (name "CI gate") fanning both in. `gated_stage` is in
+# the closure; the aggregator gates by definition.
+_GATED_ONLY = """\
+name: "1 · Quality gate"
+on:
+  pull_request:
+jobs:
+  changes:
+    name: "Detect changes"
+    runs-on: ubuntu-latest
+  gated_stage:
+    name: "Stage X"
+    runs-on: ubuntu-latest
+    needs: [changes]
+  check:
+    name: "CI gate"
+    needs:
+      - changes
+      - gated_stage
+"""
+
+
+def test_job_in_closure_passes(tmp_path: Path) -> None:
+    """A job reachable from the CI-gate aggregator's needs: closure is
+    gated — no violation."""
+    _write_ci(tmp_path, _GATED_ONLY)
+    assert f93.collect_violations(repo_root=tmp_path) == set()
+
+
+# Same workflow plus a `dangling` job the aggregator never lists and that
+# carries no informational marker — the failure class F93 exists to catch.
+_WITH_DANGLING = """\
+name: "1 · Quality gate"
+on:
+  pull_request:
+jobs:
+  changes:
+    name: "Detect changes"
+    runs-on: ubuntu-latest
+  gated_stage:
+    name: "Stage X"
+    runs-on: ubuntu-latest
+    needs: [changes]
+  dangling:
+    name: "Dangling stage"
+    runs-on: ubuntu-latest
+    needs: [changes]
+  check:
+    name: "CI gate"
+    needs:
+      - changes
+      - gated_stage
+"""
+
+
+def test_dangling_job_fails(tmp_path: Path) -> None:
+    """A job outside the closure with no informational marker is a
+    violation — a green merge could ship with it failing."""
+    _write_ci(tmp_path, _WITH_DANGLING)
+    violations = f93.collect_violations(repo_root=tmp_path)
+    assert violations == {Path(".github/workflows/ci.yml::dangling-not-in-CI-gate-fanin")}
+
+
+# The same dangling job, now annotated with the informational marker in
+# the comment block directly above its key — the sanctioned escape hatch.
+_WITH_DANGLING_MARKED = """\
+name: "1 · Quality gate"
+on:
+  pull_request:
+jobs:
+  changes:
+    name: "Detect changes"
+    runs-on: ubuntu-latest
+  gated_stage:
+    name: "Stage X"
+    runs-on: ubuntu-latest
+    needs: [changes]
+  # fan-in: informational — advisory job; posts a PR comment, never blocks.
+  dangling:
+    name: "Dangling stage"
+    runs-on: ubuntu-latest
+    needs: [changes]
+  check:
+    name: "CI gate"
+    needs:
+      - changes
+      - gated_stage
+"""
+
+
+def test_informational_marker_passes(tmp_path: Path) -> None:
+    """The same dangling job marked ``# fan-in: informational`` passes —
+    the file now SAYS the job is legitimately non-gating."""
+    _write_ci(tmp_path, _WITH_DANGLING_MARKED)
+    assert f93.collect_violations(repo_root=tmp_path) == set()
+
+
+def test_transitive_closure_is_followed(tmp_path: Path) -> None:
+    """A job two hops from the aggregator (aggregator → mid → leaf) is
+    gated — the closure is transitive, not just direct dependencies."""
+    workflow = """\
+name: "1 · Quality gate"
+on:
+  pull_request:
+jobs:
+  leaf:
+    name: "Leaf stage"
+    runs-on: ubuntu-latest
+  mid:
+    name: "Mid stage"
+    runs-on: ubuntu-latest
+    needs: [leaf]
+  check:
+    name: "CI gate"
+    needs:
+      - mid
+"""
+    _write_ci(tmp_path, workflow)
+    # `leaf` is only reachable through `mid`; if the walk were not
+    # transitive it would be flagged as dangling.
+    assert f93.collect_violations(repo_root=tmp_path) == set()
+
+
+def test_scalar_needs_form_is_understood(tmp_path: Path) -> None:
+    """GitHub accepts scalar ``needs: changes`` as well as the list form;
+    a job depended on via the scalar form is still in the closure."""
+    workflow = """\
+name: "1 · Quality gate"
+on:
+  pull_request:
+jobs:
+  changes:
+    name: "Detect changes"
+    runs-on: ubuntu-latest
+  check:
+    name: "CI gate"
+    needs: changes
+"""
+    _write_ci(tmp_path, workflow)
+    assert f93.collect_violations(repo_root=tmp_path) == set()
+
+
+def test_missing_aggregator_is_flagged(tmp_path: Path) -> None:
+    """No job named ``CI gate`` means the required status context has no
+    producer — the whole fan-in premise is broken; F93 surfaces it."""
+    workflow = """\
+name: "1 · Quality gate"
+on:
+  pull_request:
+jobs:
+  changes:
+    name: "Detect changes"
+    runs-on: ubuntu-latest
+  build:
+    name: "Build"
+    runs-on: ubuntu-latest
+    needs: [changes]
+"""
+    _write_ci(tmp_path, workflow)
+    violations = f93.collect_violations(repo_root=tmp_path)
+    assert violations == {Path(".github/workflows/ci.yml::no-aggregator-named-CI-gate")}
+
+
+def test_missing_workflow_is_a_no_op(tmp_path: Path) -> None:
+    """No ci.yml at all → nothing this rule governs (F81 owns workflow
+    presence). F93 must not crash or false-positive on an empty tree."""
+    assert f93.collect_violations(repo_root=tmp_path) == set()
+
+
+def test_real_ci_yml_is_clean() -> None:
+    """The shipped ci.yml must pass F93 — every job is either gated or
+    explicitly marked informational. Pins the production invariant."""
+    assert f93.collect_violations() == set()


### PR DESCRIPTION
Third of the #499 Phase 2 simplifications — CI graph hardening.

## What
**(a) Security re-parent** — `security` now `needs: [changes]` instead of `[changes, unit-and-type]`. bandit/pip-audit/detect-secrets are import-graph-independent, so they overlap Stage 2 instead of waiting for the full unit matrix (~45-60s/python-PR). It stays in the `check` aggregator's `needs` (still gating); `sonarcloud` is left parented as-is (it consumes coverage/test artifacts).

**(b) F93 — CI fan-in parity** (new fitness rule, +1 → 89 total). Parses `ci.yml`, finds the "CI gate" aggregator (`check` job), builds its transitive `needs` closure, and asserts every job is either in the closure, the aggregator itself, or carries an explicit `# fan-in: informational — <reason>` marker. Closes the class where a green merge could ship with a dangling job silently failing. 8 sabotage-proven tests.

## Fan-in analysis of current ci.yml
- **Gating (in closure):** changes, arch-fitness, pre-commit, contracts, unit-and-type, coverage, integration, e2e-composed-path, union-coverage, security, docker.
- **Informational:** `sonarcloud` only — branch protection requires exactly "CI gate" + "2 · Pre-merge PR gates", and SonarCloud is not a separately-required context.

## ⚠️ Flagged for human reconciliation
ci.yml's existing inline comment (~L730) says branch protection *should* gate on SonarCloud, but the actual ruleset doesn't require it. The marker reflects current reality (`informational`) and carries a `TODO(#499): confirm gating intent`. Decide later whether to promote SonarCloud to a hard gate or keep it advisory — not blocking here.

## Verification
89/89 fitness functions + F92 green under venv; full `safe-commit.sh` clean (10,064 tests). No baselines touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
