### PR TITLE
ci(fitness): kairix consumes shared ci-workflows reusables — sonar-scan + fresh-install-smoke @v1 (EPIC #499 Wave 3b)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -751,33 +751,27 @@ jobs:
   # TODO(#499): confirm gating intent — the job header comment below still
   # reads "branch protection should gate on this job"; reconcile that with the
   # current branch-protection contexts before promoting Sonar to a hard gate.
+  #
+  # EPIC #499 Wave 3b: this job now consumes the shared org reusable
+  # three-cubes/ci-workflows/sonar-scan.yml@v1 (the artifact-handoff scan
+  # generalized FROM this very job). It still DOWNLOADS the upstream coverage
+  # XML (coverage-data, from unit-and-type) + JUnit results
+  # (test-results-unit-3.12) rather than re-running pytest, keeps fetch-depth: 0
+  # for new-code blame, and stays `# fan-in: informational` — NOT in the `check`
+  # gate's needs-closure (branch protection requires exactly "CI gate"; Sonar is
+  # advisory). needs: [changes, unit-and-type] is preserved so the artifacts
+  # exist before the scan; if: gates on the python change-filter exactly as before.
   sonarcloud:
     name: "SonarCloud analysis"
-    runs-on: ubuntu-latest
     needs: [changes, unit-and-type]
     if: needs.changes.outputs.python == 'true'
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: test-results-unit-3.12
-        continue-on-error: true  # artifact missing on path-filtered runs; Sonar still scans without it
-
-      - name: Download coverage
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: coverage-data
-        continue-on-error: true  # artifact missing on path-filtered runs; Sonar still scans without it
-
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+    uses: three-cubes/ci-workflows/.github/workflows/sonar-scan.yml@v1
+    with:
+      fetch-depth: 0
+      coverage-artifact-name: coverage-data
+      test-results-artifact-name: test-results-unit-3.12
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   # ── Docker build verification ──────────────────────────────────────────────
   docker:

--- a/.github/workflows/fresh-install-smoke.yml
+++ b/.github/workflows/fresh-install-smoke.yml
@@ -10,6 +10,14 @@ name: "Fresh-install smoke (F81)"
 # NON-required workflow: not a branch-protection check, does not block
 # PR merge. Runs nightly on main, on demand, and on PRs touching the
 # fresh-install surface.
+#
+# EPIC #499 Wave 3b: the build+smoke body now consumes the shared org
+# reusable three-cubes/ci-workflows/fresh-install-smoke.yml@v1 (generalized
+# FROM this very workflow). The build half (buildx + gha-cached build-push,
+# tagged ghcr.io/three-cubes/kairix:fresh-smoke, load-only) and the smoke half
+# (export KAIRIX_IMAGE_TAG → bash scripts/checks/check-fresh-install-smoke.sh)
+# are byte-equivalent to the previous inline steps; this thin caller owns only
+# the `on:` triggers (a reusable can't carry them) and the input wiring.
 
 on:
   workflow_dispatch:
@@ -29,36 +37,18 @@ on:
       - '.env.example'
       - 'kairix.config.example.yaml'
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+permissions:
+  contents: read
 
 jobs:
   fresh-install-smoke:
     name: "Fresh install smoke"
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-
-      # Same build + gha-cache pattern as ci.yml's "Docker build" job, so
-      # both workflows share layer cache. Tagged under the production
-      # image name because docker-compose.yml interpolates
-      # ghcr.io/three-cubes/kairix:${KAIRIX_IMAGE_TAG}; the tag is local
-      # only (load, never push).
-      - name: Build candidate image
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-        with:
-          context: .
-          load: true
-          tags: ghcr.io/three-cubes/kairix:fresh-smoke
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Run fresh-install smoke
-        env:
-          KAIRIX_IMAGE_TAG: fresh-smoke
-        run: bash scripts/checks/check-fresh-install-smoke.sh
+    uses: three-cubes/ci-workflows/.github/workflows/fresh-install-smoke.yml@v1
+    with:
+      image-name: ghcr.io/three-cubes/kairix
+      image-tag: fresh-smoke
+      build-context: .
+      dockerfile: Dockerfile
+      smoke-script: scripts/checks/check-fresh-install-smoke.sh
+      smoke-env-var-name: KAIRIX_IMAGE_TAG
+      timeout-minutes: 45


### PR DESCRIPTION
## EPIC #499 Wave 3b — kairix consumes the shared `@v1` reusables

kairix now calls the `three-cubes/ci-workflows@v1` reusables for the jobs with genuine cross-repo value (these reusables were extracted *from* kairix's own jobs, so kairix is the faithful first caller).

### Converted to thin `uses:` callers
- **`ci.yml` `sonarcloud` job → `sonar-scan.yml@v1`** — the real shared-value one (both kairix and taz use SonarCloud). Preserves `needs: [changes, unit-and-type]`, `if: needs.changes.outputs.python`, artifact names (`coverage-data` / `test-results-unit-3.12`), `fetch-depth: 0`, `secrets: { SONAR_TOKEN }`, and its `# fan-in: informational` status (stays out of the `check` gate closure — F93 preserved).
- **`fresh-install-smoke.yml` → `fresh-install-smoke.yml@v1`** — faithful conversion (image-name, smoke-script, env-var).

### Deliberately left inline (with reasons)
- **`mutation-suite.yml`** — kept inline (hard-red nightly on survivor-growth). The reusable surfaces that as a *warning*; adopting it would weaken kairix's signal, and it has no second consumer yet. Adopt once the reusable gains a `fail-on-survivor-growth` toggle.
- **`docker-publish.yml`** — kept inline. GitHub forbids a caller granting `packages: write` down a reusable chain, so ghcr push can't use the reusable until it declares that permission itself. kairix-only.

### Note
- The Sonar status-context name nests to `SonarCloud analysis / SonarCloud scan` (cosmetic; Sonar is not a required branch-protection context — only "CI gate" + "Pre-merge PR gates" are).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
