### PR TITLE
perf(probe-config): wire degraded/critical p95 thresholds to the CLI; refactor 3 sleep-tests (-27s)

### DIFF
--- a/kairix/quality/probe/config_cli.py
+++ b/kairix/quality/probe/config_cli.py
@@ -51,6 +51,8 @@ from kairix.quality.probe.config_runner import (
     DEFAULT_CONCURRENCY,
     DEFAULT_REPEATED_SAMPLES,
     DEFAULT_WARM_SAMPLES,
+    WARM_P95_CRITICAL_MS,
+    WARM_P95_DEGRADED_MS,
     TransportSnapshotter,
     run_probe_config,
 )
@@ -141,6 +143,28 @@ def _build_parser() -> argparse.ArgumentParser:
         type=int,
         default=DEFAULT_REPEATED_SAMPLES,
         help=f"repeated-query samples for the cache phase (>=1). Default {DEFAULT_REPEATED_SAMPLES}.",
+    )
+    p.add_argument(
+        "--degraded-p95-ms",
+        type=float,
+        default=WARM_P95_DEGRADED_MS,
+        metavar="MS",
+        help=(
+            f"warm-p95 latency (ms) above which the verdict is 'degraded' (exit 1). "
+            f"Lower it for endpoints you expect to be local/fast; raise it for distant "
+            f"endpoints where a higher tail is acceptable. Default {WARM_P95_DEGRADED_MS:.0f}."
+        ),
+    )
+    p.add_argument(
+        "--critical-p95-ms",
+        type=float,
+        default=WARM_P95_CRITICAL_MS,
+        metavar="MS",
+        help=(
+            f"warm-p95 latency (ms) above which the verdict is still 'degraded' but a "
+            f"critical warning is added (endpoint effectively unusable). "
+            f"Default {WARM_P95_CRITICAL_MS:.0f}."
+        ),
     )
     p.add_argument(
         "--perf",
@@ -432,6 +456,12 @@ def main(
       :func:`kairix.paths.provider_name` (canonical F4-clean reader).
       Tests pass a fixed-value lookup so they don't have to mutate the
       real process env.
+
+    The ``--degraded-p95-ms`` / ``--critical-p95-ms`` flags let an
+    operator tune the warm-p95 verdict thresholds to their endpoint
+    distance without a code change; they default to
+    :data:`WARM_P95_DEGRADED_MS` / :data:`WARM_P95_CRITICAL_MS` so the
+    verdict is unchanged for operators who don't pass them.
     """
     if env_provider_lookup is None:
         env_provider_lookup = _default_env_provider_lookup
@@ -450,6 +480,15 @@ def main(
         return _invalid_args(f"--concurrency must be >= 1; got {args.concurrency}")
     if args.repeated_samples < 1:
         return _invalid_args(f"--repeated-samples must be >= 1; got {args.repeated_samples}")
+    if args.degraded_p95_ms <= 0:
+        return _invalid_args(f"--degraded-p95-ms must be > 0; got {args.degraded_p95_ms}")
+    if args.critical_p95_ms <= 0:
+        return _invalid_args(f"--critical-p95-ms must be > 0; got {args.critical_p95_ms}")
+    if args.critical_p95_ms < args.degraded_p95_ms:
+        return _invalid_args(
+            f"--critical-p95-ms ({args.critical_p95_ms}) must be >= --degraded-p95-ms "
+            f"({args.degraded_p95_ms}); critical is the harsher threshold"
+        )
 
     provider, err = _resolve_provider(args, registry, env_provider_lookup)
     if provider is None:
@@ -461,6 +500,8 @@ def main(
         concurrency=args.concurrency,
         repeated_samples=args.repeated_samples,
         snapshotter=snapshotter,
+        degraded_p95_ms=args.degraded_p95_ms,
+        critical_p95_ms=args.critical_p95_ms,
     )
 
     if args.compare:

--- a/tests/bdd/features/probe_config_health.feature
+++ b/tests/bdd/features/probe_config_health.feature
@@ -17,10 +17,19 @@ Feature: Operator probes their configured provider for health and tuning
     And the process exits with code 0
 
   Scenario: Degraded provider yields tuning advice and a non-zero exit
-    Given a configured provider whose responses exceed 2 seconds
-    When the operator runs "kairix probe-config"
+    Given a configured provider whose responses exceed the operator's degraded threshold
+    When the operator runs "kairix probe-config" with a low degraded threshold
     Then the JSON report has status "degraded"
     And the JSON report tuning_recommendations contains advice to increase pool_size or decrease coalesce_window_ms
+    And the process exits with code 1
+
+  Scenario: A stricter degraded threshold flips the same endpoint from healthy to degraded
+    Given a configured provider whose responses exceed the operator's degraded threshold
+    When the operator runs "kairix probe-config" with the default thresholds
+    Then the JSON report has status "healthy"
+    And the process exits with code 0
+    When the operator runs "kairix probe-config" with a low degraded threshold
+    Then the JSON report has status "degraded"
     And the process exits with code 1
 
   Scenario: Unreachable provider is flagged with an error

--- a/tests/bdd/steps/probe_config_health_steps.py
+++ b/tests/bdd/steps/probe_config_health_steps.py
@@ -23,9 +23,15 @@ Sabotage notes per scenario (mutate prod → confirm fail → restore):
   change ``STATUS_HEALTHY = "broken"`` → scenario fails on status
   mismatch. Confirmed locally; restored.
 
-* "Degraded provider..." — set
-  ``WARM_P95_DEGRADED_MS = 100000`` → 2 s sleep falls under it → no
-  degraded → scenario fails on status. Confirmed; restored.
+* "Degraded provider..." — raise the ``--degraded-p95-ms`` threshold
+  passed by the When step to ``1e9`` → the ~50 ms p95 falls under it →
+  no degraded → scenario fails on status. Confirmed; restored.
+
+* "A stricter degraded threshold flips..." — drop the
+  ``degraded_p95_ms=args.degraded_p95_ms`` wiring in
+  ``config_cli.main`` (so the flag is ignored) → the low-threshold run
+  stays healthy like the default run → the second "degraded" status
+  assertion fails. Confirmed; restored.
 
 * "Unreachable provider..." — set the runner to ignore
   ``embed_raises`` (catch + return empty list) → no errors counted →
@@ -132,17 +138,19 @@ def _given_healthy(_probe_state: dict[str, Any]) -> None:
     _probe_state["provider"] = FakeProvider(name="fake", dim=1536, embed_latency_s=0.005)
 
 
-@given("a configured provider whose responses exceed 2 seconds")
+@given("a configured provider whose responses exceed the operator's degraded threshold")
 def _given_degraded(_probe_state: dict[str, Any]) -> None:
-    """Slow fake: 1.2 s latency — over the 1 s degraded threshold.
+    """Fake with a small ~50 ms latency that exceeds a low degraded threshold.
 
-    1.2 s (not 2 s) keeps the BDD run wall-clock manageable while
-    still firing the WARM_P95_DEGRADED_MS branch. The feature file's
-    "exceed 2 seconds" wording is the operator's mental model; the
-    runner cares about the 1 s degraded threshold, which 1.2 s does
-    exceed.
+    The operator's mental model is "responses are slower than I'm
+    willing to accept". The runner classifies that by comparing
+    warm_p95 against the ``--degraded-p95-ms`` threshold. Pairing a
+    ~50 ms fake latency with a low 25 ms threshold (set by the When
+    step) fires the degraded branch in ~0.5 s instead of sleeping
+    >1 s per call to cross the production 1000 ms default — same
+    classification logic, a fraction of the wall-clock cost.
     """
-    _probe_state["provider"] = FakeProvider(name="fake", dim=1536, embed_latency_s=1.2)
+    _probe_state["provider"] = FakeProvider(name="fake", dim=1536, embed_latency_s=0.05)
     # Also seed a high pool_acquire so the degraded scenario's
     # tuning advice ("increase pool_size") has a snapshot to read.
     _probe_state["snapshot"] = TransportSnapshot(
@@ -259,6 +267,28 @@ def _run_cli(_probe_state: dict[str, Any], extra_argv: list[str]) -> None:
 @when(parsers.parse('the operator runs "kairix probe-config"'))
 def _when_run(_probe_state: dict[str, Any]) -> None:
     _run_cli(_probe_state, extra_argv=[])
+
+
+@when('the operator runs "kairix probe-config" with the default thresholds')
+def _when_run_default_thresholds(_probe_state: dict[str, Any]) -> None:
+    """Run with no threshold flags — the production defaults apply.
+
+    A ~50 ms endpoint sits well under the 1000 ms default degraded
+    threshold, so the verdict is healthy. The sibling low-threshold
+    When step flips the same endpoint to degraded purely via the flag.
+    """
+    _run_cli(_probe_state, extra_argv=[])
+
+
+@when('the operator runs "kairix probe-config" with a low degraded threshold')
+def _when_run_low_degraded_threshold(_probe_state: dict[str, Any]) -> None:
+    """Run with ``--degraded-p95-ms 25`` so a ~50 ms endpoint is degraded.
+
+    Exercises the operator-tunable threshold flag: the same endpoint
+    the default-threshold step classifies as healthy is degraded here
+    because the operator lowered the bar.
+    """
+    _run_cli(_probe_state, extra_argv=["--degraded-p95-ms", "25"])
 
 
 @when(parsers.parse('the operator runs "kairix probe-config --compare baseline.json"'))

--- a/tests/integration/test_outcome_quality_probe_config_cli.py
+++ b/tests/integration/test_outcome_quality_probe_config_cli.py
@@ -143,3 +143,77 @@ def test_probe_config_cli_subprocess_rejects_zero_iterations(tmp_path: Path) -> 
     assert proc.returncode == 2, f"expected exit 2, got {proc.returncode}. stderr={proc.stderr!r}"
     assert "perf iterations must be >= 1" in proc.stderr, f"stderr missing range diagnostic: {proc.stderr!r}"
     assert "fix:" in proc.stderr, f"stderr missing F21 fix: marker: {proc.stderr!r}"
+
+
+def test_probe_config_cli_subprocess_rejects_nonpositive_degraded_threshold() -> None:
+    """``--degraded-p95-ms 0`` exits 2 + actionable stderr on the real binary.
+
+    F45/F30 outcome coverage for the new ``--degraded-p95-ms`` operator
+    tuning flag: proves it is wired through the production
+    ``kairix.cli`` dispatch (argparse parses it, the range guard fires)
+    on the real subprocess surface — not just the in-process function.
+    The threshold guard runs before provider resolution, so no provider
+    config is needed and the test is hermetic and fast.
+
+    Sabotage-proof (executed locally — see commit message): mutate the
+    ``if args.degraded_p95_ms <= 0`` guard to ``< 0`` → ``--degraded-p95-ms 0``
+    falls through to provider resolution → exits 2 for "no provider
+    configured" instead, so the ``"must be > 0"`` substring assertion
+    fails. Restored.
+    """
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "kairix.cli",
+            "probe-config",
+            "--provider",
+            "fake",
+            "--degraded-p95-ms",
+            "0",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert proc.returncode == 2, f"expected exit 2, got {proc.returncode}. stderr={proc.stderr!r}"
+    assert "--degraded-p95-ms must be > 0" in proc.stderr, f"stderr missing range diagnostic: {proc.stderr!r}"
+    assert "fix:" in proc.stderr, f"stderr missing F21 fix: marker: {proc.stderr!r}"
+
+
+def test_probe_config_cli_subprocess_rejects_critical_below_degraded() -> None:
+    """``--critical-p95-ms`` below ``--degraded-p95-ms`` exits 2 on the real binary.
+
+    Proves the cross-flag guard (critical must be the harsher
+    threshold) is wired through the production dispatch. Like the
+    sibling guard test, this runs before provider resolution so it is
+    hermetic.
+
+    Sabotage-proof (executed locally — see commit message): drop the
+    ``if args.critical_p95_ms < args.degraded_p95_ms`` guard → the run
+    proceeds to provider resolution and exits 2 for "no provider
+    configured" instead, so the ``"must be >="`` substring assertion
+    fails. Restored.
+    """
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "kairix.cli",
+            "probe-config",
+            "--provider",
+            "fake",
+            "--degraded-p95-ms",
+            "1000",
+            "--critical-p95-ms",
+            "500",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert proc.returncode == 2, f"expected exit 2, got {proc.returncode}. stderr={proc.stderr!r}"
+    assert "must be >=" in proc.stderr, f"stderr missing cross-flag diagnostic: {proc.stderr!r}"
+    assert "fix:" in proc.stderr, f"stderr missing F21 fix: marker: {proc.stderr!r}"

--- a/tests/integration/test_probe_config_e2e.py
+++ b/tests/integration/test_probe_config_e2e.py
@@ -23,8 +23,10 @@ Sabotage notes per test (mutate prod → confirm fail → restore):
     fails. Confirmed; restored.
 
 * ``test_degraded_provider_writes_one_exit_and_recommendations``
-    sabotage: raise ``WARM_P95_DEGRADED_MS = 1e9`` → status stays
-    healthy → exit-code assertion fails. Confirmed; restored.
+    sabotage: raise the ``--degraded-p95-ms`` threshold passed by the
+    test to ``1e9`` (or drop the ``> degraded_p95_ms`` check in
+    ``_classify_status``) → status stays healthy → exit-code assertion
+    fails. Confirmed; restored.
 
 * ``test_unreachable_provider_writes_two_exit_with_error``
     sabotage: swallow exceptions in ``_measure_call`` (return True
@@ -138,10 +140,18 @@ def test_healthy_provider_writes_zero_exit() -> None:
 def test_degraded_provider_writes_one_exit_and_recommendations() -> None:
     """A slow provider yields exit 1 + status degraded + pool/coalesce advice.
 
-    Sabotage: raise ``WARM_P95_DEGRADED_MS = 1e9`` → healthy status →
-    rc == 1 fails.
+    Drives the degraded branch via the operator-tunable
+    ``--degraded-p95-ms 25`` flag against a small ~50 ms fake latency,
+    rather than sleeping >1 s per call to cross the production 1000 ms
+    default. Same CLI dispatch, same classification, ~0.5 s instead of
+    ~9 s. The flag defaults to the production threshold, so this
+    exercises the genuine operator knob.
+
+    Sabotage: raise ``--degraded-p95-ms`` to ``1e9`` (or drop the
+    ``> degraded_p95_ms`` check in ``_classify_status``) → healthy
+    status → rc == 1 fails.
     """
-    provider = FakeProvider(name="fake_d", dim=1536, embed_latency_s=1.2)
+    provider = FakeProvider(name="fake_d", dim=1536, embed_latency_s=0.05)
     snap = TransportSnapshot(
         coalesce_ratio=0.85,
         cache_hit_rate=0.4,
@@ -149,7 +159,7 @@ def test_degraded_provider_writes_one_exit_and_recommendations() -> None:
         current_pool_size=4,
         current_coalesce_window_ms=50,
     )
-    rc, stdout = _run(provider, snap=snap)
+    rc, stdout = _run(provider, snap=snap, extra_argv=["--degraded-p95-ms", "25"])
     assert rc == 1, f"expected exit 1; got {rc}"
     report = json.loads(stdout)
     assert report["status"] == "degraded"

--- a/tests/quality/probe/test_config_cli.py
+++ b/tests/quality/probe/test_config_cli.py
@@ -173,16 +173,24 @@ def test_main_returns_2_when_provider_not_registered(capsys: pytest.CaptureFixtu
         (["--warm-samples", "0", "--concurrency", "1", "--repeated-samples", "1"], "warm-samples"),
         (["--warm-samples", "1", "--concurrency", "0", "--repeated-samples", "1"], "concurrency"),
         (["--warm-samples", "1", "--concurrency", "1", "--repeated-samples", "0"], "repeated-samples"),
+        (["--degraded-p95-ms", "0"], "--degraded-p95-ms must be > 0"),
+        (["--critical-p95-ms", "-1"], "--critical-p95-ms must be > 0"),
+        # ``0`` (not just a negative) must be rejected — pins the ``<= 0``
+        # boundary against a ``< 0`` weakening on the critical guard.
+        (["--critical-p95-ms", "0"], "--critical-p95-ms must be > 0"),
+        (["--degraded-p95-ms", "1000", "--critical-p95-ms", "500"], "must be >="),
     ],
 )
 def test_main_returns_2_when_sample_flag_below_minimum(
     capsys: pytest.CaptureFixture[str], argv: list[str], needle: str
 ) -> None:
-    """Sample-count flags below 1 → exit code 2 + actionable stderr.
+    """Out-of-range sample/threshold flags → exit code 2 + actionable stderr.
 
-    Sabotage-proof: dropping any of the three ``if args.X < 1: return
-    _invalid_args(...)`` guards lets the runner attempt N=0 samples
-    and either hangs or surfaces a different error class.
+    Sabotage-proof: dropping any of the ``if args.X < 1`` /
+    ``args.degraded_p95_ms <= 0`` / ``args.critical_p95_ms <
+    args.degraded_p95_ms`` guards lets the runner attempt the invalid
+    value and either hangs or surfaces a different error class — the
+    per-row ``needle`` substring then misses.
     """
     rc = main(
         [*argv, "--provider", "openai"],
@@ -194,6 +202,88 @@ def test_main_returns_2_when_sample_flag_below_minimum(
     assert rc == 2
     captured = capsys.readouterr()
     assert needle in captured.err
+
+
+@pytest.mark.unit
+def test_equal_degraded_and_critical_thresholds_are_accepted(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--critical-p95-ms == --degraded-p95-ms`` is valid, not a usage error.
+
+    Critical is the "harsher or equal" threshold, so equal values are
+    a legitimate operator choice (every degraded run is also critical).
+    The run proceeds to a real verdict rather than exiting 2 for the
+    cross-flag guard.
+
+    Sabotage-proof (executed locally — see commit message): weaken the
+    cross-flag guard from ``args.critical_p95_ms < args.degraded_p95_ms``
+    to ``<=`` → equal values are rejected → ``rc != 2`` fails. Restored.
+    """
+    rc = main(
+        _short_argv("--provider", "openai", "--degraded-p95-ms", "1000", "--critical-p95-ms", "1000"),
+        registry=_registry_with("openai"),
+        snapshotter=_StubSnapshotter(),
+        env_provider_lookup=lambda: None,
+    )
+
+    captured = capsys.readouterr()
+    assert rc != 2, f"equal thresholds should be accepted; got usage-error rc=2. stderr={captured.err!r}"
+    assert "must be >=" not in captured.err, f"cross-flag guard fired on equal thresholds: {captured.err!r}"
+    # The fast fake's ~0 ms latency sits under the 1000 ms threshold → healthy.
+    assert rc == 0, f"expected healthy verdict (exit 0); got {rc}"
+
+
+@pytest.mark.unit
+def test_degraded_threshold_flag_flips_verdict_for_the_same_endpoint(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--degraded-p95-ms`` tunes the verdict for one fixed endpoint.
+
+    The default 1000 ms threshold classifies a ~50 ms endpoint as
+    healthy (exit 0); lowering it to 25 ms re-classifies the SAME
+    endpoint as degraded (exit 1). This is the operator tuning knob —
+    no provider change, only the threshold.
+
+    Sabotage-proof (executed locally — see commit message): drop the
+    ``degraded_p95_ms=args.degraded_p95_ms`` wiring in ``main``'s
+    ``run_probe_config`` call → the low-threshold run reverts to the
+    1000 ms default → stays healthy (exit 0) → the ``rc_strict == 1``
+    assertion fails. Restored.
+    """
+    registry = FakeProviderRegistry({"openai": FakeProvider(name="openai", dim=8, embed_latency_s=0.05)})
+
+    # Default thresholds: ~50 ms p95 sits well under the 1000 ms default → healthy.
+    rc_default = main(
+        ["--warm-samples", "3", "--concurrency", "2", "--repeated-samples", "3", "--provider", "openai"],
+        registry=registry,
+        snapshotter=_StubSnapshotter(),
+        env_provider_lookup=lambda: None,
+    )
+    default_payload = json.loads(capsys.readouterr().out)
+    assert rc_default == 0, f"expected healthy (exit 0) at default threshold; got {rc_default}"
+    assert default_payload["status"] == "healthy"
+
+    # Strict threshold: the SAME endpoint is now degraded purely because the operator lowered the bar.
+    rc_strict = main(
+        [
+            "--warm-samples",
+            "3",
+            "--concurrency",
+            "2",
+            "--repeated-samples",
+            "3",
+            "--provider",
+            "openai",
+            "--degraded-p95-ms",
+            "25",
+        ],
+        registry=registry,
+        snapshotter=_StubSnapshotter(),
+        env_provider_lookup=lambda: None,
+    )
+    strict_payload = json.loads(capsys.readouterr().out)
+    assert rc_strict == 1, f"expected degraded (exit 1) at 25 ms threshold; got {rc_strict}"
+    assert strict_payload["status"] == "degraded"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/quality/probe/test_config_runner.py
+++ b/tests/quality/probe/test_config_runner.py
@@ -99,13 +99,22 @@ def test_healthy_provider_yields_status_healthy_with_zero_warnings() -> None:
 
 
 def test_slow_provider_yields_status_degraded() -> None:
-    """Latency >1 s → warm_p95 > WARM_P95_DEGRADED_MS → degraded.
+    """warm_p95 above ``degraded_p95_ms`` → status degraded.
 
-    Sabotage: raise ``WARM_P95_DEGRADED_MS = 1e9`` → no sample exceeds →
-    status healthy → this assertion fails. Confirmed; restored.
+    Drives the degraded branch with a low ``degraded_p95_ms`` (25 ms)
+    against a small ~50 ms fake latency instead of sleeping >1 s per
+    call to cross the production 1000 ms default. The runner already
+    accepts ``degraded_p95_ms`` as an injectable threshold, so the
+    same classification logic is exercised at a fraction of the
+    wall-clock cost (~0.5 s instead of ~9 s).
+
+    Sabotage: raise ``degraded_p95_ms`` to ``1e9`` (or drop the
+    ``> degraded_p95_ms`` check in ``_classify_status``) → no sample
+    exceeds → status healthy → this assertion fails. Confirmed;
+    restored.
     """
-    provider = FakeProvider(name="fake_d", dim=1536, embed_latency_s=1.1)
-    report = run_probe_config(provider, **_fast_runner_kwargs())
+    provider = FakeProvider(name="fake_d", dim=1536, embed_latency_s=0.05)
+    report = run_probe_config(provider, degraded_p95_ms=25.0, **_fast_runner_kwargs())
     assert report.status == STATUS_DEGRADED
     assert report.exit_code == EXIT_CODE_DEGRADED
 


### PR DESCRIPTION
## Summary

Wave 2 of the test-cost work — the highest-value item: one small production change kills three near-duplicate ~9s tests at once (~27s off the per-commit critical path).

The `probe-config` "degraded" verdict is decided by `warm_p95` vs a 1000 ms default. `run_probe_config` already accepted `degraded_p95_ms` / `critical_p95_ms` kwargs, but **they were not wired at the CLI boundary** — so the only way to drive the degraded branch in a test was a real `~1.2s/embed` sleep stacked across the cold + warm + concurrent + repeated phases (~9s per test, ×3 near-identical tests).

## Production change (a real operator tuning knob)

- New `--degraded-p95-ms` / `--critical-p95-ms` flags on `kairix probe-config`, threaded to `run_probe_config(degraded_p95_ms=, critical_p95_ms=)`.
- Validation: each must be `> 0`; `--critical-p95-ms` must be `>= --degraded-p95-ms` (critical is the harsher/equal threshold). Actionable `fix:`/`next:`/`run:` stderr per F21.
- **Default-safe**: both default to the production constants (`WARM_P95_DEGRADED_MS` / `WARM_P95_CRITICAL_MS`), so operators who don't pass them see byte-identical behaviour.

This lets an operator tune the verdict to their endpoint distance without a code change (a local provider can demand a 50 ms bar; a distant endpoint can accept a higher tail).

## F45 discipline (new flag → BDD scenario + outcome test, same commit)

- New BDD scenario in `probe_config_health.feature` proving a stricter threshold flips the **same** endpoint from healthy → degraded.
- Two new subprocess F30 outcome tests exercising the real `python -m kairix.cli probe-config` dispatch (reject non-positive degraded threshold; reject `critical < degraded`).
- New in-process unit test pinning the verdict flip, plus an equal-threshold acceptance test and 4 new parametrised validation rows.

## Test refactor (same assertion, ~9s → ~0.5s each)

| Test | Before | After |
|---|---|---|
| `bdd::test_degraded_provider_yields_tuning_advice_and_a_nonzero_exit` | 9.72s | 0.43s |
| `integration::test_degraded_provider_writes_one_exit_and_recommendations` | 9.66s | 0.44s |
| `probe::test_slow_provider_yields_status_degraded` | 8.88s | 0.44s |
| **Total (the 3 targets)** | **28.26s** | **1.31s** |

Each now uses a low threshold (25 ms) + a tiny 50 ms fake latency instead of a 1.2 s real sleep — same classification logic, same assertions.

## Sabotage-proofs (all executed mutate → fail → restore)

- Drop the `degraded_p95_ms` wiring in `main` → all 4 threshold-dependent tests revert to healthy and fail.
- Weaken the `<= 0` degraded guard to `< 0` → the `0`-value validation tests stop getting exit 2 and fail.
- Drop the `critical >= degraded` cross-flag guard → both cross-flag tests fail.
- Mutation parity confirms all 3 boundary mutants on the new guards are killed (`<=`→`<`, `<`→`<=`).

## Verification

- `safe-commit.sh` green: 10118 passed, 95.77% coverage, mutation parity 0 survivors, all arch-fitness (incl. F45/F30) green.
- Scope: only the probe-config CLI + the 3 named test files + the BDD feature/steps + the F45/F30 outcome test. No `tests/checks/*` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
