### PR TITLE
ci: revert sonar-scan@v1 reusable wiring — fixes ci.yml startup_failure on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -751,27 +751,33 @@ jobs:
   # TODO(#499): confirm gating intent — the job header comment below still
   # reads "branch protection should gate on this job"; reconcile that with the
   # current branch-protection contexts before promoting Sonar to a hard gate.
-  #
-  # EPIC #499 Wave 3b: this job now consumes the shared org reusable
-  # three-cubes/ci-workflows/sonar-scan.yml@v1 (the artifact-handoff scan
-  # generalized FROM this very job). It still DOWNLOADS the upstream coverage
-  # XML (coverage-data, from unit-and-type) + JUnit results
-  # (test-results-unit-3.12) rather than re-running pytest, keeps fetch-depth: 0
-  # for new-code blame, and stays `# fan-in: informational` — NOT in the `check`
-  # gate's needs-closure (branch protection requires exactly "CI gate"; Sonar is
-  # advisory). needs: [changes, unit-and-type] is preserved so the artifacts
-  # exist before the scan; if: gates on the python change-filter exactly as before.
   sonarcloud:
     name: "SonarCloud analysis"
+    runs-on: ubuntu-latest
     needs: [changes, unit-and-type]
     if: needs.changes.outputs.python == 'true'
-    uses: three-cubes/ci-workflows/.github/workflows/sonar-scan.yml@v1
-    with:
-      fetch-depth: 0
-      coverage-artifact-name: coverage-data
-      test-results-artifact-name: test-results-unit-3.12
-    secrets:
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: test-results-unit-3.12
+        continue-on-error: true  # artifact missing on path-filtered runs; Sonar still scans without it
+
+      - name: Download coverage
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: coverage-data
+        continue-on-error: true  # artifact missing on path-filtered runs; Sonar still scans without it
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   # ── Docker build verification ──────────────────────────────────────────────
   docker:


### PR DESCRIPTION
## Hotfix — ci.yml startup_failure on main

#528 wired the `sonarcloud` job onto `sonar-scan.yml@v1`. That diff was workflow-only, so change-detection gated the sonar job OFF on #528's own PR (`python=false`) — the reusable caller was **never exercised** before merge. On main (and the first python-touching PR) `ci.yml` fails at **startup** (`b21dc5f8`✅ → `d91beeb7` startup_failure), blocking every run.

This restores the proven inline `sonarcloud` job (from `6537b69a`). `fresh-install-smoke.yml`'s reusable conversion is untouched (separate file, validated live on #528).

**Re-attempt later** with a forced python-change test so the caller actually runs in CI before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)