### PR TITLE
perf(fitness): precise per-rule staged selection — sound, <1s inner loop (#499 Phase 2)

### DIFF
--- a/scripts/checks/_rule_catalogue.py
+++ b/scripts/checks/_rule_catalogue.py
@@ -443,9 +443,13 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         summary="BDD step impls compose via CLI/MCP/factory — no direct *Pipeline(...) construction",
         exemplar="tests/integration/test_vec_index_lifecycle.py",
         task_type=("writing-a-bdd-feature", "writing-a-test"),
-        # File-local: scans tests/bdd/steps/*.py for direct *Pipeline(...)
-        # construction; each step file is judged in isolation.
-        staged_scope=("tests/bdd/steps",),
+        # Relational, not file-local: collect_violations reads the cross-file
+        # source kairix/agents/mcp/server.py (via _discover_mcp_tool_names) to
+        # decide whether a step's bare call routes through an MCP tool — so a
+        # staged server.py edit (removing a @server.tool() a step relies on) can
+        # newly violate an UN-staged step file. Scope spans both sides.
+        staged_class="relational",
+        staged_scope=("tests/bdd/steps", "kairix/agents/mcp/server.py"),
     ),
     RuleEntry(
         id="F47",
@@ -773,6 +777,13 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         category="plugin-contract",
         scope="per-plugin",
         summary="every connector declares SourceConnector + at least one of {Poll, Checkpointed, Event}Connector",
+        # Relational, not file-local: _capability_names_via_runtime imports
+        # kairix/core/protocols.py and runtime-isinstance-checks each connector
+        # against the Protocols DEFINED there, so a staged protocols.py edit
+        # (removing a member from a runtime-checkable Protocol) can newly violate
+        # an UN-staged connector. Scope spans the connector tree + protocols.py.
+        staged_class="relational",
+        staged_scope=("kairix/connectors", "kairix/core/protocols.py"),
     ),
     RuleEntry(
         id="F64",

--- a/scripts/checks/_rule_catalogue.py
+++ b/scripts/checks/_rule_catalogue.py
@@ -77,6 +77,40 @@ Status = Literal[
     "superseded",
 ]
 
+# ── staged-selection class (#499 Phase 2 stage 4b) ──────────────────────
+#
+# How ``run_checks.py --staged`` decides whether — and over WHAT — to run a
+# rule given the staged file set. Three classes, ordered by how much the
+# runner may safely narrow:
+#
+# * ``"file-local"`` — a violation is determinable from a single file in
+#   isolation (every import-boundary / location / marker / regex rule:
+#   F26 / F8 / F76 / …). A staged change can only NEWLY violate the rule if a
+#   staged file is in the rule's path-scope, AND only the staged files need
+#   re-checking — the non-staged files were clean at the previous commit and
+#   their content is unchanged, so the baseline-diff verdict for them is
+#   unchanged. Deleting a file can only REMOVE a file-local violation, never
+#   add one. → run over ``staged ∩ scope``; skip when that intersection is
+#   empty. This is the default residue.
+#
+# * ``"relational"`` — a violation depends on cross-file state: a code
+#   surface in tree A paired with a test / spec / route artefact in tree B
+#   (F30 CLI↔outcome-test, F45 capability↔BDD-feature, F54 flag↔both-branch,
+#   F90 template↔route, …). A staged change anywhere in the rule's broader
+#   scope — INCLUDING a deletion of the paired artefact, or a NEW surface
+#   file — can break the invariant even when the obviously-"in-scope" file
+#   isn't itself staged. → if any staged path is within the rule's scope,
+#   run the rule over its FULL scope (not just the staged files).
+#
+# * ``"always-run"`` — the trigger is "any change at all": net-new-file
+#   detection (F50), catalogue currency (F92), README / path-naming
+#   invariants that fire on any new tracked path. → always run.
+StagedClass = Literal[
+    "file-local",
+    "relational",
+    "always-run",
+]
+
 # ── paved-road task-type vocabulary (#499 Phase 2) ──────────────────────
 #
 # A CLOSED set of agent-facing "I'm about to do X" tasks. ``rules.py
@@ -159,6 +193,29 @@ class RuleEntry:
       ``rules.py --task <t>`` can list every rule an agent must satisfy
       for that task. Empty (the default) for rules an agent doesn't hit
       while building a capability.
+
+    Staged selection (#499 Phase 2 stage 4b — precise per-rule narrowing)
+    --------------------------------------------------------------------
+    Two OPTIONAL fields tell ``run_checks.py --staged`` how to select and
+    scope this rule against the staged file set. They are SINGLE-SOURCED
+    here so the staged narrowing can never drift from the rule's real
+    detection surface, and default conservatively so an un-annotated rule is
+    never under-run:
+
+    * ``staged_class`` — one of :data:`StagedClass`. Defaults to
+      ``"file-local"`` (the safe residue: most rules ARE file-local). Set
+      ``"relational"`` for cross-file / deletion-sensitive rules (run full
+      scope when touched) and ``"always-run"`` for any-change rules.
+
+    * ``staged_scope`` — the repo-relative path prefixes whose staged change
+      could trigger this rule. ``None`` (the default) means "derive it": the
+      runner asks the rule's own detector for its scan roots (the
+      ``FitnessRule.roots`` / import-boundary / location-engine roots), and
+      falls back to running the rule when no scope can be resolved
+      (fail-safe — never silently skip). Set an explicit tuple only when the
+      relational scope is BROADER than the file-local scan roots (e.g. F30's
+      scan walks ``tests/`` but its trigger also includes ``kairix/cli.py``).
+      An ``"always-run"`` rule ignores ``staged_scope``.
     """
 
     id: str
@@ -174,6 +231,8 @@ class RuleEntry:
     run_all: bool = True
     exemplar: str | None = None
     task_type: tuple[str, ...] = field(default_factory=tuple)
+    staged_class: StagedClass = "file-local"
+    staged_scope: tuple[str, ...] | None = None
 
 
 _ENTRIES: tuple[RuleEntry, ...] = (
@@ -261,6 +320,10 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         scope="per-file",
         summary="no @patch / monkeypatch on kairix internals — inject Fake* through a seam",
         script="check-no-internal-patches.sh",
+        # Shell detector greps tests/ for @patch on kairix.* targets. File-local
+        # (per-test-file), but runs as a subprocess so it can't narrow to staged
+        # files — it runs its full tests/ grep when a tests/ path is staged.
+        staged_scope=("tests",),
     ),
     RuleEntry(
         id="F2",
@@ -270,6 +333,8 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         scope="per-file",
         summary='no monkeypatch.setenv("KAIRIX_*") — pass deps as kwargs instead',
         script="check-no-env-monkeypatch.sh",
+        # Shell detector greps tests/ for monkeypatch.setenv("KAIRIX_*").
+        staged_scope=("tests",),
     ),
     RuleEntry(
         id="F5",
@@ -286,6 +351,8 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         category="test-discipline",
         scope="per-method",
         summary="no *_fn=None test-only kwargs in production",
+        # File-local: scans kairix/ for *_fn=None test-only kwargs in prod.
+        staged_scope=("kairix",),
     ),
     RuleEntry(
         id="F7",
@@ -361,6 +428,11 @@ _ENTRIES: tuple[RuleEntry, ...] = (
             "adding-a-provider",
             "writing-a-bdd-feature",
         ),
+        # Relational: a new capability surface (CLI/MCP/provider/connector/
+        # extractor) under kairix/, OR a deleted feature file, breaks the
+        # "ships a BDD feature in the same commit" invariant.
+        staged_class="relational",
+        staged_scope=("kairix", "tests/bdd/features"),
     ),
     RuleEntry(
         id="F46",
@@ -371,6 +443,9 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         summary="BDD step impls compose via CLI/MCP/factory — no direct *Pipeline(...) construction",
         exemplar="tests/integration/test_vec_index_lifecycle.py",
         task_type=("writing-a-bdd-feature", "writing-a-test"),
+        # File-local: scans tests/bdd/steps/*.py for direct *Pipeline(...)
+        # construction; each step file is judged in isolation.
+        staged_scope=("tests/bdd/steps",),
     ),
     RuleEntry(
         id="F47",
@@ -391,6 +466,10 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         summary="tests/e2e/test_composed_production_path.py exists, runs in CI Stage 4.5",
         exemplar="tests/e2e/test_composed_production_path.py",
         task_type=("writing-a-test",),
+        # Relational: presence/shape of the composed-path E2E file. Deleting or
+        # gutting it under tests/e2e breaks the invariant.
+        staged_class="relational",
+        staged_scope=("tests/e2e",),
     ),
     RuleEntry(
         id="F54",
@@ -404,6 +483,15 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         tags=("test-discipline",),
         exemplar="tests/bdd/features/feature_flag_connector_github.feature",
         task_type=("adding-a-feature-flag",),
+        # Relational: a flag added to REGISTRY, OR a deleted both-branch
+        # BDD/integration/e2e artefact, breaks coverage parity.
+        staged_class="relational",
+        staged_scope=(
+            "kairix/core/features",
+            "tests/bdd/features",
+            "tests/integration",
+            "tests/e2e",
+        ),
     ),
     RuleEntry(
         id="F62",
@@ -413,6 +501,15 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         scope="per-class",
         summary="every stateful tick/run_batch component has a multi-tick advance/idempotency test",
         adr_origin="2026-05 production cursor-write incident",
+        # Relational: a new tick/run_batch class under kairix/core/connectors |
+        # maintenance, OR a deleted multi-tick test, breaks the pairing.
+        staged_class="relational",
+        staged_scope=(
+            "kairix/core/connectors",
+            "kairix/core/maintenance",
+            "tests/integration",
+            "tests/contracts",
+        ),
     ),
     RuleEntry(
         id="F68",
@@ -422,6 +519,10 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         scope="per-protocol-method",
         summary="every Protocol method has a failure-injection contract test",
         adr_origin="docs/architecture/ADR-024-test-pyramid-redesign.md §F68",
+        # Relational: a Protocol declared anywhere under kairix/, OR a deleted
+        # failure-mode contract test, breaks the pairing.
+        staged_class="relational",
+        staged_scope=("kairix", "tests/contracts"),
     ),
     RuleEntry(
         id="F69",
@@ -431,6 +532,9 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         scope="per-test",
         summary="every integration test with .fetchall()/list_changes has a ≥10K-row variant",
         adr_origin="docs/architecture/ADR-024-test-pyramid-redesign.md §F69",
+        # File-local: scans tests/integration/ for fetchall/list_changes tests
+        # lacking a scale variant; each test file is judged in isolation.
+        staged_scope=("tests/integration",),
     ),
     RuleEntry(
         id="F72",
@@ -440,6 +544,10 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         scope="cross-cutting",
         summary="every cross-layer integrity invariant has a fixture-scale AND soak-scale test",
         adr_origin="docs/architecture/ADR-024-test-pyramid-redesign.md §F72",
+        # Relational: pairs a fixture-scale invariant test with its soak-scale
+        # sibling; deleting either (anywhere under tests/) breaks the pair.
+        staged_class="relational",
+        staged_scope=("tests",),
     ),
     RuleEntry(
         id="F81",
@@ -455,6 +563,11 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         ),
         adr_origin="onboarding tranche 3, 2026-06-11 — registered via EPIC #499 Phase 0; "
         "choreography stage added EPIC #499 Phase 3",
+        # Relational wiring check: the smoke script and the workflow that
+        # invokes it live in different trees; deleting either (or breaking the
+        # invocation) trips it.
+        staged_class="relational",
+        staged_scope=("scripts/checks/check-fresh-install-smoke.sh", ".github/workflows/fresh-install-smoke.yml"),
     ),
     RuleEntry(
         id="F82",
@@ -482,6 +595,10 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         adr_origin="EPIC #499 Phase 1 — #492 overlay split-brain (H1)",
         exemplar="tests/integration/test_wizard_config_overlay_split_brain.py",
         task_type=("a-schema-change", "writing-a-test"),
+        # Relational: a config-write site under kairix/, OR a deleted round-trip
+        # test under tests/, breaks the write→read coverage pairing.
+        staged_class="relational",
+        staged_scope=("kairix", "tests"),
     ),
     RuleEntry(
         id="F88",
@@ -497,6 +614,11 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         adr_origin="EPIC #499 Phase 1 — session-escape-5 (save_source ValueError surfaced as 500)",
         exemplar="tests/platform/setup/test_setup_service.py",
         task_type=("writing-a-test",),
+        # Relational: a documented Raises: on a SetupService method, the wizard
+        # route that must handle it, OR the render test, all live in different
+        # files; touching any can change the parity verdict.
+        staged_class="relational",
+        staged_scope=("kairix/platform/setup", "tests/platform/setup"),
     ),
     RuleEntry(
         id="F87",
@@ -513,6 +635,10 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         adr_origin="EPIC #499 Phase 1 — GitHub-PEM multi-line secret round-trip (session escape 2)",
         exemplar="tests/integration/test_secrets_pem_round_trip.py",
         task_type=("writing-a-test",),
+        # Relational: a registered persist/load pair in kairix/ pairs with an
+        # adversarial-corpus test under tests/; deleting either breaks it.
+        staged_class="relational",
+        staged_scope=("kairix", "tests"),
     ),
     RuleEntry(
         id="F86",
@@ -525,6 +651,9 @@ _ENTRIES: tuple[RuleEntry, ...] = (
             "kairix/** stays visible to the coverage floor: no # pragma: no cover (escape-4 class)"
         ),
         adr_origin="EPIC #499 Phase 1 — escape 4, the terminal-wizard pragma'd embed seam",
+        # File-local: scans kairix/ for _default_* seams carrying a no-cover
+        # pragma; each seam is judged in its own file.
+        staged_scope=("kairix",),
     ),
     RuleEntry(
         id="F86-dynamic",
@@ -547,6 +676,10 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         category="plugin-contract",
         scope="per-plugin",
         summary="every provider plugin has matching BDD feature + Examples-table row in E2E features",
+        # Relational: a provider plugin dir pairs with a per-plugin feature +
+        # an Examples-row in the E2E feature; deleting either breaks parity.
+        staged_class="relational",
+        staged_scope=("kairix/providers", "tests/bdd/features"),
     ),
     RuleEntry(
         id="F36",
@@ -557,6 +690,10 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         summary="every connector + extractor plugin has matching BDD feature + Examples-table row",
         exemplar="tests/bdd/features/e2e_connector_sync.feature",
         task_type=("adding-a-connector", "adding-an-extractor", "writing-a-bdd-feature"),
+        # Relational: a connector/extractor plugin dir pairs with a per-plugin
+        # feature + an Examples-row in e2e_connector_sync.feature.
+        staged_class="relational",
+        staged_scope=("kairix/connectors", "kairix/extractors", "tests/bdd/features"),
     ),
     RuleEntry(
         id="F40",
@@ -577,6 +714,10 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         summary="every plugin tree has py.typed marker + no unjustified # type: ignore",
         exemplar="kairix/connectors/obsidian/__init__.py",
         task_type=("adding-a-connector", "adding-an-extractor", "adding-a-provider"),
+        # Relational: the py.typed marker is a per-plugin-tree file separate
+        # from the plugin code; a new plugin dir needs it and deleting it
+        # breaks coverage. Scope derives from the FitnessRule plugin-tree roots.
+        staged_class="relational",
     ),
     RuleEntry(
         id="F42",
@@ -586,6 +727,9 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         scope="per-protocol-method",
         summary="Protocol methods return frozen-dc/tuple — never dict[str, Any] or bare Any",
         tags=("observability",),
+        # File-local: scans the single kairix/core/protocols.py for surface
+        # Protocol method return annotations.
+        staged_scope=("kairix/core/protocols.py",),
     ),
     RuleEntry(
         id="F43",
@@ -598,6 +742,17 @@ _ENTRIES: tuple[RuleEntry, ...] = (
             "(≥2 impl fixtures), not separate real-only/fake-only assertions; plus the per-plugin "
             "contract-test presence limb"
         ),
+        # Relational: a plugin dir pairs with tests/contracts/test_<name>_
+        # protocol.py importing the real impl AND tests.fakes; deleting the
+        # contract test or a fake breaks parity.
+        staged_class="relational",
+        staged_scope=(
+            "kairix/connectors",
+            "kairix/extractors",
+            "kairix/providers",
+            "tests/contracts",
+            "tests/fakes.py",
+        ),
     ),
     RuleEntry(
         id="F55",
@@ -607,6 +762,9 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         scope="per-plugin",
         summary="every Chunker plugin declares version + every Chunk(...) passes chunker_version=",
         status="vacuous",
+        # File-local (vacuous today): scans kairix/chunkers/<name>/ which does
+        # not yet exist.
+        staged_scope=("kairix/chunkers",),
     ),
     RuleEntry(
         id="F56",
@@ -623,6 +781,16 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         category="plugin-contract",
         scope="per-plugin",
         summary="every plugin importing an HTTP client ships a rate-limit test (429/Retry-After)",
+        # Relational: a plugin that imports an HTTP client pairs with a
+        # rate-limit test under tests/integration | tests/bdd; deleting the
+        # test breaks the pairing.
+        staged_class="relational",
+        staged_scope=(
+            "kairix/connectors",
+            "kairix/providers",
+            "tests/integration",
+            "tests/bdd/features",
+        ),
     ),
     RuleEntry(
         id="F65",
@@ -632,6 +800,10 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         scope="per-plugin",
         summary="every connector implements metadata_for + propagation test for chunk_date/author",
         adr_origin="docs/architecture/ADR-021-per-source-metadata-normalisation.md",
+        # Relational: a connector dir pairs with tests/integration/test_<name>_
+        # metadata_propagation.py; deleting the test breaks the pairing.
+        staged_class="relational",
+        staged_scope=("kairix/connectors", "tests/integration"),
     ),
     # ----- production-safety ----------------------------------------------
     RuleEntry(
@@ -660,6 +832,9 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         category="production-safety",
         scope="per-commit",
         summary="net-new files may not appear in any per-file F-rule baseline",
+        # Any net-new file in the commit can trip this — the trigger is "a
+        # file was added", not a path-scope. Always run.
+        staged_class="always-run",
     ),
     RuleEntry(
         id="F63",
@@ -687,6 +862,9 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         scope="per-file",
         summary="token-pattern scanner for private infra identifiers (externalised pattern source)",
         tags=("security",),
+        # File-local: scans kairix/ + scripts/ + tests/ + docs/ for private
+        # infra identifier patterns; each file judged in isolation.
+        staged_scope=("kairix", "scripts", "tests", "docs"),
     ),
     RuleEntry(
         id="F89",
@@ -701,6 +879,11 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         ),
         adr_origin="EPIC #499 Phase 3 — un-pinned vendored browser-asset class",
         tags=("security",),
+        # Relational within a web/static tree: a served file pairs with its
+        # ASSETS.lock manifest row (sha256 + url); a new/swapped asset or a
+        # deleted manifest row breaks the pinning.
+        staged_class="relational",
+        staged_scope=("kairix",),
     ),
     RuleEntry(
         id="F91",
@@ -716,6 +899,11 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         ),
         adr_origin="EPIC #499 Phase 3 — browser-surface CSP/XSS/inline-JS governance",
         tags=("security",),
+        # Relational: Limb A pairs the render path (routes.py) with the headers
+        # it must set; Limb B's no-cross-template-duplication is inherently
+        # cross-file. A staged template / route change can break either.
+        staged_class="relational",
+        staged_scope=("kairix/platform/setup/web",),
     ),
     # ----- schema-integrity -----------------------------------------------
     RuleEntry(
@@ -735,6 +923,10 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         scope="cross-cutting",
         summary="HierarchyConnector impls have a parent-before-child contract test",
         status="vacuous",
+        # Relational (vacuous today): a HierarchyConnector impl under kairix/
+        # pairs with a parent-before-child contract test under tests/contracts.
+        staged_class="relational",
+        staged_scope=("kairix", "tests/contracts"),
     ),
     RuleEntry(
         id="F67",
@@ -744,6 +936,10 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         scope="per-table",
         summary="every pushed_to_<sink> column has a matching UPDATE site flipping 0 → 1",
         adr_origin="GH #334 — entity_signals 2.3M un-pushed rows",
+        # Relational: a pushed_to_<sink> column declared in schema.py needs a
+        # drain UPDATE elsewhere under kairix/; deleting the drain breaks it.
+        staged_class="relational",
+        staged_scope=("kairix",),
     ),
     RuleEntry(
         id="F70",
@@ -753,6 +949,11 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         scope="per-table",
         summary="every CREATE TABLE has at least one INSERT INTO site OR a # table-is-derived: rationale",
         adr_origin="GH #336 — documents_media 1M-chunk empty-table incident",
+        # Relational: a CREATE TABLE in schema.py needs an INSERT site
+        # elsewhere under kairix/ (or a derived-rationale); deleting the writer
+        # breaks the symmetry.
+        staged_class="relational",
+        staged_scope=("kairix",),
     ),
     RuleEntry(
         id="F71",
@@ -762,6 +963,11 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         scope="per-method",
         summary="every preflight _check_* counting external state has a count-equals-ground-truth contract test",
         adr_origin="docs/architecture/ADR-024-test-pyramid-redesign.md §F71",
+        # Relational: a preflight _check_* under kairix/ pairs with the
+        # truthfulness contract test under tests/contracts; deleting the test
+        # breaks the pairing.
+        staged_class="relational",
+        staged_scope=("kairix", "tests/contracts"),
     ),
     # ----- feature-flag ---------------------------------------------------
     RuleEntry(
@@ -772,6 +978,8 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         scope="per-flag",
         summary="every FeatureFlag has target_retire_in ≤ current scm version + 6 months",
         adr_origin="docs/architecture/feature-flag-architecture.md §6",
+        # File-local: reads target_retire_in deadlines from the flag REGISTRY.
+        staged_scope=("kairix/core/features",),
     ),
     RuleEntry(
         id="F52",
@@ -780,6 +988,11 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         category="feature-flag",
         scope="per-flag",
         summary='every flag("<name>") call site references a name that exists in REGISTRY',
+        # Relational: a flag("<name>") call site anywhere under kairix/ is
+        # validated against REGISTRY. Removing a flag from the registry can
+        # make an UN-staged call site newly invalid → run full scope.
+        staged_class="relational",
+        staged_scope=("kairix",),
     ),
     RuleEntry(
         id="F53",
@@ -788,6 +1001,11 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         category="feature-flag",
         scope="cross-cutting",
         summary="kairix features status CLI subcommand + features_status MCP tool both exist",
+        # Relational: the CLI "features" entry (cli.py) and the features_status
+        # MCP tool (server.py) are the two surfaces; touching either can break
+        # the both-exist invariant.
+        staged_class="relational",
+        staged_scope=("kairix/cli.py", "kairix/agents/mcp/server.py"),
     ),
     # ----- agent-affordance -----------------------------------------------
     RuleEntry(
@@ -798,6 +1016,9 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         scope="per-file",
         summary="every # noqa / # NOSONAR / # pragma / # type: ignore / # nosec has rationale text",
         script="check-suppressions-have-rationale.sh",
+        # Shell detector greps kairix/ + tests/ + scripts/ for un-rationalised
+        # suppressions. File-local (each suppression is judged in isolation).
+        staged_scope=("kairix", "tests", "scripts"),
     ),
     RuleEntry(
         id="F10",
@@ -807,6 +1028,10 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         scope="cross-cutting",
         summary="CI workflow silencers (continue-on-error, fail_ci_if_error: false) require rationale",
         script="check-workflow-silencers-have-rationale.sh",
+        # Relational across the workflows dir: greps .github/workflows/*.yml
+        # for un-rationalised silencers.
+        staged_class="relational",
+        staged_scope=(".github/workflows",),
     ),
     RuleEntry(
         id="F14",
@@ -815,6 +1040,10 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         category="agent-affordance",
         scope="cross-cutting",
         summary="every sonar.issue.ignore.multicriteria entry has a preceding rationale comment",
+        # Relational to the single sonar config file: a staged edit to it can
+        # introduce an un-rationalised multicriteria entry.
+        staged_class="relational",
+        staged_scope=("sonar-project.properties",),
     ),
     RuleEntry(
         id="F16",
@@ -863,6 +1092,10 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         category="agent-affordance",
         scope="cross-cutting",
         summary="every check_*.py failure-output carries fix:/next:/run: action markers",
+        # Relational across the checks dir: a staged check_*.{py,sh} could lack
+        # action markers; the detector sweeps the whole scripts/checks tree.
+        staged_class="relational",
+        staged_scope=("scripts/checks",),
     ),
     RuleEntry(
         id="F23",
@@ -871,6 +1104,10 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         category="agent-affordance",
         scope="cross-cutting",
         summary="every top-level directory has a README.md resolver",
+        # A new top-level directory (a new path anywhere) can leave a README
+        # gap; deleting a README breaks it. The trigger is repo structure,
+        # not a path-scope. Always run.
+        staged_class="always-run",
     ),
     RuleEntry(
         id="F83",
@@ -884,6 +1121,9 @@ _ENTRIES: tuple[RuleEntry, ...] = (
             "severity, safe-commit.sh/run-all.sh stages emit named OK/FAIL verdicts"
         ),
         adr_origin="EPIC #499 Phase 0 — #483 silent gate-death class",
+        # File-local: scans the shell gate scripts under scripts/ (incl.
+        # safe-commit.sh / run-all.sh) for the gate-runner contract.
+        staged_scope=("scripts",),
     ),
     RuleEntry(
         id="F85",
@@ -899,6 +1139,10 @@ _ENTRIES: tuple[RuleEntry, ...] = (
             "(session-escape-8 phase-string class)"
         ),
         adr_origin="EPIC #499 Phase 1 — session-escape-8 cross-tier vocabulary drift",
+        # Relational: a vocabulary owned by service.py is re-declared in another
+        # setup-tier module or hardcoded in a template — cross-file drift.
+        staged_class="relational",
+        staged_scope=("kairix/platform/setup",),
     ),
     RuleEntry(
         id="F90",
@@ -913,6 +1157,11 @@ _ENTRIES: tuple[RuleEntry, ...] = (
             "(dangling-button class: the tour replacing first-search left no dead control)"
         ),
         adr_origin="EPIC #499 Phase 3 — dangling-button choreography class",
+        # Relational: a template's hx-* URL resolves against routes.py, and a
+        # template id resolves against another template — cross-file. A staged
+        # change to either (or a deleted route/template) breaks referentiality.
+        staged_class="relational",
+        staged_scope=("kairix/platform/setup/web",),
     ),
     # ----- repo-hygiene ---------------------------------------------------
     RuleEntry(
@@ -923,6 +1172,9 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         scope="per-file",
         summary='no os.environ.get("KAIRIX_*") outside paths.py / secrets.py',
         script="check-env-reads-stay-in-paths.sh",
+        # Shell detector greps kairix/ for os.environ KAIRIX_* reads outside the
+        # paths/secrets allow-list. File-local.
+        staged_scope=("kairix",),
     ),
     RuleEntry(
         id="F22",
@@ -931,6 +1183,9 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         category="repo-hygiene",
         scope="per-file",
         summary="repo paths follow per-tree naming conventions",
+        # Walks `git ls-files` over the whole repo; any net-new tracked path
+        # with a non-conforming name trips it, regardless of tree. Always run.
+        staged_class="always-run",
     ),
     RuleEntry(
         id="F24",
@@ -959,6 +1214,11 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         summary="every CLI subcommand + every MCP tool has an outcome test (subprocess or direct handler)",
         exemplar="tests/test_worker_cli_maintenance.py",
         task_type=("adding-a-cli-subcommand", "adding-an-mcp-tool", "writing-a-test"),
+        # Relational: a new subcommand in cli.py / a new @server.tool() in the
+        # MCP server, OR a DELETED outcome test under tests/, can break parity.
+        # Run full scope when any of those trees is touched.
+        staged_class="relational",
+        staged_scope=("kairix/cli.py", "kairix/agents/mcp/server.py", "tests"),
     ),
     RuleEntry(
         id="F32",
@@ -967,6 +1227,8 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         category="repo-hygiene",
         scope="per-file",
         summary="no real names in test fixtures (use agent-alpha etc. + reference library)",
+        # File-local: scans tests/ (.py + .feature) for embedded real names.
+        staged_scope=("tests",),
     ),
     RuleEntry(
         id="F33",
@@ -999,6 +1261,10 @@ _ENTRIES: tuple[RuleEntry, ...] = (
             "ship with an un-gated job failing"
         ),
         adr_origin="EPIC #499 Phase 2 — CI fan-in parity (dangling-job-ships-green class)",
+        # Relational to ci.yml: a new job (or a changed needs: closure) in the
+        # one workflow file can leave a job outside the CI-gate fan-in.
+        staged_class="relational",
+        staged_scope=(".github/workflows/ci.yml",),
     ),
     RuleEntry(
         id="F75",
@@ -1114,6 +1380,9 @@ _ENTRIES: tuple[RuleEntry, ...] = (
             "(the self-hosting guard for the catalogue-driven runner)"
         ),
         adr_origin="EPIC #499 Phase 2 — catalogue-driven runner single-source-of-truth",
+        # Self-hosting guard: a staged check script / catalogue / doc edit can
+        # break currency, and a doc region can drift from any edit. Always run.
+        staged_class="always-run",
     ),
     RuleEntry(
         id="capability-affordance",
@@ -1122,6 +1391,10 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         category="agent-affordance",
         scope="cross-cutting",
         summary="agent-callable capabilities surface their affordances at the call boundary",
+        # Relational: every COMMANDS entry in cli.py pairs with a tool_<cmd> in
+        # the MCP server; touching either side can break parity.
+        staged_class="relational",
+        staged_scope=("kairix/cli.py", "kairix/agents/mcp/server.py"),
     ),
     RuleEntry(
         id="no-hardcoded-user-paths",
@@ -1130,6 +1403,9 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         category="repo-hygiene",
         scope="per-file",
         summary="F31: no hardcoded /Users/ or /home/<dev>/ paths",
+        # Walks `git ls-files` over the whole repo (any text file can carry a
+        # hardcoded path); the trigger isn't a single tree. Always run.
+        staged_class="always-run",
     ),
     # ----- go-discipline (active when services/*/go.mod exists) -----------
     RuleEntry(
@@ -1139,6 +1415,7 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         category="go-discipline",
         scope="per-file",
         summary="every Go binary exposes --version",
+        staged_scope=("services",),
     ),
     RuleEntry(
         id="G6",
@@ -1147,6 +1424,7 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         category="go-discipline",
         scope="per-file",
         summary="no panic outside main/init",
+        staged_scope=("services",),
     ),
     RuleEntry(
         id="G8",
@@ -1155,6 +1433,7 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         category="go-discipline",
         scope="per-file",
         summary="logging via log/slog (no log.Println or fmt.Println in service code)",
+        staged_scope=("services",),
     ),
     RuleEntry(
         id="G9",
@@ -1163,6 +1442,10 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         category="go-discipline",
         scope="per-plugin",
         summary="every services/<name>/ has a README.md",
+        # Relational within services/: a new service dir needs a README; a
+        # deleted README breaks coverage.
+        staged_class="relational",
+        staged_scope=("services",),
     ),
     RuleEntry(
         id="G10",
@@ -1171,6 +1454,10 @@ _ENTRIES: tuple[RuleEntry, ...] = (
         category="go-discipline",
         scope="per-plugin",
         summary="dependency-rationale registry per services/<name>/DEPENDENCIES.md",
+        # Relational within services/: a new service / new dep needs a
+        # DEPENDENCIES.md entry; a deleted registry breaks it.
+        staged_class="relational",
+        staged_scope=("services",),
     ),
 )
 

--- a/scripts/checks/_staged_selection.py
+++ b/scripts/checks/_staged_selection.py
@@ -1,0 +1,315 @@
+"""Precise per-rule staged selection for the fitness runner (#499 Phase 2 stage 4b).
+
+``run_checks.py --staged`` must give fast feedback that the STAGED CHANGE
+introduced no fitness violation. The non-negotiable property is **no false
+negative on staged changes**: if staging file(s) introduces a violation of
+rule R, staged mode MUST run R. Speed is the goal, but a fast path that
+silently MISSES a violation is worse than a slow one. When in doubt, run the
+rule — the full ``--all`` gate is the merge bar, so over-running is cheap and
+under-running is the only real danger.
+
+This module turns each rule's catalogue metadata into a concrete decision:
+
+* **scope predicate** — the repo-relative path prefixes whose staged change
+  could trip the rule. Single-sourced: the explicit ``RuleEntry.staged_scope``
+  wins; otherwise it is DERIVED from the rule's own detector (its
+  import-boundary ``RULE.roots``, its ``FitnessRule.roots``, or — for the
+  location/singleton engine — the ``kairix/`` tree those checks always walk).
+  When no scope can be resolved, the predicate is ``None`` → the rule is
+  treated as always-in-scope (fail-safe).
+
+* **selection class** — from :data:`~_rule_catalogue.StagedClass`:
+    - ``file-local`` — run over ``staged ∩ scope`` (and the runner scopes the
+      shared file index to the staged files so an in-process check walks ONLY
+      them). Skipped when that intersection is empty. Sound because a
+      non-staged file's baseline-diff verdict is unchanged (its content is
+      unchanged) and a deletion can only REMOVE a file-local violation.
+    - ``relational`` — if any staged path is within ``scope``, run over the
+      FULL scope (a deletion of the paired artefact, or a new surface file,
+      can break a cross-file invariant even when the obvious file isn't
+      staged).
+    - ``always-run`` — run unconditionally (net-new-file / catalogue-currency
+      / README / path-naming — the trigger is "any change at all").
+
+The soundness contract is proven by ``tests/checks/test_staged_selection.py``
+(the executed soundness battery + the staged-vs-full completeness table).
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import tc_fitness
+from _fitness_rule import FitnessRule
+from _rule_catalogue import RuleEntry, StagedClass
+
+# The location/singleton engine (F29 / F38 / F61) always walks ``kairix/``
+# regardless of each rule's ``allowed_roots`` allow-list, so a check that
+# imports it is scoped to the production package.
+_LOCATION_ENGINE_MODULE = "_location_engine"
+# The boundary engine shims expose a module-level ``RULE`` carrying ``roots``.
+_BOUNDARY_RULE_ATTR = "RULE"
+
+
+def _module_name_for(script: str) -> str | None:
+    """Module name for a ``check_<x>.py`` script, or ``None`` for a ``.sh``
+    detector (shell rules can't be introspected for scan roots — their scope
+    must be carried explicitly on the catalogue entry)."""
+    if not script.endswith(".py"):
+        return None
+    return script[: -len(".py")]
+
+
+def _roots_from_module(module_name: str) -> tuple[str, ...] | None:
+    """Derive a rule's scan roots by importing its check module and reading,
+    in order of specificity:
+
+      1. a module-level ``RULE`` with a ``roots`` tuple (import-boundary
+         engine shims: F26 / F27 / F34 / F35 / F37 / F44);
+      2. a ``FitnessRule`` subclass's ``roots`` class attribute (the ABC
+         checks: F8 / F15 / F47 / F63 / …);
+      3. ``("kairix",)`` when the module imports the location/singleton engine
+         (F29 / F38 / F61 — those always walk the production package).
+
+    Returns ``None`` when nothing resolves (the caller treats that as
+    always-in-scope — fail-safe, never a silent skip). Import failures are
+    swallowed into ``None`` for the same reason.
+    """
+    try:
+        module = importlib.import_module(module_name)
+    except BaseException:  # pragma: no cover - import hiccup → fail-safe None
+        # An un-importable check can't be narrowed; fall back to always-run.
+        return None
+
+    rule = getattr(module, _BOUNDARY_RULE_ATTR, None)
+    boundary_roots = getattr(rule, "roots", None)
+    if isinstance(boundary_roots, tuple) and boundary_roots:
+        return boundary_roots
+
+    for _name, obj in inspect.getmembers(module, inspect.isclass):
+        if obj is FitnessRule or not issubclass(obj, FitnessRule):
+            continue
+        if obj.__module__ != module.__name__:
+            # Skip the imported FitnessRule ABC / re-exports; only the check's
+            # OWN subclass declares its roots.
+            continue
+        roots = getattr(obj, "roots", None)
+        if isinstance(roots, tuple) and roots:
+            return roots
+
+    if _imports_location_engine(module):
+        return ("kairix",)
+
+    return None
+
+
+def _imports_location_engine(module: object) -> bool:
+    """True if the check module is a location/singleton-engine shim.
+
+    The shims (F29 / F38 / F61) all ``from _location_engine import
+    LocationRule``, so the imported ``LocationRule`` name resolving to the
+    engine's class is the distinguishing signal. The import-boundary shims
+    import ``ImportBoundaryRule`` instead and are already handled by the
+    ``RULE.roots`` branch upstream of this call.
+    """
+    location_rule = getattr(module, "LocationRule", None)
+    return location_rule is not None and getattr(location_rule, "__module__", "") == _LOCATION_ENGINE_MODULE
+
+
+def resolve_staged_scope(entry: RuleEntry, script: str) -> tuple[str, ...] | None:
+    """The repo-relative path-prefix scope for ``entry`` under ``script``.
+
+    Explicit ``entry.staged_scope`` always wins (single source of truth for
+    the rules whose scope can't be derived — shell detectors, multi-tree
+    standalone checks, relational rules with a BROADER trigger than their scan
+    roots). Otherwise the scope is derived from the check's own detector via
+    :func:`_roots_from_module`. ``None`` means "no resolvable scope" → the
+    caller runs the rule unconditionally.
+    """
+    if entry.staged_scope is not None:
+        return entry.staged_scope
+    module_name = _module_name_for(script)
+    if module_name is None:
+        return None
+    return _roots_from_module(module_name)
+
+
+def _path_under(path: str, prefix: str) -> bool:
+    """True if repo-relative ``path`` is the file ``prefix`` or sits under the
+    directory ``prefix``. A ``prefix`` ending in a file suffix (``.py`` etc.)
+    matches that exact file only."""
+    if path == prefix:
+        return True
+    # Directory prefix: ``kairix`` matches ``kairix/...`` but not ``kairixx``.
+    return path.startswith(prefix + "/")
+
+
+def staged_in_scope(scope: tuple[str, ...] | None, staged: list[str]) -> list[str]:
+    """The staged paths that fall within ``scope``.
+
+    ``scope is None`` → every staged path is "in scope" (conservative). A
+    concrete scope intersects each staged path against its prefixes.
+    """
+    if scope is None:
+        return list(staged)
+    return [p for p in staged if any(_path_under(p, prefix) for prefix in scope)]
+
+
+@dataclass(frozen=True)
+class StagedDecision:
+    """The runner's decision for one rule against the staged set.
+
+    Attributes:
+        run: whether to dispatch the rule at all.
+        reason: a short human-readable why (printed in the transparent
+            staged ledger so narrowing is auditable, never silent).
+        scope_files: for a ``file-local`` rule that should run, the staged
+            files to restrict the shared file index to (so the in-process
+            check walks ONLY them). Empty/``None`` for relational / always-run
+            (those run over their full natural scope).
+    """
+
+    run: bool
+    reason: str
+    scope_files: tuple[str, ...] | None = None
+
+
+def decide(entry: RuleEntry, script: str, staged: list[str]) -> StagedDecision:
+    """Decide whether — and over what — to run ``entry`` given ``staged``.
+
+    The three classes:
+
+    * ``always-run`` → always dispatch (full scope).
+    * ``relational`` → dispatch over full scope iff any staged path is within
+      the rule's scope; else skip.
+    * ``file-local`` → dispatch over ``staged ∩ scope`` iff that intersection
+      is non-empty (and hand those files back so the runner scopes the file
+      index); else skip.
+
+    With no staged paths at all (``staged == []``), every rule runs — the
+    pre-commit ``--all-files`` quirk must never silently pass.
+    """
+    klass: StagedClass = entry.staged_class
+
+    if not staged:
+        return StagedDecision(run=True, reason="no staged paths — run everything (fail-safe)")
+
+    if klass == "always-run":
+        return StagedDecision(run=True, reason="always-run (trigger is any change)")
+
+    scope = resolve_staged_scope(entry, script)
+    matched = staged_in_scope(scope, staged)
+
+    if klass == "relational":
+        if matched:
+            where = "unresolved scope" if scope is None else ", ".join(scope)
+            return StagedDecision(run=True, reason=f"relational — staged path in scope ({where}); full scope")
+        return StagedDecision(run=False, reason="relational — no staged path in scope")
+
+    # file-local
+    if scope is None:
+        # No resolvable scope → can't narrow soundly; run unconditionally.
+        return StagedDecision(run=True, reason="file-local — scope unresolved; run (fail-safe)")
+    if matched:
+        return StagedDecision(
+            run=True,
+            reason=f"file-local — {len(matched)} staged file(s) in scope",
+            scope_files=tuple(matched),
+        )
+    return StagedDecision(run=False, reason="file-local — no staged file in scope")
+
+
+# ── file-index narrowing for a file-local rule ──────────────────────────
+#
+# When a file-local rule runs in staged mode, it only needs to RE-CHECK the
+# staged files — every other in-scope file was clean at the previous commit
+# and its content is unchanged, so its baseline-diff verdict is unchanged.
+# Narrowing the rule's file enumeration to the staged set turns a full-tree
+# walk into a handful of files. The narrowing is installed by intersecting
+# the rule's own enumeration surfaces with the staged set, so NO per-check
+# edit is needed and the verdict for the staged files is byte-identical to a
+# full run (the same files are inspected, just fewer of them).
+#
+# Soundness note: this only narrows FILE-LOCAL rules, where a per-file
+# verdict is independent of the other files. Relational and always-run rules
+# are NEVER narrowed — they run over their full natural scope.
+
+
+def _filter_to_staged(paths: list[Path], staged_abs: frozenset[Path]) -> list[Path]:
+    """Keep only the ``paths`` that are in the staged set (by resolved path)."""
+    out: list[Path] = []
+    for p in paths:
+        try:
+            resolved = p.resolve()
+        except OSError:  # pragma: no cover - resolve hiccup → drop conservatively only if not staged
+            resolved = p
+        if resolved in staged_abs:
+            out.append(p)
+    return out
+
+
+@contextmanager
+def restrict_enumeration(repo_root: Path, staged: list[str]) -> Iterator[None]:
+    """Restrict the file-enumeration surfaces to the ``staged`` files for the
+    duration of the ``with`` block, then restore them.
+
+    Patches the enumeration entry points that file-local checks funnel
+    through — :meth:`FitnessRule.enumerate_files` and the module-level
+    :func:`tc_fitness.python_files` (plus every already-imported
+    ``check_*`` module's local ``python_files`` binding) — so each returns
+    only the staged files (intersected with what it would otherwise yield).
+    The detectors' own ``is_in_scope`` / extension filtering still applies on
+    top, so a staged file outside a rule's scope is still skipped.
+
+    This is correctness-preserving for file-local rules specifically: the set
+    of staged files a rule inspects is exactly ``what-it-would-walk ∩
+    staged``, and the per-file verdict for each is identical to the full run.
+    """
+    staged_abs = frozenset((repo_root / s).resolve() for s in staged)
+
+    real_enumerate = FitnessRule.enumerate_files
+    real_python_files = tc_fitness.python_files
+
+    def _scoped_enumerate(self: FitnessRule) -> list[Path]:
+        return _filter_to_staged(real_enumerate(self), staged_abs)
+
+    def _scoped_python_files(*roots: str, repo_root: Path | None = None, **kwargs: Any) -> list[Path]:
+        full = real_python_files(*roots, repo_root=repo_root, **kwargs)
+        return _filter_to_staged(full, staged_abs)
+
+    # Patch the canonical surfaces. ``_fitness_rule`` does not bind
+    # ``python_files`` itself (it uses ``FitnessRule.enumerate_files``), so only
+    # the ABC method and the ``tc_fitness`` source function need patching here;
+    # the per-check ``from tc_fitness import python_files`` bindings are
+    # patched in the loop below.
+    FitnessRule.enumerate_files = _scoped_enumerate  # type: ignore[method-assign]  # run-scoped staged narrowing; restored in finally
+    tc_fitness.python_files = _scoped_python_files
+
+    # Patch every already-imported check module that bound ``python_files`` by
+    # value (``from tc_fitness import python_files``) so its local reference
+    # also narrows. Record originals to restore exactly. ``module`` is the
+    # dynamic check module object; ``setattr`` rebinds its local name.
+    patched_modules: list[tuple[Any, Any]] = []
+    for module in list(sys.modules.values()):
+        candidate: Any = module
+        name = getattr(candidate, "__name__", "")
+        if not name.startswith("check_"):
+            continue
+        if getattr(candidate, "python_files", None) is real_python_files:
+            patched_modules.append((candidate, real_python_files))
+            candidate.python_files = _scoped_python_files
+
+    try:
+        yield
+    finally:
+        FitnessRule.enumerate_files = real_enumerate  # type: ignore[method-assign]  # restore pristine enumeration
+        tc_fitness.python_files = real_python_files
+        for patched, original in patched_modules:
+            patched.python_files = original

--- a/scripts/checks/check_path_naming.py
+++ b/scripts/checks/check_path_naming.py
@@ -29,6 +29,8 @@ Trees enforced (first match wins; the order matters):
       the shared table engines ``_import_boundary_engine.py`` /
       ``_location_engine.py`` (#499 Phase 2 — the nine boundary/location
       rules collapse into these two declarative tables),
+      ``_check_context.py`` / ``_staged_selection.py`` (#499 Phase 2 — the
+      in-process AST cache + precise staged selection for the runner),
       ``run-all.sh``, ``audit_baselines.py``, ``merge_coverage_xml.py``,
       the catalogue-runner tooling ``run_checks.py`` /
       ``generate_catalogue_docs.py`` (#499 Phase 2), and the diff-scoped
@@ -73,7 +75,7 @@ _TEST_PY = re.compile(r"^(__init__|conftest|fakes|test_[a-z0-9_]+|_?[a-z][a-z0-9
 _SNAKE_FEATURE = re.compile(r"^[a-z][a-z0-9_]*\.feature$")
 _CHECK_SCRIPT_PY = re.compile(
     r"^(check_[a-z0-9_]+|_fitness_rule|_rule_catalogue|_integrity_invariants_registry"
-    r"|_import_boundary_engine|_location_engine|_check_context"
+    r"|_import_boundary_engine|_location_engine|_check_context|_staged_selection"
     r"|audit_baselines|merge_coverage_xml|run_checks|generate_catalogue_docs|mutation_parity"
     r"|rules)\.py$"
 )

--- a/scripts/checks/run_checks.py
+++ b/scripts/checks/run_checks.py
@@ -46,10 +46,16 @@ Modes
 -----
 * ``--all`` — every in-scope rule (the full tree). The entrypoint
   ``run-all.sh`` calls; safe-commit / CI Stage 0 consume it.
-* ``--staged`` — only rules whose ``scope`` plausibly intersects the
-  staged paths (``git diff --cached --name-only``). When scope can't be
-  resolved to a path predicate, the rule runs (fail-safe: never silently
-  drop a rule). pre-commit calls this.
+* ``--staged`` — precise per-rule selection against the staged paths
+  (``git diff --cached --name-only``), single-sourced on each
+  :class:`~_rule_catalogue.RuleEntry` (``staged_class`` / ``staged_scope``)
+  and resolved by :mod:`_staged_selection` (stage 4b). File-local rules run
+  over ``staged ∩ scope`` (with the file index narrowed to the staged files);
+  relational rules run their FULL scope when any staged path is in scope;
+  always-run rules run unconditionally. The hard invariant is no false
+  negative on staged changes — when scope can't be resolved, the rule runs
+  (fail-safe). The transparent ledger prints which rules ran vs were skipped
+  as not-in-scope. pre-commit calls this; the ``--all`` gate is the backstop.
 * ``--gate <id>`` — one rule by catalogue id (e.g. ``F26``).
 
 Output contract (F83 gate-runner discipline)
@@ -78,6 +84,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _check_context import CheckContext
 from _rule_catalogue import ALL_ENTRIES, RuleEntry
+from _staged_selection import StagedDecision, decide, restrict_enumeration
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 CHECKS_DIR = REPO_ROOT / "scripts" / "checks"
@@ -114,41 +121,26 @@ def is_dispatchable(entry: RuleEntry) -> bool:
 
 # ── scope → staged-path predicate (the --staged narrowing) ──────────────
 #
-# A rule's ``scope`` is a coarse shape, not a path glob, so the staged
-# narrowing is deliberately permissive: it maps a scope to the path
-# prefixes the rule could plausibly fire on. Anything not confidently
-# narrowable falls through to "run it" — the whole point is to never
-# silently skip a rule that a staged file might violate.
-_CROSS_CUTTING_SCOPES = frozenset({"cross-cutting", "per-commit", "per-flag", "per-table", "per-protocol-method"})
+# Stage 4b (#499 Phase 2) makes the narrowing PRECISE and SOUND. The per-rule
+# selection class + path-scope are single-sourced on each
+# :class:`~_rule_catalogue.RuleEntry` (``staged_class`` / ``staged_scope``)
+# and resolved by :mod:`_staged_selection`. The runner asks that module for a
+# :class:`~_staged_selection.StagedDecision` per rule and dispatches
+# accordingly. The hard invariant — never silently drop a rule a staged file
+# could violate — is enforced there: file-local rules run over ``staged ∩
+# scope``, relational rules run their FULL scope when any staged path is in
+# scope, and always-run rules run unconditionally.
 
 
 def _rule_touches_staged(entry: RuleEntry, staged: list[str]) -> bool:
-    """Decide whether ``entry`` should run given the ``staged`` paths.
+    """Back-compat shim: True iff ``entry`` would be DISPATCHED for ``staged``.
 
-    Conservative: returns ``True`` (run the rule) whenever the staged
-    set could plausibly contain a file the rule governs. Only returns
-    ``False`` when the rule is confidently a no-op for the staged set.
+    Delegates to the stage-4b :func:`_staged_selection.decide`. Kept so the
+    existing ``test_staged_narrowing_*`` cases keep asserting the run/skip
+    boundary; new code consumes :func:`_staged_selection.decide` directly for
+    the full decision (scope + file narrowing).
     """
-    if not staged:
-        # pre-commit with no staged files (e.g. --all-files dispatch
-        # quirk) — run everything rather than silently pass.
-        return True
-    # Cross-cutting / whole-tree rules always run: their detectors walk
-    # the repo, not a per-file delta, so a staged change anywhere can
-    # flip them.
-    if entry.scope in _CROSS_CUTTING_SCOPES:
-        return True
-    # Shell-script rules (F83 etc.) fire on staged .sh changes; the
-    # F3 suppression-rationale rule fires on any .py. Resolve by the
-    # script's own breadth — cheapest correct answer is "run it".
-    script = resolve_script(entry)
-    if script.endswith(".sh"):
-        # gate-runner / shell-scoped rules: run if any shell or python
-        # source is staged (their detectors walk fixed trees).
-        return any(p.endswith((".sh", ".py", ".feature", ".yml", ".yaml")) for p in staged)
-    # Default python checks walk kairix/ and/or tests/ — run when any
-    # python, feature, or config source is staged.
-    return any(p.endswith((".py", ".feature", ".yml", ".yaml", ".properties", ".toml")) for p in staged)
+    return decide(entry, resolve_script(entry), staged).run
 
 
 def _staged_paths() -> list[str]:
@@ -348,10 +340,35 @@ def _select_all() -> list[RuleEntry]:
     return [e for e in ALL_ENTRIES if is_dispatchable(e) and e.run_all]
 
 
+def _staged_decisions(staged: list[str]) -> list[tuple[RuleEntry, StagedDecision]]:
+    """Per-rule staged decision for every ``--all`` entry, in catalogue order.
+
+    Deduped by resolved script (the same script runs once), mirroring the
+    ``--all`` dispatch. Each pair carries the rule's
+    :class:`~_staged_selection.StagedDecision` — run/skip, the reason (for the
+    transparent ledger), and the staged file subset to narrow a file-local
+    rule's file index to.
+    """
+    out: list[tuple[RuleEntry, StagedDecision]] = []
+    seen_scripts: set[str] = set()
+    for entry in _select_all():
+        script = resolve_script(entry)
+        if script in seen_scripts:
+            continue
+        seen_scripts.add(script)
+        out.append((entry, decide(entry, script, staged)))
+    return out
+
+
 def _select_staged() -> list[RuleEntry]:
-    """``--all`` set, narrowed to rules a staged change could trip."""
+    """``--all`` set, narrowed to the rules a staged change could trip.
+
+    Back-compat surface (the dispatch now consumes :func:`_staged_decisions`
+    so it can also narrow file-local rules' file index). Returns only the
+    rules that WILL run.
+    """
     staged = _staged_paths()
-    return [e for e in _select_all() if _rule_touches_staged(e, staged)]
+    return [e for e, decision in _staged_decisions(staged) if decision.run]
 
 
 def _select_gate(gate_id: str) -> list[RuleEntry]:
@@ -402,6 +419,77 @@ def _dispatch(entries: list[RuleEntry], *, skip_coverage: bool) -> int:
     return 0
 
 
+def _dispatch_staged(staged: list[str], *, skip_coverage: bool) -> int:
+    """Precise staged dispatch (#499 Phase 2 stage 4b).
+
+    For every ``--all`` rule, ask :func:`_staged_selection.decide` whether — and
+    over what — to run it against ``staged``:
+
+    * SKIPPED rules print a transparent ``skip [id] — <reason>`` line, so the
+      narrowing is auditable, never silent.
+    * RUN rules dispatch exactly as ``--all`` does (in-process for pure-python,
+      guarded subprocess for shell / coverage). A FILE-LOCAL rule with a staged
+      file subset runs inside :func:`restrict_enumeration`, so its file
+      enumeration is narrowed to the staged files (the big inner-loop win)
+      while its per-file verdict stays byte-identical to a full run.
+
+    Aggregate ledger + exit code match the ``--all`` contract; only the
+    SELECTION (which rules, over which files) differs.
+    """
+    decisions = _staged_decisions(staged)
+    failures: list[str] = []
+    ran = 0
+    skipped = 0
+    ctx = CheckContext(repo_root=REPO_ROOT)
+    with ctx.install():
+        for entry, decision in decisions:
+            if not decision.run:
+                print(f"{_YELLOW}skip [{entry.id}]{_RESET} {resolve_script(entry)} — {decision.reason}")
+                skipped += 1
+                continue
+            result = _run_staged_one(entry, ctx, decision, staged=staged, skip_coverage=skip_coverage)
+            if result is None:
+                skipped += 1
+                continue
+            ran += 1
+            if result != 0:
+                failures.append(entry.id)
+
+    print()
+    print(f"{_YELLOW}staged selection:{_RESET} {ran} ran, {skipped} skipped (not in staged scope or report absent)")
+    if failures:
+        print(
+            f"{_RED}=== Architecture fitness functions FAILED ==={_RESET} "
+            f"({len(failures)}/{ran} rule(s) failed: {', '.join(failures)})"
+        )
+        return 1
+    print(f"{_GREEN}=== All {ran} staged architecture fitness functions passed ==={_RESET}")
+    return 0
+
+
+def _run_staged_one(
+    entry: RuleEntry,
+    ctx: CheckContext,
+    decision: StagedDecision,
+    *,
+    staged: list[str],
+    skip_coverage: bool,
+) -> int | None:
+    """Dispatch one RUN-decided rule in staged mode.
+
+    File-local rules carrying a staged file subset run inside
+    :func:`restrict_enumeration` so the in-process check walks ONLY those
+    files. Everything else (relational / always-run / shell / coverage) runs
+    over its full natural scope, exactly as ``--all`` would.
+    """
+    if not _dispatches_in_process(entry):
+        return _run_one(entry, skip_coverage=skip_coverage)
+    if decision.scope_files:
+        with restrict_enumeration(REPO_ROOT, list(decision.scope_files)):
+            return _run_one_inprocess(entry, ctx)
+    return _run_one_inprocess(entry, ctx)
+
+
 def main(argv: list[str] | None = None) -> int:
     """Parse mode flags and dispatch. ``--all`` is the default."""
     parser = argparse.ArgumentParser(
@@ -426,14 +514,19 @@ def main(argv: list[str] | None = None) -> int:
             print("   fix: pass a real id (see scripts/checks/_rule_catalogue.py) or run --all.")
             return 2
         print(f"=== Architecture fitness function: {args.gate} ===")
-    elif args.staged:
-        entries = _select_staged()
-        print("=== Architecture fitness functions (staged) ===")
-    else:
-        entries = _select_all()
-        print("=== Architecture fitness functions ===")
+        return _dispatch(entries, skip_coverage=args.skip_coverage)
 
-    return _dispatch(entries, skip_coverage=args.skip_coverage)
+    if args.staged:
+        # Precise per-rule staged selection (#499 Phase 2 stage 4b): the
+        # dispatcher computes each rule's decision, prints the transparent
+        # run/skip ledger, and narrows file-local rules' file index to the
+        # staged files. Selection is sound — no false negative on staged
+        # changes; the full --all gate remains the merge backstop.
+        print("=== Architecture fitness functions (staged) ===")
+        return _dispatch_staged(_staged_paths(), skip_coverage=args.skip_coverage)
+
+    print("=== Architecture fitness functions ===")
+    return _dispatch(_select_all(), skip_coverage=args.skip_coverage)
 
 
 if __name__ == "__main__":

--- a/tests/checks/test_catalogue_runner.py
+++ b/tests/checks/test_catalogue_runner.py
@@ -107,18 +107,31 @@ def test_staged_narrowing_is_failsafe_on_empty() -> None:
     assert run_checks._rule_touches_staged(entry, []) is True
 
 
-def test_staged_narrowing_runs_cross_cutting_for_any_change() -> None:
-    """Cross-cutting rules walk the tree, so any staged change runs them."""
-    cross = next(e for e in run_checks._select_all() if e.scope == "cross-cutting")
-    assert run_checks._rule_touches_staged(cross, ["docs/only.md"]) is True
+def test_staged_narrowing_runs_always_run_for_any_change() -> None:
+    """An ``always-run`` rule (net-new-file / catalogue currency) fires on any
+    staged change, including a doc-only edit — its trigger is "any change"."""
+    always = next(e for e in run_checks._select_all() if e.staged_class == "always-run")
+    assert run_checks._rule_touches_staged(always, ["docs/only.md"]) is True
 
 
-def test_staged_narrowing_skips_python_rules_for_doc_only_change() -> None:
-    """A per-file python rule (walks kairix/ + tests/) does NOT run when
-    only a markdown file is staged — the narrowing earns its keep."""
+def test_staged_narrowing_skips_in_scope_python_rule_for_doc_only_change() -> None:
+    """A file-local rule scoped to kairix/ does NOT run when only a markdown
+    file is staged (precise stage-4b selection); a staged kairix/ file runs it.
+
+    Uses a real catalogue rule (F76, file-local, scope kairix/) so the scope
+    derivation is exercised end-to-end, not a synthetic stub whose check can't
+    be imported."""
+    f76 = next(e for e in run_checks._select_all() if e.id == "F76")
+    assert run_checks._rule_touches_staged(f76, ["docs/only.md"]) is False
+    assert run_checks._rule_touches_staged(f76, ["kairix/core/foo.py"]) is True
+
+
+def test_staged_narrowing_unresolvable_scope_runs_failsafe() -> None:
+    """A file-local rule whose check can't be imported (scope unresolvable)
+    runs anyway — the fail-safe residue, never a silent skip."""
     py_rule = RuleEntry(id="X", gate="x", check="some_python_check", category="layering", scope="per-file", summary="s")
-    assert run_checks._rule_touches_staged(py_rule, ["docs/only.md"]) is False
-    assert run_checks._rule_touches_staged(py_rule, ["kairix/core/foo.py"]) is True
+    # scope can't be derived (no such module) → run, never skip.
+    assert run_checks._rule_touches_staged(py_rule, ["docs/only.md"]) is True
 
 
 # ── run_checks: the equivalence invariant ───────────────────────────────

--- a/tests/checks/test_staged_selection.py
+++ b/tests/checks/test_staged_selection.py
@@ -34,6 +34,7 @@ restore runs):
 from __future__ import annotations
 
 import contextlib
+import dataclasses
 import io
 import sys
 from collections.abc import Iterator
@@ -118,6 +119,35 @@ def _skipped_rule_ids(output: str) -> set[str]:
         if "skip [" in line:
             ids.add(line.split("skip [", 1)[1].split("]", 1)[0])
     return ids
+
+
+# ── cross-file-source mutation helper (F46 server.py dependency) ─────────
+
+
+@contextlib.contextmanager
+def _server_tool_unregistered(tool: str) -> Iterator[None]:
+    """Temporarily un-register one ``@server.tool()`` from the REAL
+    ``kairix/agents/mcp/server.py`` by renaming its ``def`` so
+    ``_discover_mcp_tool_names`` no longer yields it, then restore the file
+    byte-for-byte on exit (try/finally — a failed assert never leaves the
+    source mutated).
+
+    This is the EXACT cross-file edit the F46 soundness defect is about: a
+    staged ``server.py`` change that drops a tool a step file routes through.
+    The mutation is a single surgical text replacement of ``def <tool>(`` →
+    ``def <tool>_zzz_probe_unregistered(``; the original bytes are captured up
+    front and rewritten in ``finally``.
+    """
+    server_path = _REPO_ROOT / "kairix" / "agents" / "mcp" / "server.py"
+    original = server_path.read_text(encoding="utf-8")
+    needle = f"def {tool}("
+    replacement = f"def {tool}_zzz_probe_unregistered("
+    assert needle in original, f"expected a `def {tool}(` to un-register in server.py"
+    server_path.write_text(original.replace(needle, replacement, 1), encoding="utf-8")
+    try:
+        yield
+    finally:
+        server_path.write_text(original, encoding="utf-8")
 
 
 # ── baseline: a clean staged set passes ─────────────────────────────────
@@ -208,6 +238,134 @@ def test_relational_f36_new_plugin_without_feature_caught_end_to_end() -> None:
         code, out = _run_staged([conn_rel])
     assert code == 1, f"a new connector plugin without a BDD feature must fail staged mode; ledger:\n{out}"
     assert "F36" in _failed_rule_ids(out), f"F36 must be the failing rule; ledger:\n{out}"
+
+
+# ── audit-driven: cross-file source dependencies (F46 / F56) ────────────
+#
+# Two rules an adversarial audit found mis-classified ``file-local`` even
+# though their detectors read CROSS-FILE state, so a staged edit to the
+# cross-file SOURCE (not the obvious scanned file) could slip a violation
+# past a file-local scoping. Reclassifying them ``relational`` with a scope
+# that spans the source closes the gap. These cases prove the SELECTION
+# property — staging the source alone selects the rule — plus, for F46, an
+# executed end-to-end FAIL through the real ``server.py`` dependency.
+
+
+def test_f46_server_py_edit_selects_f46() -> None:
+    """SOUNDNESS (F46): F46's verdict for a step file depends on
+    ``kairix/agents/mcp/server.py`` (its ``@server.tool()`` set decides
+    whether a bare call routes through the MCP surface). So staging
+    server.py ALONE — with NO step file staged — must select F46. The
+    relational scope spans both ``tests/bdd/steps`` and the server source."""
+    f46 = next(e for e in run_checks._select_all() if e.id == "F46")
+    script = run_checks.resolve_script(f46)
+    d = decide(f46, script, ["kairix/agents/mcp/server.py"])
+    assert d.run is True, "staging server.py alone MUST select F46 (its tool set drives step verdicts)"
+    assert d.scope_files is None, "F46 is relational — full scope, never narrowed to staged files"
+    # And it appears in the ran-set of a REAL staged dispatch over server.py alone.
+    _code, out = _run_staged(["kairix/agents/mcp/server.py"])
+    assert "F46" in _ran_rule_ids(out), f"F46 must RUN on a server.py-only staged change; ledger:\n{out}"
+
+
+def test_f46_file_local_would_miss_server_py_edit_sabotage() -> None:
+    """SABOTAGE PROOF (F46): with F46 left ``file-local`` + its old narrow
+    scope (``tests/bdd/steps`` only), staging server.py ALONE does NOT select
+    F46 — the exact missed-violation route the audit found. The shipped
+    catalogue value (relational, scope spans server.py) DOES select it. Proven
+    here by reconstructing the pre-fix entry with ``dataclasses.replace``; the
+    real catalogue entry asserts the fixed behaviour."""
+    f46 = next(e for e in run_checks._select_all() if e.id == "F46")
+    script = run_checks.resolve_script(f46)
+    pre_fix = dataclasses.replace(f46, staged_class="file-local", staged_scope=("tests/bdd/steps",))
+    assert decide(pre_fix, script, ["kairix/agents/mcp/server.py"]).run is False, (
+        "the BUG: file-local F46 scoped to tests/bdd/steps SKIPS a server.py-only staged edit"
+    )
+    assert decide(f46, script, ["kairix/agents/mcp/server.py"]).run is True, (
+        "the FIX: relational F46 with server.py in scope SELECTS the same staged edit"
+    )
+
+
+def test_f46_server_py_tool_removal_fails_dependent_step_end_to_end() -> None:
+    """END-TO-END (F46): a step file that routes through the ``search`` MCP
+    tool (bare call to an imported ``search`` from server.py) is F46-clean
+    ONLY because ``search`` is a registered ``@server.tool()``. Un-register it
+    in the real server.py (the staged cross-file edit) → that same step file
+    now VIOLATES F46. Staging server.py drives the relational rule full-scope,
+    which re-checks the step file → staged mode FAILS F46. This is the missed
+    violation file-local scoping would have let through."""
+    step_rel = "tests/bdd/steps/zzz_staged_probe_f46_dependent_steps.py"
+    # A step file that constructs a *Pipeline directly (so it's "at risk") but
+    # routes through the MCP `search` tool — clean WHILE `search` is registered.
+    step_src = (
+        "from pytest_bdd import when\n"
+        "from kairix.agents.mcp.server import search\n"
+        "from kairix.core.search.pipeline import SearchPipeline\n"
+        "\n"
+        "\n"
+        "@when('the agent builds a pipeline directly')\n"
+        "def _build_pipeline_directly():\n"
+        "    return SearchPipeline(retriever=None, ranker=None)\n"
+        "\n"
+        "\n"
+        "@when('the agent searches')\n"
+        "def _do_search():\n"
+        "    return search('hello')\n"
+    )
+    with _probe_file(step_rel, step_src) as rel:
+        # Control: while `search` is registered, the dependent step is clean.
+        code_clean, out_clean = _run_staged([rel])
+        assert code_clean == 0, f"dependent step must be F46-clean while search is registered; ledger:\n{out_clean}"
+        # Stage the cross-file edit: un-register `search` in the real server.py
+        # and stage server.py. The relational rule re-checks the step full-scope.
+        with _server_tool_unregistered("search"):
+            code_broken, out_broken = _run_staged([rel, "kairix/agents/mcp/server.py"])
+    assert code_broken == 1, f"un-registering search must make the dependent step FAIL F46; ledger:\n{out_broken}"
+    assert "F46" in _failed_rule_ids(out_broken), f"F46 must be the failing rule; ledger:\n{out_broken}"
+
+
+def test_f56_protocols_py_edit_selects_f56() -> None:
+    """SOUNDNESS (F56): F56's runtime probe imports ``kairix/core/protocols.py``
+    and ``isinstance``-checks each connector against the Protocols DEFINED
+    there. A staged protocols.py edit (e.g. dropping a member from a
+    runtime-checkable Protocol) can change whether an UN-staged connector
+    satisfies its capability declaration — so staging protocols.py ALONE must
+    select F56. Selection is the soundness property the relational scope
+    guarantees.
+
+    Note (additive-probe nuance): the runtime ``isinstance`` probe is
+    fail→pass-only on the CONNECTOR side (it can only ADD a satisfied
+    capability, never remove the AST-declared one), so a true missed-violation
+    is hard to construct from the connector side alone. The genuine
+    missed-violation route is the protocols.py edit, which this asserts via
+    SELECTION — the property that closes the audit gap."""
+    f56 = next(e for e in run_checks._select_all() if e.id == "F56")
+    script = run_checks.resolve_script(f56)
+    d = decide(f56, script, ["kairix/core/protocols.py"])
+    assert d.run is True, "staging protocols.py alone MUST select F56 (its Protocols drive the runtime probe)"
+    assert d.scope_files is None, "F56 is relational — full scope, never narrowed to staged files"
+    # And it appears in the ran-set of a REAL staged dispatch over protocols.py.
+    _code, out = _run_staged(["kairix/core/protocols.py"])
+    assert "F56" in _ran_rule_ids(out), f"F56 must RUN on a protocols.py-only staged change; ledger:\n{out}"
+
+
+def test_f56_file_local_would_miss_protocols_py_edit_sabotage() -> None:
+    """SABOTAGE PROOF (F56): with F56 left ``file-local`` and its detector-
+    derived scope (``kairix/connectors`` only), staging protocols.py ALONE
+    does NOT select F56 — the missed-violation route the audit found. The
+    shipped catalogue value (relational, scope spans protocols.py) DOES select
+    it. Pre-fix entry reconstructed with ``dataclasses.replace``; the real
+    catalogue entry asserts the fixed behaviour."""
+    f56 = next(e for e in run_checks._select_all() if e.id == "F56")
+    script = run_checks.resolve_script(f56)
+    # Pre-fix: file-local + scope DERIVED from the F56 detector's roots
+    # ("kairix/connectors",), i.e. no protocols.py in scope.
+    pre_fix = dataclasses.replace(f56, staged_class="file-local", staged_scope=("kairix/connectors",))
+    assert decide(pre_fix, script, ["kairix/core/protocols.py"]).run is False, (
+        "the BUG: file-local F56 scoped to kairix/connectors SKIPS a protocols.py-only staged edit"
+    )
+    assert decide(f56, script, ["kairix/core/protocols.py"]).run is True, (
+        "the FIX: relational F56 with protocols.py in scope SELECTS the same staged edit"
+    )
 
 
 # ── relational deletion: breaking a paired invariant ────────────────────

--- a/tests/checks/test_staged_selection.py
+++ b/tests/checks/test_staged_selection.py
@@ -1,0 +1,342 @@
+"""Soundness battery for precise per-rule staged selection (#499 Phase 2 stage 4b).
+
+The non-negotiable property of ``run_checks.py --staged`` is **no false
+negative on staged changes**: if staging file(s) introduces a violation of
+rule R, staged mode MUST select, run, and FAIL R. This module proves that
+EXECUTED — for a representative violation of each selection class it stages the
+offending file(s) and asserts staged mode catches it — and then closes the
+loop with a completeness table: across a battery of staged sets, the rules
+staged mode RUNS are a superset of the rules a full ``--all`` run would flag
+restricted to those staged files (over-running a cross-cutting rule is fine;
+under-running is the only real danger).
+
+Mechanism
+---------
+Each scenario writes a real violating file into the actual repo tree (under a
+``zzz_staged_probe*`` name a try/finally unlinks), then drives the real
+``_dispatch_staged`` with that path in the staged list. Because file-local
+rules narrow their file index to the staged set, the dispatch inspects only the
+probe file — so a clean tree stays green and the injected violation is the only
+signal. No monkeypatch of kairix internals: the probe file IS the production
+scenario, and ``decide`` / ``restrict_enumeration`` are the real runner code.
+
+Sabotage proofs (executed; see the runner-agent report for the mutate→fail→
+restore runs):
+
+  * file-local F26: removing the forbidden import from the probe → dispatch
+    goes green; restoring it → red. (The probe IS the mutation.)
+  * relational F30: pointing the new COMMANDS subcommand at an EXISTING tested
+    command → green; a brand-new untested name → red.
+  * completeness: dropping a rule from ``_staged_decisions`` (so it stops being
+    selected) → the superset assertion below goes red for that rule's scope.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CHECKS_DIR = _REPO_ROOT / "scripts" / "checks"
+if str(_CHECKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_CHECKS_DIR))
+
+import run_checks  # noqa: E402
+from _rule_catalogue import ALL_ENTRIES  # noqa: E402
+from _staged_selection import decide, resolve_staged_scope, staged_in_scope  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+# ── harness ─────────────────────────────────────────────────────────────
+
+
+@contextlib.contextmanager
+def _probe_file(rel: str, content: str) -> Iterator[str]:
+    """Write ``content`` to ``rel`` under the real repo tree, yield the
+    repo-relative path string, and FULLY remove it on exit — the file, any
+    ``__pycache__`` an import created, and any directory the probe itself
+    created (try/finally so a failed assert never leaves a shadow). ``rel``
+    must be a ``zzz_staged_probe*`` path so it can never collide with a real
+    file, and the probe-dir teardown only deletes ``zzz_staged_probe*``
+    directories so it can never touch a real tree."""
+    assert "zzz_staged_probe" in rel, "probe paths must be uniquely named to avoid collisions"
+    path = _REPO_ROOT / rel
+    created_dir = "zzz_staged_probe" in path.parent.name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    try:
+        yield rel
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            path.unlink()
+        # A staged-mode dispatch may have imported the probe, leaving a
+        # __pycache__ that would keep a probe PLUGIN dir alive (F36/F41/...
+        # treat any dir under kairix/connectors/ as a plugin). Remove the
+        # whole probe dir — but only ever a uniquely-named probe dir.
+        if created_dir and path.parent.exists():
+            import shutil
+
+            shutil.rmtree(path.parent, ignore_errors=True)
+
+
+def _run_staged(staged: list[str]) -> tuple[int, str]:
+    """Drive the real ``_dispatch_staged`` over ``staged``; return
+    ``(exit_code, captured_output)``."""
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
+        code = run_checks._dispatch_staged(staged, skip_coverage=True)
+    return code, buf.getvalue()
+
+
+def _failed_rule_ids(output: str) -> set[str]:
+    """The rule ids that FAILED in a staged ledger (the ``FAIL [id]`` lines)."""
+    ids: set[str] = set()
+    for line in output.splitlines():
+        if "FAIL [" in line:
+            ids.add(line.split("FAIL [", 1)[1].split("]", 1)[0])
+    return ids
+
+
+def _ran_rule_ids(output: str) -> set[str]:
+    """The rule ids that RAN (the ``run [id]`` lines) in a staged ledger."""
+    ids: set[str] = set()
+    for line in output.splitlines():
+        if "run [" in line:
+            ids.add(line.split("run [", 1)[1].split("]", 1)[0])
+    return ids
+
+
+def _skipped_rule_ids(output: str) -> set[str]:
+    ids: set[str] = set()
+    for line in output.splitlines():
+        if "skip [" in line:
+            ids.add(line.split("skip [", 1)[1].split("]", 1)[0])
+    return ids
+
+
+# ── baseline: a clean staged set passes ─────────────────────────────────
+
+
+def test_clean_staged_change_passes() -> None:
+    """Staging a clean (non-violating) kairix file leaves staged mode green —
+    the control that proves a FAIL below is the injected violation, not noise."""
+    with _probe_file(
+        "kairix/zzz_staged_probe_clean.py",
+        "def f() -> int:\n    return 1\n",
+    ) as rel:
+        code, out = _run_staged([rel])
+    assert code == 0, f"clean probe should pass; ledger:\n{out}"
+
+
+# ── file-local: forbidden import (F26) ──────────────────────────────────
+
+
+def test_file_local_f26_forbidden_import_caught() -> None:
+    """A staged kairix/core file importing kairix.providers → staged mode runs
+    and FAILS F26 (file-local class)."""
+    with _probe_file(
+        "kairix/core/zzz_staged_probe_f26.py",
+        "from kairix.providers import something  # forbidden core→providers import\n",
+    ) as rel:
+        code, out = _run_staged([rel])
+    assert code == 1, f"F26 violation must fail staged mode; ledger:\n{out}"
+    assert "F26" in _failed_rule_ids(out), f"F26 must be the failing rule; ledger:\n{out}"
+    # Sabotage check (inline): the SAME probe without the import passes.
+    with _probe_file("kairix/core/zzz_staged_probe_f26.py", "x = 1\n") as rel:
+        code2, _ = _run_staged([rel])
+    assert code2 == 0, "removing the forbidden import must clear F26 (sabotage proof)"
+
+
+# ── file-local marker: missing test category marker (F8) ────────────────
+
+
+def test_file_local_f8_missing_marker_caught() -> None:
+    """A staged test module with a ``def test_*`` but no category marker →
+    staged mode runs and FAILS F8."""
+    with _probe_file(
+        "tests/zzz_staged_probe_f8.py",
+        "def test_unmarked_probe():\n    assert True\n",
+    ) as rel:
+        code, out = _run_staged([rel])
+    assert code == 1, f"F8 missing-marker must fail staged mode; ledger:\n{out}"
+    assert "F8" in _failed_rule_ids(out), f"F8 must be the failing rule; ledger:\n{out}"
+    # Sabotage: adding the marker clears F8.
+    with _probe_file(
+        "tests/zzz_staged_probe_f8.py",
+        "import pytest\n\npytestmark = pytest.mark.unit\n\n\ndef test_marked_probe():\n    assert True\n",
+    ) as rel:
+        code2, _ = _run_staged([rel])
+    assert code2 == 0, "adding the unit marker must clear F8 (sabotage proof)"
+
+
+# ── relational: new CLI subcommand with no outcome test (F30) ───────────
+
+
+def test_relational_f30_new_surface_selects_full_scope() -> None:
+    """A staged CLI/MCP surface change SELECTS F30 (relational) to run over its
+    FULL scope — and a deletion of an outcome test does too (deletion-
+    sensitivity). This is the no-false-negative property of the NEW selection
+    code: the surface change and the paired-artefact deletion both run F30."""
+    f30 = next(e for e in run_checks._select_all() if e.id == "F30")
+    d = decide(f30, run_checks.resolve_script(f30), ["kairix/cli.py"])
+    assert d.run is True, "F30 must run when cli.py (a subcommand surface) is staged"
+    assert d.scope_files is None, "F30 is relational — it runs full scope, not narrowed to staged files"
+    d_del = decide(f30, run_checks.resolve_script(f30), ["tests/test_worker_cli_maintenance.py"])
+    assert d_del.run is True, "deleting/altering an outcome test must run F30 (deletion-sensitivity)"
+    # A change OUTSIDE F30's scope (a connector plugin file) does NOT run F30.
+    d_out = decide(f30, run_checks.resolve_script(f30), ["kairix/connectors/obsidian/connector.py"])
+    assert d_out.run is False, "F30 must skip when no staged path is in its scope (precision)"
+
+
+def test_relational_f36_new_plugin_without_feature_caught_end_to_end() -> None:
+    """End-to-end relational FAIL: staging a NEW connector plugin (a real
+    plugin dir under kairix/connectors/) without its BDD feature → staged mode
+    runs F36 over its FULL scope and FAILS. The new plugin is the cross-file
+    gap a staged plugin change introduces — exactly the class F36 guards."""
+    plugin_init = "kairix/connectors/zzz_staged_probe_conn/__init__.py"
+    plugin_conn = "kairix/connectors/zzz_staged_probe_conn/connector.py"
+    with (
+        _probe_file(plugin_init, "def make_connector():\n    return None\n"),
+        _probe_file(plugin_conn, "class ProbeConnector:\n    pass\n") as conn_rel,
+    ):
+        code, out = _run_staged([conn_rel])
+    assert code == 1, f"a new connector plugin without a BDD feature must fail staged mode; ledger:\n{out}"
+    assert "F36" in _failed_rule_ids(out), f"F36 must be the failing rule; ledger:\n{out}"
+
+
+# ── relational deletion: breaking a paired invariant ────────────────────
+
+
+def test_relational_deletion_selects_rule() -> None:
+    """A staged DELETION within a relational rule's scope still selects the
+    rule (deletion-sensitivity). F45 (capability↔BDD-feature): deleting a
+    feature file is a staged path under tests/bdd/features → F45 runs full
+    scope."""
+    f45 = next(e for e in run_checks._select_all() if e.id == "F45")
+    d = decide(f45, run_checks.resolve_script(f45), ["tests/bdd/features/bootstrap.feature"])
+    assert d.run is True, "deleting a BDD feature must run F45 at full scope"
+    assert d.scope_files is None, "relational rules are never narrowed to staged files"
+
+
+# ── cross-cutting / always-run: catalogue drift (F92) ───────────────────
+
+
+def test_always_run_f92_runs_for_any_change() -> None:
+    """F92 (catalogue currency, always-run) runs for ANY staged change,
+    including a doc-only edit far from any check tree."""
+    f92 = next(e for e in run_checks._select_all() if e.id == "F92")
+    d = decide(f92, run_checks.resolve_script(f92), ["docs/only.md"])
+    assert d.run is True, "F92 must always run (trigger is any change)"
+    # And it appears in the ran-set of a real doc-only staged dispatch.
+    _code, out = _run_staged(["docs/architecture/ENGINEERING.md"])
+    assert "F92" in _ran_rule_ids(out), f"F92 must run on a doc-only staged change; ledger:\n{out}"
+
+
+def test_always_run_f50_runs_for_any_change() -> None:
+    """F50 (net-new-file detection, always-run) runs for any staged change."""
+    f50 = next(e for e in run_checks._select_all() if e.id == "F50")
+    assert decide(f50, run_checks.resolve_script(f50), ["docs/only.md"]).run is True
+
+
+# ── completeness / negative-control table ───────────────────────────────
+#
+# For a battery of staged sets, assert the rules staged mode RUNS are a
+# SUPERSET of every rule whose scope contains a staged path (so no rule that
+# COULD be tripped by a staged file is skipped). The real tree is clean, so we
+# prove completeness structurally: every rule in-scope for a staged set is run.
+
+
+_BATTERY: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("docs-only", ("docs/architecture/ENGINEERING.md",)),
+    ("single-kairix-core", ("kairix/core/search/pipeline.py",)),
+    ("tests-only", ("tests/test_credentials.py",)),
+    ("bdd-feature", ("tests/bdd/features/bootstrap.feature",)),
+    ("cli-surface", ("kairix/cli.py",)),
+    ("workflow", (".github/workflows/ci.yml",)),
+    ("sonar-config", ("sonar-project.properties",)),
+    ("connector", ("kairix/connectors/obsidian/connector.py",)),
+    ("setup-template", ("kairix/platform/setup/web/templates/setup/folder.html",)),
+    ("services-go", ("services/hello/cmd/hello/main.go",)),
+    ("multi-3", ("kairix/core/factory.py", "tests/test_paths.py", "docs/x.md")),
+)
+
+
+def _rules_in_scope_for(staged: list[str]) -> set[str]:
+    """Every dispatchable run_all rule that, by its catalogue scope/class,
+    COULD be tripped by ``staged`` — the ground-truth set staged mode must run
+    a superset of. ``always-run`` rules are always in; for the rest, a rule is
+    in-scope iff a staged path falls within its resolved scope (None scope →
+    always in, fail-safe)."""
+    in_scope: set[str] = set()
+    seen_scripts: set[str] = set()
+    for e in run_checks._select_all():
+        script = run_checks.resolve_script(e)
+        if script in seen_scripts:
+            continue
+        seen_scripts.add(script)
+        if e.staged_class == "always-run":
+            in_scope.add(e.id)
+            continue
+        scope = resolve_staged_scope(e, script)
+        if scope is None or staged_in_scope(scope, staged):
+            in_scope.add(e.id)
+    return in_scope
+
+
+@pytest.mark.parametrize("label,staged", _BATTERY, ids=[b[0] for b in _BATTERY])
+def test_completeness_staged_runs_superset_of_in_scope(label: str, staged: tuple[str, ...]) -> None:
+    """No false negative: every rule whose scope a staged path falls within IS
+    run by staged mode (the ran-set ⊇ the in-scope ground-truth set)."""
+    staged_list = list(staged)
+    ran: set[str] = set()
+    skipped: set[str] = set()
+    for entry, d in run_checks._staged_decisions(staged_list):
+        (ran if d.run else skipped).add(entry.id)
+    ground_truth = _rules_in_scope_for(staged_list)
+    missing = ground_truth - ran
+    assert not missing, (
+        f"[{label}] staged mode SKIPPED in-scope rules (false-negative risk): "
+        f"{sorted(missing)}\n  staged={staged_list}\n  skipped={sorted(skipped)}"
+    )
+
+
+def test_completeness_skips_are_genuinely_out_of_scope() -> None:
+    """The dual: a skipped rule's scope genuinely contains NONE of the staged
+    paths (and it is not always-run). Proves the skips are precise, not random
+    under-running — for a docs-only change, every skipped rule is out of
+    scope."""
+    staged = ["docs/architecture/ENGINEERING.md"]
+    for entry, d in run_checks._staged_decisions(staged):
+        if d.run:
+            continue
+        assert entry.staged_class != "always-run", f"{entry.id}: always-run rule must never be skipped"
+        scope = resolve_staged_scope(entry, run_checks.resolve_script(entry))
+        assert scope is not None, f"{entry.id}: a scope-unresolved rule must run (fail-safe), not skip"
+        assert not staged_in_scope(scope, staged), f"{entry.id}: skipped but a staged path is in scope {scope}"
+
+
+def test_every_dispatchable_rule_has_a_decision() -> None:
+    """Every rule the ``--all`` set dispatches gets a staged decision (no rule
+    silently falls out of the staged selection)."""
+    all_ids = {e.id for e in run_checks._select_all()}
+    decided = {e.id for e, _ in run_checks._staged_decisions(["kairix/x.py"])}
+    # Deduped by script, so the count may differ; every decided id is a real
+    # all-set id and the F7/F9-style script dedup is the only divergence.
+    assert decided <= all_ids
+    assert "F26" in decided and "F92" in decided
+
+
+def test_staged_classes_are_valid() -> None:
+    """Every catalogue entry's ``staged_class`` is a member of the closed
+    vocabulary, and ``staged_scope`` (when set) is a non-empty tuple."""
+    valid = {"file-local", "relational", "always-run"}
+    for e in ALL_ENTRIES:
+        assert e.staged_class in valid, f"{e.id}: invalid staged_class {e.staged_class!r}"
+        if e.staged_scope is not None:
+            assert isinstance(e.staged_scope, tuple) and e.staged_scope, f"{e.id}: empty staged_scope"


### PR DESCRIPTION
Stage 4b of the #499 Phase 2 runner work — precise per-rule staged selection (the inner-loop speedup that unblocks `safe-commit --check`).

## What
Staged mode now classifies every rule and selects soundly instead of narrowing by file extension:
- **file-local (51)** — verdict determinable from the file alone → run over `staged ∩ scope`, skip if empty; the AST file-index is narrowed to staged files (e.g. F5: 1402→2 files).
- **relational (34)** — verdict depends on cross-file state (F30 CLI↔test, F45 capability↔BDD, F52 flag↔registry, …) → run FULL scope when any staged path is in scope.
- **always-run (5)** — F22/F23/F50/F92/no-hardcoded-paths — trigger is "any change".

Single-sourced via two defaulted `RuleEntry` fields (`staged_class`, `staged_scope`); `--all` and the named ledger are byte-identical to 4a.

## The bar: soundness — no false negative on staged changes
- Soundness battery (`tests/checks/test_staged_selection.py`): for 11 staged sets, rules-run ⊇ in-scope ground truth. Every injected violation (file-local F26/F8, relational F36/F30, always-run F92) is caught. Sabotage-proven.
- **Adversarial audit (3 reviewers over all 51 file-local rules)** caught **two unsound misclassifications** the battery missed — F46 (reads `kairix/agents/mcp/server.py`) and F56 (reads `kairix/core/protocols.py`). Both reclassified `relational` with scope extended to the cross-file source, so staging either side re-runs the rule. The other 49 confirmed truly per-file.

## Perf (soundness-first)
- docs/config/workflow commits: **~0.5s** (<1s — the common iteration loop).
- 2-4 file code commits: ~3s; kairix/tests commits 7-10s — the irreducible cost of deletion-sensitive relational rules + shell detectors running conservatively. Still well under Item 5's <45s budget.

## Verification
89/89 + F92 green; `--all` byte-identical to 4a; full `safe-commit.sh` clean. No baselines touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
