### PR TITLE
test(perf): use existing seams to cut ~45s real sleep/network/subprocess from 5 tests

### DIFF
--- a/tests/agents/mcp/test_cold_start_envelope_during_warm.py
+++ b/tests/agents/mcp/test_cold_start_envelope_during_warm.py
@@ -19,9 +19,12 @@ This module pins the contract against the production wiring:
     the readiness check (matches ``cli.py`` line 369).
   - Real :func:`kairix.agents.mcp.transport.build_mcp_app` composes
     the Starlette app (matches ``cli.py`` lines 372-377).
-  - A background thread that flips the gate after a fixed delay —
-    mirrors the production ``_default_warm_runner`` daemon-thread
-    pattern (``cli.py`` lines 178-196).
+  - The gate is left in its construction-default cold state — which is
+    exactly the warm-window state a freshly-restarted container is in,
+    so the during-warm assertion needs no background gate-flipping
+    thread. (The flip-to-ready transition is covered by the sibling
+    ``test_request_after_warm_completes_no_longer_returns_503`` and by
+    the unit test ``test_mark_ready_flips_state``.)
   - Starlette's ``TestClient`` drives the actual ASGI request path —
     the same path uvicorn drives in production.
 
@@ -41,8 +44,6 @@ and exercised manually before commit:
 
 from __future__ import annotations
 
-import threading
-import time
 from typing import Any
 
 import pytest
@@ -77,24 +78,6 @@ def _make_real_fastmcp_server() -> Any:
     return server
 
 
-def _spawn_warm_thread_flipping_gate_after(gate: EventReadinessGate, delay_s: float) -> threading.Thread:
-    """Mirror the production warm-runner: a daemon thread that flips
-    the readiness gate after ``delay_s`` seconds.
-
-    Production ``_default_warm_runner`` (``cli.py`` line 178-196) does
-    exactly this with ``warm_retrieval_stack`` as the body. The test
-    substitutes a fixed sleep so the warm window has a known duration.
-    """
-
-    def _warm_body() -> None:
-        time.sleep(delay_s)
-        gate.mark_ready()
-
-    thread = threading.Thread(target=_warm_body, daemon=True, name="kairix-mcp-warm-test")
-    thread.start()
-    return thread
-
-
 @pytest.mark.integration
 def test_first_mcp_request_during_warm_returns_503_envelope_not_fetch_failed() -> None:
     """During the warm window, the first ``POST /mcp`` returns HTTP 503
@@ -108,8 +91,20 @@ def test_first_mcp_request_during_warm_returns_503_envelope_not_fetch_failed() -
       - FastMCP ``streamable_http_app()`` lifespan + ``/mcp`` route.
       - ``build_mcp_app`` composing the outer Starlette + middleware.
       - ``ColdStartMiddleware`` short-circuiting non-health requests.
-      - Real ``EventReadinessGate`` flipping mid-test from a daemon
-        thread (production warm-runner shape).
+      - Real ``EventReadinessGate`` left in its construction-default
+        cold state — which is exactly the warm-window state a
+        freshly-restarted container is in.
+
+    A freshly-constructed ``EventReadinessGate`` is cold by default
+    (``is_ready() is False`` — pinned by
+    ``tests/agents/mcp/test_readiness.py``), so the during-warm 503
+    assertion needs no background thread to flip it. The previous shape
+    spawned a daemon thread that slept 5s then flipped the gate, paying a
+    real 5s wall-clock tax to manufacture a window the gate is already in
+    at construction. The flip-to-ready behaviour is owned by the sibling
+    ``test_request_after_warm_completes_no_longer_returns_503`` (same file,
+    through the production wiring) and by the unit test
+    ``test_mark_ready_flips_state`` — zero coverage is lost here.
 
     Envelope shape pinned (matches ``cold_start.py`` +
     ``_build_cold_start_body``):
@@ -124,55 +119,44 @@ def test_first_mcp_request_during_warm_returns_503_envelope_not_fetch_failed() -
         affordance markers (``next:`` and ``fix:``).
     """
     server = _make_real_fastmcp_server()
-    gate = EventReadinessGate()
+    gate = EventReadinessGate()  # cold at construction — the warm-window state
     app = build_mcp_app(server, with_sse=False, readiness_check=gate.is_ready)
 
-    # Spawn a warm thread that flips the gate after 5s — long enough that
-    # the first request below lands before it. Mirrors production where
-    # ``warm_retrieval_stack`` runs in the background.
-    warm_thread = _spawn_warm_thread_flipping_gate_after(gate, delay_s=5.0)
+    with TestClient(app) as client:
+        assert not gate.is_ready(), "gate must be cold for the first assertion to be meaningful"
 
-    try:
-        with TestClient(app) as client:
-            assert not gate.is_ready(), "gate must be cold for the first assertion to be meaningful"
+        response = client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "method": "tools/list", "id": 1},
+        )
 
-            response = client.post(
-                "/mcp",
-                json={"jsonrpc": "2.0", "method": "tools/list", "id": 1},
-            )
+        assert response.status_code == 503, (
+            f"first MCP call during warm must return 503; got {response.status_code}. "
+            f"body={response.text!r}. If status is 200 the middleware is bypassed; "
+            f"if connection refused, uvicorn never bound the port. "
+            f"fix: check ColdStartMiddleware mount in build_mcp_app."
+        )
+        retry_after_header = response.headers.get("Retry-After")
+        assert retry_after_header is not None
+        assert int(retry_after_header) > 0, f"Retry-After must be a positive int; got {retry_after_header!r}"
 
-            assert response.status_code == 503, (
-                f"first MCP call during warm must return 503; got {response.status_code}. "
-                f"body={response.text!r}. If status is 200 the middleware is bypassed; "
-                f"if connection refused, uvicorn never bound the port. "
-                f"fix: check ColdStartMiddleware mount in build_mcp_app."
-            )
-            retry_after_header = response.headers.get("Retry-After")
-            assert retry_after_header is not None
-            assert int(retry_after_header) > 0, f"Retry-After must be a positive int; got {retry_after_header!r}"
+        body = response.json()
+        assert body["error"] == "ColdStart", f"envelope error must be 'ColdStart'; got {body.get('error')!r}"
+        assert body["error_code"] == "KAIRIX_COLD_START"
+        assert body["status"] == "retryable_not_ready"
 
-            body = response.json()
-            assert body["error"] == "ColdStart", f"envelope error must be 'ColdStart'; got {body.get('error')!r}"
-            assert body["error_code"] == "KAIRIX_COLD_START"
-            assert body["status"] == "retryable_not_ready"
+        retry_after_ms = body["retry_after_ms"]
+        assert isinstance(retry_after_ms, int) and retry_after_ms > 0, (
+            f"retry_after_ms must be a positive int; got {retry_after_ms!r}"
+        )
+        estimated = body["estimated_seconds_remaining"]
+        assert isinstance(estimated, (int, float)) and estimated > 0
 
-            retry_after_ms = body["retry_after_ms"]
-            assert isinstance(retry_after_ms, int) and retry_after_ms > 0, (
-                f"retry_after_ms must be a positive int; got {retry_after_ms!r}"
-            )
-            estimated = body["estimated_seconds_remaining"]
-            assert isinstance(estimated, (int, float)) and estimated > 0
-
-            # F21 affordance markers — agent reading this envelope needs a
-            # positive ``next:`` action and a ``fix:`` fallback.
-            assert "next:" in body["guidance"]
-            assert "next:" in body["agent_instruction"]
-            assert "fix:" in body["agent_instruction"]
-    finally:
-        # Daemon thread will die with the process, but join briefly so
-        # the gate-flip log line lands before pytest tears down — keeps
-        # log output deterministic for the next test in the suite.
-        warm_thread.join(timeout=6.0)
+        # F21 affordance markers — agent reading this envelope needs a
+        # positive ``next:`` action and a ``fix:`` fallback.
+        assert "next:" in body["guidance"]
+        assert "next:" in body["agent_instruction"]
+        assert "fix:" in body["agent_instruction"]
 
 
 @pytest.mark.integration

--- a/tests/connectors/sharepoint/test_connector.py
+++ b/tests/connectors/sharepoint/test_connector.py
@@ -946,8 +946,30 @@ def test_init_probe_warns_when_include_path_returns_404(caplog: pytest.LogCaptur
 
 
 @pytest.mark.unit
-def test_init_probe_swallows_transient_errors_without_failing_init() -> None:
-    """Network failure during probe must not block connector construction."""
+def test_init_probe_swallows_transient_errors_without_failing_init(caplog: pytest.LogCaptureFixture) -> None:
+    """Network failure during probe must not block connector construction,
+    and the swallowed error surfaces as a ``sharepoint_probe_error`` warning.
+
+    The probe call against ``/Foo`` returns a sustained 503; the Graph
+    client's throttling-retry loop would otherwise pay the full
+    ``2+2+4+8 = 16s`` tenacity backoff. The Graph client exposes a
+    documented ``sleep_fn`` seam (``graph_client.py`` line 195) — the test
+    threads a no-op sleep so the retries collapse to ~0s while still
+    exercising every retry attempt and the final give-up.
+
+    Strengthened (medium→high): the prior ``connector is not None``
+    assertion only proved the constructor returned, not that the
+    transient error was actually swallowed at the documented site. We now
+    assert the ``sharepoint_probe_error`` warning is emitted naming the
+    failing drive + path, so a regression that re-raises (or swallows the
+    error silently without logging) is caught.
+
+    Sabotage proof: change ``_probe_include_paths``'s ``except Exception``
+    to re-raise — construction raises and the test fails. Drop the
+    ``logger.warning(... sharepoint_probe_error ...)`` line — the warning
+    assertion below fails.
+    """
+    import logging
 
     def handler(request: httpx.Request) -> httpx.Response:
         token = _token_response(request)
@@ -957,12 +979,41 @@ def test_init_probe_swallows_transient_errors_without_failing_init() -> None:
             return httpx.Response(503, json={"error": {"code": "serviceUnavailable"}})
         return httpx.Response(200, json=_delta_response([]))
 
-    # Constructor must not raise even when the probe call fails
-    connector = _build_connector_with_spec(
-        handler,
-        SharePointDriveSpec(drive_id=_DRIVE_ID, include_paths=("/Foo",)),
+    transport = httpx.MockTransport(handler)
+    shared = httpx.Client(transport=transport)
+    auth = OAuth2ClientCredsAuth(
+        tenant_id="t",
+        client_id="c",
+        client_secret="s-value",  # pragma: allowlist secret — test fixture
+        scope="https://graph.microsoft.com/.default",
+        http_client=shared,
     )
+    spec = SharePointDriveSpec(drive_id=_DRIVE_ID, include_paths=("/Foo",))
+
+    with caplog.at_level(logging.WARNING, logger="kairix.connectors.sharepoint.connector"):
+        # Constructor must not raise even when the probe call fails. The
+        # ``sleep_fn`` no-op collapses the tenacity backoff so this test is
+        # fast instead of paying 16s of real sleep.
+        connector = SharePointConnector(
+            drives=[spec],
+            credentials=SharePointCredentials(
+                tenant_id="t",
+                client_id="c",
+                client_secret="s-value",  # pragma: allowlist secret — test fixture
+            ),
+            auth=auth,
+            client_builder=lambda a: SharePointGraphClient(auth=a, http_client=shared, sleep_fn=lambda _s: None),
+        )
+
     assert connector is not None
+    probe_errors = [r for r in caplog.records if "sharepoint_probe_error" in r.getMessage()]
+    assert len(probe_errors) == 1, (
+        f"transient probe failure must surface exactly one sharepoint_probe_error warning; "
+        f"saw {[r.getMessage() for r in caplog.records]!r}"
+    )
+    message = probe_errors[0].getMessage()
+    assert _DRIVE_ID in message
+    assert "/Foo" in message
 
 
 # ---------------------------------------------------------------------------

--- a/tests/onboard/test_check.py
+++ b/tests/onboard/test_check.py
@@ -1042,11 +1042,37 @@ def test_run_onboard_check_failure_check_id_matches_a_known_check() -> None:
     Sabotage check: if the failure check ID ever drifts from CheckResult.name
     (e.g. someone renames a check but doesn't update CANONICAL_REMEDIATIONS),
     this catches the mismatch.
-    """
-    from kairix.platform.onboard.check import run_all_checks, run_onboard_check
 
-    all_names = {r.name for r in run_all_checks()}
-    result = run_onboard_check()
+    Driven through the public ``checks=`` DI seam (the same seam
+    ``run_all_checks`` / ``run_onboard_check`` expose) with a small fake
+    check list — one passing, one failing. The prior shape ran the full
+    unmocked ``ALL_CHECKS`` registry TWICE (real subprocess spawns for
+    ``check_mcp_service`` + real socket timeouts), paying ~5.8s of
+    wall-clock to assert a near-definitional subset relation. The fake
+    list exercises the identical collation path (``run_onboard_check`` ->
+    ``run_all_checks`` -> ``CheckFailure(check=r.name, ...)``) in <0.1s,
+    and pins the invariant the same way: every ``CheckFailure.check``
+    must be the ``.name`` of a result the runner actually produced.
+
+    Sabotage proof: change ``CheckFailure(check=r.name, ...)`` in
+    ``run_onboard_check`` to ``check=r.name + "-typo"`` — the failing
+    check's id no longer appears in ``all_names`` and the assertion fails.
+    """
+    from kairix.platform.onboard.check import CheckResult, run_all_checks, run_onboard_check
+
+    def _passing_check() -> CheckResult:
+        return CheckResult(name="alpha", ok=True, detail="ok")
+
+    def _failing_check() -> CheckResult:
+        return CheckResult(name="beta", ok=False, detail="boom", fix="run `kairix fix beta`")
+
+    fake_checks = [_passing_check, _failing_check]
+
+    all_names = {r.name for r in run_all_checks(checks=fake_checks)}
+    result = run_onboard_check(checks=fake_checks)
+    # The fake list guarantees exactly one failure surfaces, so the
+    # subset relation is exercised against a real (non-empty) failure.
+    assert [f.check for f in result.failures] == ["beta"]
     for failure in result.failures:
         assert failure.check in all_names, f"unknown check id: {failure.check!r}"
 

--- a/tests/providers/litellm_proxy/test_provider_branches.py
+++ b/tests/providers/litellm_proxy/test_provider_branches.py
@@ -204,18 +204,63 @@ def test_api_timeout_error_class_name_maps_to_provider_unreachable() -> None:
 def test_chat_uses_lazily_resolved_client_when_transport_not_supplied() -> None:
     """When ``transport_client=None`` the plugin resolves via the pool.
 
-    Drives the production-path lines (236-242). The real openai-compat
-    client is constructed; the network is not actually contacted
-    because the fake api_key surfaces an auth error first.
+    Drives the production-path lines (236-242): ``_client()`` calls
+    ``kairix.transport.pool.get_client`` with the credential's
+    ``(api_key, endpoint, timeout)``. We inject a fake builder via the
+    documented ``install_production_builder`` seam so the openai SDK never
+    builds a real client and **no network is contacted** (the prior shape
+    paid a real 5x connection retry against dead ``localhost:4000`` — the
+    old docstring claiming "the network is not actually contacted" was
+    false).
+
+    Strengthened: the prior over-broad ``pytest.raises(ProviderError)``
+    only proved *some* error surfaced. We now assert the exact
+    ``(api_key, endpoint, timeout)`` tuple the provider forwards into the
+    pool builder — proving the credential plumbing, not just that the
+    lazy path ran.
 
     Sabotage-proof: removing the ``return get_client(...)`` line means
-    ``_client()`` returns ``None``; next attribute access surfaces a
-    TypeError that doesn't pattern-match ProviderError.
-    """
-    provider = LiteLLMProxyProvider(credentials=_creds(), transport_client=None)
+    ``_client()`` returns ``None``; the fake builder never records a call
+    and the captured-tuple assertion fails. Swapping ``credentials.api_key``
+    for ``endpoint`` (or vice versa) in the ``get_client(...)`` call flips
+    the recorded tuple and fails too.
 
-    with pytest.raises(ProviderError):
-        provider.chat([{"role": "user", "content": "hi"}])
+    The autouse ``_reset_client_pool`` fixture in ``tests/conftest.py``
+    drops the production pool's cached client at teardown, so this
+    builder swap does not leak into sibling tests.
+    """
+    from kairix.transport.pool.client_pool import install_production_builder
+
+    captured: list[tuple[str, str, float]] = []
+
+    class _RecordingFakeClient:
+        """Surfaces a recognised-shape error so ``chat`` maps to ProviderError."""
+
+        class _Chat:
+            class _Completions:
+                def create(self, **_kwargs: object) -> object:
+                    raise RuntimeError("fake-no-network")
+
+            completions = _Completions()
+
+        chat = _Chat()
+
+    def _fake_builder(api_key: str, endpoint: str, *, timeout: float) -> _RecordingFakeClient:
+        captured.append((api_key, endpoint, timeout))
+        return _RecordingFakeClient()
+
+    original_builder = install_production_builder(_fake_builder)
+    try:
+        provider = LiteLLMProxyProvider(credentials=_creds(), transport_client=None)
+        with pytest.raises(ProviderError):
+            provider.chat([{"role": "user", "content": "hi"}])
+    finally:
+        install_production_builder(original_builder)
+
+    assert captured == [("litellm-virtual-key", "http://localhost:4000/v1", 30.0)], (
+        f"provider must forward credentials.(api_key, endpoint) + the default 30s timeout "
+        f"into the pool builder; recorded {captured!r}"
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/test_connect_store_azure_kv.py
+++ b/tests/unit/test_connect_store_azure_kv.py
@@ -270,42 +270,49 @@ def test_lazy_import_real_azure_identity_returns_credential() -> None:
 
 @_SKIP_NO_AZURE
 def test_lazy_import_real_azure_keyvault_returns_client() -> None:
-    """When ``azure-keyvault-secrets`` IS installed, ``_build_secret_client`` returns a real client.
+    """When ``azure-keyvault-secrets`` IS installed, ``_build_secret_client``
+    constructs a real ``SecretClient``.
 
-    Drives the import-success branch via the public store() path.
-    Strengthened: previously the test wrapped the entire ``store()`` call
-    in a try/except where BOTH outcomes (raise or no-raise) returned
-    silently — the test passed even when ``SecretClient`` was never
-    constructed (i.e. a stub was returned). The strengthened form asserts
-    on an OBSERVABLE side-effect: the real SDK's ``set_secret`` call
-    raises a credential-bound error (proves a real SecretClient was
-    instantiated), and the rationale string we check pins the SDK class
-    name to confirm it came from the real azure-keyvault-secrets SDK.
+    Mirrors the offline ``isinstance`` shape of the sibling
+    ``test_lazy_import_real_azure_identity_returns_credential`` (which
+    asserts the built credential ``isinstance DefaultAzureCredential``).
+    A ``SecretClient`` performs no DNS/TCP at construction — the network
+    is only touched on the first request — so building one and asserting
+    its type is fully offline (~0.15s) and strictly stronger than the
+    previous shape.
+
+    The previous shape drove ``store()`` to completion so the real SDK's
+    ``set_secret`` paid a real Azure DNS/TCP timeout (~4.8s), then
+    asserted on a URL substring in the wrapped error — but that substring
+    is present on ANY failure branch (the wrap message names the vault URL
+    regardless of whether a real ``SecretClient`` was ever built), so it
+    did not actually prove the lazy import + real construction ran.
+
+    Strengthened: assert the constructed object IS an
+    ``azure.keyvault.secrets.SecretClient`` instance, proving the lazy
+    import + real construction executed. A stub return (or a regression
+    that swaps in a fake) fails the ``isinstance`` check rather than
+    slipping through a substring match.
+
+    Sabotage proof: replace the ``SecretClient(...)`` construction in
+    ``_build_secret_client`` with ``return object()`` — the
+    ``isinstance`` assertion fails. (The companion direct-call import
+    tests in this file establish the same ``_build_*`` direct-drive
+    pattern.)
     """
     from azure.keyvault.secrets import SecretClient
 
     store = AzureKeyVaultTokenStore(
         vault_name="x",
         env={},
+        # Stand-in credential so the identity lazy-import path is bypassed
+        # and only the keyvault construction branch under test runs.
         credential_factory=lambda: object(),
     )
-    # The real SDK's ``set_secret`` rejects the stub credential. We
-    # confirm the error came from the real SDK by checking the wrap
-    # message that names the vault URL the SDK was given — this proves
-    # the SDK's construction + ``set_secret`` call ran, which is what
-    # the test pins.
-    with pytest.raises(TokenStoreUnauthorizedError, match=r"https://x\.vault\.azure\.net/"):
-        store.store(
-            scope="connector",
-            area="gmail",
-            instance=None,
-            tokens=_tokens(),
-            client=_client(),
-        )
-    # And a sanity check that the SDK is actually importable in this env
-    # (the test would have ImportError'd at the top-of-function import
-    # otherwise; this re-states the contract for the reader).
-    assert SecretClient is not None
+    secret_client = store._build_secret_client("https://x.vault.azure.net/")
+    assert isinstance(secret_client, SecretClient), (
+        f"lazy import + real construction must yield an azure SecretClient; got {type(secret_client)!r}"
+    )
 
 
 def test_lazy_import_azure_keyvault_raises_typed(monkeypatch: Any) -> None:


### PR DESCRIPTION
## What

Speeds up five tests that burned real `time.sleep` / real-network / real-subprocess wall-clock where an injection seam **already existed** — by using the seam. These are test-only changes through documented seams; no production behaviour changes. Each strengthened/preserved assertion was sabotage-proven (mutate prod → confirm fail → restore).

Addresses the Wave 1 quick-wins from the 2026-06-15 test-cost triage (#506).

## Measured savings (standalone, before → after)

| Test | Before | After | Saving |
|---|---|---|---|
| `sharepoint::test_init_probe_swallows_transient_errors_without_failing_init` | 16.02s | 0.07s | ~15.95s |
| `litellm_proxy::test_chat_uses_lazily_resolved_client_when_transport_not_supplied` | 14.53s | 0.03s | ~14.50s |
| `agents/mcp::test_first_mcp_request_during_warm_returns_503_envelope_not_fetch_failed` | 5.01s | 0.33s | ~4.68s |
| `unit::test_lazy_import_real_azure_keyvault_returns_client` | 4.83s | 0.19s | ~4.64s |
| `onboard::test_run_onboard_check_failure_check_id_matches_a_known_check` | 5.80s | 0.07s | ~5.73s |
| **Total** | **~46.2s** | **~0.7s** | **~45.5s** |

## Per-test detail + assertion strengthening

1. **sharepoint** — Thread the documented `SharePointGraphClient(sleep_fn=lambda _s: None)` seam so the tenacity backoff (`2+2+4+8 = 16s` real sleep) collapses to ~0s. **Strengthen (medium→high):** the prior `connector is not None` only proved the constructor returned. Now asserts the `sharepoint_probe_error` warning is emitted naming the failing drive + path, so a regression that re-raises (or swallows the error silently without logging) is caught.

2. **litellm_proxy** — Replace the real openai-SDK 5× connection retry against dead `localhost:4000` with the `client_pool.install_production_builder(fake_builder)` seam (the autouse `_reset_client_pool` fixture isolates pool state). **Strengthen:** assert the exact captured `(api_key, endpoint, timeout)` tuple the provider forwards into the pool builder, instead of the over-broad `pytest.raises(ProviderError)`. **Fixed the lying docstring** (it claimed no network was contacted — it was contacting dead `localhost:4000`). No `azure_foundry` sibling exists in that file, so nothing else to swap.

3. **agents/mcp** — Delete the daemon-thread + `time.sleep(5.0)` + `join` machinery. A freshly-constructed `EventReadinessGate()` is cold at construction — exactly the warm-window state a restarted container is in, which is all the during-warm 503 assertion needs. Flip-to-ready is owned by the sibling `test_request_after_warm_completes_no_longer_returns_503` (same file, production wiring) and the unit test `test_mark_ready_flips_state`. **Zero coverage loss.**

4. **azure_kv** — Rewrite to the offline `isinstance` shape of the sibling `test_lazy_import_real_azure_identity_returns_credential`. The prior shape paid a real Azure DNS/TCP timeout (~4.8s) and asserted a URL-substring that is present on **any** failure branch (it did not prove a real `SecretClient` was built). The new `isinstance(secret_client, SecretClient)` actually proves the lazy import + real construction ran — `SecretClient` does no DNS/TCP at construction, so this is fully offline and strictly stronger.

5. **onboard** — Inject a small `checks=` fake (one passing, one failing) through the public DI seam (`run_all_checks(checks=...)` / `run_onboard_check(checks=...)`) instead of running the full unmocked `ALL_CHECKS` registry **twice** (real subprocess spawns for `check_mcp_service` + socket timeouts). Same `CheckFailure.check ∈ all_names` invariant, plus an explicit `failures == ["beta"]` assertion so the subset relation is exercised against a real non-empty failure. Chose the seam over delete-redundant because this keeps the explicit failure-id-drift assertion that `test_canonical_remediations_cover_every_registered_check` does not make.

## Sabotage proofs (all executed: mutate prod → fail → restore)

- sharepoint: drop the `sharepoint_probe_error` warning → test fails.
- litellm: swap `api_key`/`endpoint` order in `get_client(...)` → captured-tuple assertion fails.
- mcp: remove the `add_middleware(ColdStartMiddleware, ...)` mount → 503 assertion fails.
- azure_kv: `_build_secret_client` returns `object()` → `isinstance` assertion fails.
- onboard: `CheckFailure(check=r.name + "-typo")` → `failure.check in all_names` fails.

All five touched test files pass in full (160 tests). `safe-commit.sh` green (one retry past the unrelated `test_description_keyword_query_surfaces_entity` order-dependent flake — passes standalone, #504 class, not in any touched file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
