### PR TITLE
perf(test): reranker_override seam — stop the ~5s torch import in SEMANTIC backend integration tests (Wave 2 #506)

### DIFF
--- a/kairix/core/factory.py
+++ b/kairix/core/factory.py
@@ -433,6 +433,16 @@ class FactoryDeps:
       :data:`QUERY_CACHE_DISABLED` to wire ``query_cache=None`` on the
       pipeline; pass an explicit ``QueryResultCache`` instance to wire
       a specific cache.
+    - ``reranker_override``: replace the cross-encoder rerank closure.
+      ``None`` builds the production default (the
+      ``sentence-transformers`` cross-encoder closure, gated per-call by
+      ``pipeline._maybe_rerank``). Use the sentinel
+      :data:`RERANK_DISABLED` to wire ``reranker=None`` (the rerank stage
+      becomes a structural no-op — ``_maybe_rerank`` short-circuits on
+      ``reranker is None``). Pass any ``Callable[[str, list[FusedResult]],
+      list[FusedResult]]`` to inject a no-op / fake reranker that skips
+      the ~5s torch import in integration tests whose assertions never
+      read the reranked order.
     """
 
     vec_index_factory: Callable[[], Any] = field(default_factory=lambda: _default_vec_index_factory)
@@ -452,6 +462,7 @@ class FactoryDeps:
     logger_override: Any = None
     resolver_override: Any = None
     query_cache_override: Any = None  # QueryResultCache | QUERY_CACHE_DISABLED | None
+    reranker_override: Any = None  # reranker closure | RERANK_DISABLED | None
 
 
 class _QueryCacheDisabledSentinel:
@@ -467,6 +478,24 @@ class _QueryCacheDisabledSentinel:
 
 
 QUERY_CACHE_DISABLED = _QueryCacheDisabledSentinel()
+
+
+class _RerankDisabledSentinel:
+    """Sentinel for ``FactoryDeps.reranker_override`` meaning ``reranker=None``.
+
+    A bare ``None`` is indistinguishable from "use the production default
+    cross-encoder closure" — this sentinel disambiguates "wire no reranker
+    at all" so the pipeline's ``_maybe_rerank`` short-circuits without
+    importing ``sentence-transformers`` / torch. Used by integration tests
+    that assert pre-rerank pipeline behaviour and never read the reranked
+    order.
+    """
+
+    def __repr__(self) -> str:  # pragma: no cover - cosmetic
+        return "RERANK_DISABLED"
+
+
+RERANK_DISABLED = _RerankDisabledSentinel()
 
 
 def _build_vector_repo(vec_index_factory: Callable[[], Any]) -> Any:
@@ -933,9 +962,10 @@ def _is_default_deps(deps: FactoryDeps) -> bool:
 
     Any non-``None`` pipeline-component override (classifier, doc_repo,
     vec_repo, embed_service, graph, fusion, boosts, logger, resolver,
-    query_cache) also flips this to ``False`` so tests get a fresh
-    pipeline per call — the cache key is the resolved RetrievalConfig
-    alone, so caching a fake-wired pipeline would leak across cases.
+    query_cache, reranker) also flips this to ``False`` so tests get a
+    fresh pipeline per call — the cache key is the resolved
+    RetrievalConfig alone, so caching a fake-wired pipeline would leak
+    across cases.
     """
     overrides_clean = (
         deps.classifier_override is None
@@ -948,6 +978,7 @@ def _is_default_deps(deps: FactoryDeps) -> bool:
         and deps.logger_override is None
         and deps.resolver_override is None
         and deps.query_cache_override is None
+        and deps.reranker_override is None
     )
     return (
         deps.vec_index_factory is _default_vec_index_factory
@@ -1070,18 +1101,13 @@ def _build_search_pipeline_uncached(
     # logs WARNING once. None-out the reranker only when the operator
     # has explicitly disabled rerank AND no intents are registered for
     # it — saves a closure allocation per build for the disabled path.
-    rerank_disabled = not cfg.rerank.enabled and not cfg.rerank_intents
-    pipeline_reranker = None
-    if not rerank_disabled:
-        from kairix.core.search.rerank import rerank as _rerank_impl
-
-        def pipeline_reranker(query: str, fused: list[FusedResult]) -> list[FusedResult]:
-            return _rerank_impl(
-                query,
-                fused,
-                model=cfg.rerank.model,
-                candidate_limit=cfg.rerank.candidate_limit,
-            )
+    #
+    # F47 paydown — ``reranker_override`` short-circuits the production
+    # closure: the ``RERANK_DISABLED`` sentinel wires ``reranker=None``
+    # (no torch import); any other non-``None`` value is used verbatim
+    # (a no-op / fake reranker for tests). Production callers leave the
+    # override ``None`` and the cross-encoder closure below is built.
+    pipeline_reranker = _resolve_reranker(deps.reranker_override, cfg)
 
     return SearchPipeline(
         classifier=classifier,
@@ -1139,6 +1165,46 @@ def _resolve_query_cache(override: Any, cfg: RetrievalConfig) -> Any:
     if override is not None:
         return override
     return _get_or_create_query_cache(cfg_hash=_compute_cfg_hash(cfg))
+
+
+def _resolve_reranker(override: Any, cfg: RetrievalConfig) -> Any:
+    """Return the wired ``reranker`` closure for the pipeline.
+
+    Three resolution branches (mirrors :func:`_resolve_query_cache`):
+      * ``override is RERANK_DISABLED`` → ``None`` (the pipeline's
+        ``_maybe_rerank`` short-circuits; no ``sentence-transformers`` /
+        torch import).
+      * ``override`` is any other non-``None`` value (a no-op / fake
+        reranker closure) → use it verbatim.
+      * ``override is None`` → the production cross-encoder closure
+        keyed on the config-derived model + candidate_limit, unless the
+        operator has fully disabled rerank (``rerank.enabled`` False and
+        no ``rerank_intents``), in which case ``None`` is wired to save
+        a per-build closure allocation.
+
+    The production closure is built lazily — the
+    ``kairix.core.search.rerank`` import (and its transitive
+    ``sentence-transformers`` load on first call) only happens when the
+    real closure is actually wired.
+    """
+    if override is RERANK_DISABLED:
+        return None
+    if override is not None:
+        return override
+    rerank_disabled = not cfg.rerank.enabled and not cfg.rerank_intents
+    if rerank_disabled:
+        return None
+    from kairix.core.search.rerank import rerank as _rerank_impl
+
+    def pipeline_reranker(query: str, fused: list[FusedResult]) -> list[FusedResult]:
+        return _rerank_impl(
+            query,
+            fused,
+            model=cfg.rerank.model,
+            candidate_limit=cfg.rerank.candidate_limit,
+        )
+
+    return pipeline_reranker
 
 
 def _compute_cfg_hash(cfg: RetrievalConfig) -> str:

--- a/tests/core/test_factory.py
+++ b/tests/core/test_factory.py
@@ -626,6 +626,129 @@ def test_build_search_pipeline_propagates_provider_not_registered() -> None:
     assert "fake" in excinfo.value.available
 
 
+# ── reranker resolution wiring (FactoryDeps.reranker_override) ─────────
+
+
+@pytest.mark.unit
+def test_build_search_pipeline_wires_cross_encoder_closure_by_default() -> None:
+    """Default config (rerank_intents non-empty) builds the production
+    cross-encoder closure so per-intent rerank can fire at search time.
+
+    Building the closure does NOT import torch — that happens only when
+    the closure is *called*. This test asserts the closure is wired, not
+    that it runs, so it stays sub-second.
+
+    Sabotage proof: forcing ``reranker=None`` in the factory's resolution
+    would fail the ``is not None`` assertion.
+    """
+    cfg = RetrievalConfig(fusion_strategy="rrf", rerank_intents=("semantic",))
+    assert cfg.rerank.enabled is False  # not force-enabled — intents alone wire it
+    pipeline = build_search_pipeline(config=_wire_cfg(cfg), registry=_provider_registry())
+
+    assert pipeline.reranker is not None
+
+
+@pytest.mark.unit
+def test_build_search_pipeline_wires_cross_encoder_when_force_enabled_no_intents() -> None:
+    """``rerank.enabled=True`` builds the closure even with empty rerank_intents.
+
+    Pins the ``not cfg.rerank.enabled`` operand of the rerank-disabled
+    test: with ``enabled=True`` the closure must be built regardless of
+    ``rerank_intents``. An ``or`` swap in ``not enabled and not intents``
+    would wrongly disable rerank here (``True or ...``), so this kills
+    that mutant from the enabled side.
+    """
+    from kairix.core.search.config import RerankConfig
+
+    cfg = RetrievalConfig(
+        fusion_strategy="rrf",
+        rerank=RerankConfig(enabled=True),
+        rerank_intents=(),
+    )
+    pipeline = build_search_pipeline(config=_wire_cfg(cfg), registry=_provider_registry())
+
+    assert pipeline.reranker is not None
+
+
+@pytest.mark.unit
+def test_build_search_pipeline_wires_cross_encoder_when_intents_only() -> None:
+    """``rerank_intents`` non-empty (enabled=False) builds the closure.
+
+    The complementary kill for the ``and`` at the rerank-disabled check:
+    ``not False and not ("semantic",)`` = ``True and False`` = False →
+    NOT disabled → closure built. An ``or`` swap gives ``True or False`` =
+    True → wrongly disabled → ``reranker is None`` → this assertion fails.
+    """
+    cfg = RetrievalConfig(fusion_strategy="rrf", rerank_intents=("multi_hop",))
+    assert cfg.rerank.enabled is False
+    pipeline = build_search_pipeline(config=_wire_cfg(cfg), registry=_provider_registry())
+
+    assert pipeline.reranker is not None
+
+
+@pytest.mark.unit
+def test_build_search_pipeline_wires_no_reranker_when_fully_disabled() -> None:
+    """``rerank.enabled=False`` AND empty ``rerank_intents`` → ``reranker=None``.
+
+    Both operands of ``not enabled and not intents`` are True → rerank
+    disabled → the factory wires no closure (no sentence-transformers
+    import even on the production path).
+
+    Sabotage proof: dropping the disabled short-circuit would build a
+    closure and fail the ``is None`` assertion.
+    """
+    cfg = RetrievalConfig(fusion_strategy="rrf", rerank_intents=())
+    assert cfg.rerank.enabled is False
+    pipeline = build_search_pipeline(config=_wire_cfg(cfg), registry=_provider_registry())
+
+    assert pipeline.reranker is None
+
+
+@pytest.mark.unit
+def test_build_search_pipeline_rerank_disabled_sentinel_wires_no_reranker() -> None:
+    """``FactoryDeps(reranker_override=RERANK_DISABLED)`` wires ``reranker=None``.
+
+    The sentinel overrides the production resolution: even with a default
+    config whose ``rerank_intents`` would otherwise build the closure, the
+    pipeline carries no reranker — the seam integration tests rely on this
+    to skip the ~5s torch import.
+
+    Sabotage proof: ignoring the sentinel would build the closure and fail
+    the ``is None`` assertion.
+    """
+    from kairix.core.factory import RERANK_DISABLED
+
+    cfg = RetrievalConfig(fusion_strategy="rrf", rerank_intents=("semantic",))
+    pipeline = build_search_pipeline(
+        config=_wire_cfg(cfg),
+        registry=_provider_registry(),
+        deps=FactoryDeps(reranker_override=RERANK_DISABLED),
+    )
+
+    assert pipeline.reranker is None
+
+
+@pytest.mark.unit
+def test_build_search_pipeline_reranker_override_callable_used_verbatim() -> None:
+    """A callable ``reranker_override`` is wired onto the pipeline verbatim.
+
+    Sabotage proof: building the production closure instead of using the
+    injected callable would fail the identity assertion.
+    """
+
+    def fake_reranker(query: str, fused: list) -> list:
+        return fused
+
+    cfg = RetrievalConfig(fusion_strategy="rrf", rerank_intents=("semantic",))
+    pipeline = build_search_pipeline(
+        config=_wire_cfg(cfg),
+        registry=_provider_registry(),
+        deps=FactoryDeps(reranker_override=fake_reranker),
+    )
+
+    assert pipeline.reranker is fake_reranker
+
+
 @pytest.mark.unit
 def test_build_search_pipeline_auto_hydrates_secrets_via_bootstrap() -> None:
     """Every Python-API entry into ``build_search_pipeline`` auto-bootstraps

--- a/tests/integration/test_backends_integration.py
+++ b/tests/integration/test_backends_integration.py
@@ -20,7 +20,12 @@ from __future__ import annotations
 
 import pytest
 
-from kairix.core.factory import QUERY_CACHE_DISABLED, FactoryDeps, build_search_pipeline
+from kairix.core.factory import (
+    QUERY_CACHE_DISABLED,
+    RERANK_DISABLED,
+    FactoryDeps,
+    build_search_pipeline,
+)
 from kairix.core.protocols import (
     DocumentRepository,
     EmbeddingService,
@@ -107,6 +112,7 @@ def _build_pipeline(
     intent: QueryIntent = QueryIntent.SEMANTIC,
     logger: FakeSearchLogger | None = None,
     graph_available: bool = False,
+    reranker_override: object = RERANK_DISABLED,
 ):
     """Compose a SearchPipeline through the factory with protocol-compliant fakes.
 
@@ -114,6 +120,16 @@ def _build_pipeline(
     ``(embed, vec_repo)`` in ``VectorSearchBackend`` exactly as production
     does — the test wires the fakes at the same boundary the
     SQLite/Azure/usearch implementations sit on.
+
+    Rerank seam: ``reranker_override`` defaults to ``RERANK_DISABLED`` so
+    these backend-composition tests never pull the production
+    cross-encoder closure — the ~5s ``sentence-transformers``/torch import
+    that every SEMANTIC-intent search would otherwise trigger via
+    ``pipeline._maybe_rerank`` (``RetrievalConfig.defaults().rerank_intents``
+    includes ``"semantic"``). None of these tests assert the reranked
+    order, so disabling rerank is behaviour-preserving for their
+    assertions. A test that wants to prove the seam is exercised passes a
+    tracking no-op closure instead.
     """
     return build_search_pipeline(
         config=RetrievalConfig.defaults(),
@@ -129,6 +145,7 @@ def _build_pipeline(
             logger_override=logger,
             resolver_override=FakeCollectionResolver(),
             query_cache_override=QUERY_CACHE_DISABLED,
+            reranker_override=reranker_override,
         ),
     )
 
@@ -296,6 +313,135 @@ class TestVectorBackendInPipeline:
 
         assert result.vec_count == 1
         assert _result_paths(result) == ["b.md"]
+
+    @pytest.mark.integration
+    def test_injected_reranker_seam_is_invoked_on_semantic_intent(self) -> None:
+        """The factory's ``reranker_override`` seam reaches the pipeline rerank stage.
+
+        Proves the seam is wired end-to-end: a SEMANTIC-intent search with
+        ``RetrievalConfig.defaults()`` (whose ``rerank_intents`` includes
+        ``"semantic"``) passes through ``pipeline._maybe_rerank``, which
+        invokes the *injected* closure rather than the production
+        cross-encoder. This is what lets the SEMANTIC tests skip the ~5s
+        torch import: the seam is the live code path, not a bypass.
+        """
+        calls: list[tuple[str, int]] = []
+
+        def tracking_noop_reranker(query: str, fused: list) -> list:
+            calls.append((query, len(fused)))
+            return fused
+
+        vec_results = [_vec_hit(path="sem.md", distance=0.1, collection="shared")]
+        pipeline = _build_pipeline(
+            doc_repo=FakeDocumentRepository(),
+            embed=FakeEmbeddingService(),
+            vec_repo=FakeVectorRepository(results=vec_results),
+            intent=QueryIntent.SEMANTIC,
+            reranker_override=tracking_noop_reranker,
+        )
+
+        result = pipeline.search("semantic query")
+
+        # The injected reranker was called exactly once for the SEMANTIC
+        # query, and the result still surfaces (no-op returns input order).
+        assert len(calls) == 1
+        assert calls[0][0] == "semantic query"
+        assert _result_paths(result) == ["sem.md"]
+
+    @pytest.mark.integration
+    def test_disabled_reranker_seam_skips_rerank_stage(self) -> None:
+        """``RERANK_DISABLED`` wires ``reranker=None`` so the rerank stage is a no-op.
+
+        This is the default the SEMANTIC tests use to avoid the torch
+        import. With ``reranker=None``, ``pipeline._maybe_rerank``
+        short-circuits before any ``sentence-transformers`` import, and the
+        pipeline still returns the fused results unchanged.
+        """
+        vec_results = [
+            _vec_hit(path="sem-a.md", distance=0.1, collection="shared"),
+            _vec_hit(path="sem-b.md", distance=0.2, collection="shared"),
+        ]
+        pipeline = _build_pipeline(
+            doc_repo=FakeDocumentRepository(),
+            embed=FakeEmbeddingService(),
+            vec_repo=FakeVectorRepository(results=vec_results),
+            intent=QueryIntent.SEMANTIC,
+            reranker_override=RERANK_DISABLED,
+        )
+        # The pipeline carries no reranker — the rerank stage cannot fire.
+        assert pipeline.reranker is None
+
+        result = pipeline.search("semantic query")
+
+        assert result.vec_count == 2
+        assert sorted(_result_paths(result)) == ["sem-a.md", "sem-b.md"]
+
+    @staticmethod
+    def _build_production_reranker_pipeline(config: RetrievalConfig):
+        """Build a pipeline through the *production* reranker path (no override).
+
+        Every component except the reranker is a fake so the only live
+        wiring under test is the factory's config-driven choice of whether
+        to build the cross-encoder closure. ``reranker_override`` is left
+        unset, so ``cfg`` alone decides ``pipeline.reranker``.
+        """
+        return build_search_pipeline(
+            config=config,
+            paths=FakePaths(),
+            deps=FactoryDeps(
+                classifier_override=FakeClassifier(intent=QueryIntent.SEMANTIC),
+                doc_repo_override=FakeDocumentRepository(),
+                embed_service_override=FakeEmbeddingService(),
+                vec_repo_override=FakeVectorRepository(
+                    results=[_vec_hit(path="x.md", distance=0.1, collection="shared")]
+                ),
+                graph_override=FakeGraphRepository(available=False),
+                fusion_override=RRFFusion(k=60),
+                boosts_override=[],
+                logger_override=FakeSearchLogger(),
+                resolver_override=FakeCollectionResolver(),
+                query_cache_override=QUERY_CACHE_DISABLED,
+                # No reranker_override — the production default path runs.
+            ),
+        )
+
+    @pytest.mark.integration
+    def test_rerank_fully_disabled_in_config_wires_no_reranker(self) -> None:
+        """A config with rerank disabled AND no rerank_intents wires ``reranker=None``.
+
+        Exercises the *production default* path (no ``reranker_override``):
+        when ``cfg.rerank.enabled`` is False AND ``cfg.rerank_intents`` is
+        empty, the factory skips building the cross-encoder closure
+        entirely — no ``sentence-transformers`` import even with production
+        wiring. Proves the operator-config "rerank off" branch.
+        """
+        # rerank.enabled defaults to False; rerank_intents=() — BOTH operands
+        # of ``not enabled and not intents`` are True → rerank disabled.
+        pipeline = self._build_production_reranker_pipeline(RetrievalConfig(rerank_intents=()))
+
+        assert pipeline.reranker is None
+
+        result = pipeline.search("semantic query")
+        assert _result_paths(result) == ["x.md"]
+
+    @pytest.mark.integration
+    def test_rerank_built_when_intents_registered_even_if_not_force_enabled(self) -> None:
+        """Non-empty ``rerank_intents`` builds the closure even with ``enabled=False``.
+
+        Pins the ``and`` in ``not enabled AND not intents``: with
+        ``rerank.enabled`` False but ``rerank_intents`` non-empty (the
+        ``RetrievalConfig.defaults()`` shape), the closure MUST be built so
+        per-intent rerank can fire. An ``or`` here would wrongly disable
+        rerank for the default config — this assertion kills that mutant.
+        """
+        # enabled=False, intents non-empty → ``not False and not (...)`` =
+        # ``True and False`` = False → NOT disabled → closure built.
+        config = RetrievalConfig(rerank_intents=("semantic",))
+        assert config.rerank.enabled is False  # guards the precondition
+
+        pipeline = self._build_production_reranker_pipeline(config)
+
+        assert pipeline.reranker is not None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Wave 2 item 9 of the test-cost triage (#506). Stops every SEMANTIC integration test in `test_backends_integration.py` from paying a ~5s `sentence-transformers`/torch import inside `pipeline._maybe_rerank`, even though none of them assert the reranked order.

## Problem

`RetrievalConfig.defaults().rerank_intents` includes `"semantic"`, so any SEMANTIC-intent search built through `build_search_pipeline` with the default config wires the production cross-encoder closure and triggers a one-time torch load the first time it fires. Every other dep in these tests is an in-memory fake (imports + build are ~0.1s); the rerank result is never asserted, so the cost is pure waste on the per-commit path.

Measured (fresh process, this machine):

| scope | before | after |
|---|---|---|
| `TestVectorBackendInPipeline` (SEMANTIC class) | 4.67s | 0.09s |
| whole `test_backends_integration.py` | ~4.76s | 0.10s |

The ~4.5s is the cross-encoder `CrossEncoder(...)` load (torch + sentence-transformers).

## Fix — approach (a): a `reranker_override` seam on `FactoryDeps`

Chose the seam over a rerank-disabled config because `FactoryDeps` already injects ten sibling `*_override` pipeline components (the F47 paydown pattern) — consistency with how every other fake is wired through `kairix.core.factory.build_*`. The change mirrors the existing `query_cache_override` + `QUERY_CACHE_DISABLED` shape exactly:

- New `FactoryDeps.reranker_override` field.
- New `RERANK_DISABLED` sentinel → wires `reranker=None` (the rerank stage becomes a structural no-op; `_maybe_rerank` short-circuits on `reranker is None`, so no torch import).
- Any callable → used verbatim (a no-op / fake reranker).
- `None` (production default) → builds the real cross-encoder closure **unchanged**. Operators and production are byte-identical — default-safe.
- Extracted the closure-building logic into `_resolve_reranker(override, cfg)` (mirrors `_resolve_query_cache`), and added the override to `_is_default_deps` so a set override bypasses the process-shared pipeline cache like the others.

## Tests

- `test_backends_integration.py`: the shared `_build_pipeline` helper now defaults `reranker_override=RERANK_DISABLED`. Added 3 seam tests — the injected no-op reranker **is** invoked on SEMANTIC intent (proves the seam is the live code path, not a bypass), `RERANK_DISABLED` skips the stage, and a fully rerank-disabled config wires no reranker through the production path.
- `tests/core/test_factory.py`: 6 unit tests pinning all four `_resolve_reranker` branches through the public factory surface (default closure / force-enabled / intents-only / fully-disabled / `RERANK_DISABLED` / callable-verbatim). These kill the `and`→`or` mutant at the rerank-disabled check that the integration-marked tests alone could not (mutation_parity only runs `unit or bdd or contract`).

## Verification

- `safe-commit.sh` green: 10117 passed, 95.77% coverage, mutation_parity 0 survivors, arch-fitness / secrets / confidential / sonar all clean.
- `factory.py` holds ≥90% per-file coverage in the unit+integration union (all four new `_resolve_reranker` lines covered).
- **Sabotage-proof (executed):** stubbing `_resolve_reranker` to ignore the override makes both seam tests FAIL — and re-incurs the 5.4s torch load — confirming the tests are load-bearing; restoring makes them pass in 0.07s.

Scope: only `kairix/core/factory.py`, `tests/integration/test_backends_integration.py`, and `tests/core/test_factory.py` (the new seam-pinning unit tests). No production behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)