### PR TITLE
build(fitness): bump tc_fitness pin to v0.4.1 — byte-stable --staged (EPIC #499)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,7 +201,7 @@ dev = [
     # The python_version marker is required: the package pins >=3.12 but kairix
     # declares >=3.10 with a 3.10/3.11/3.12 matrix; without the marker uv's
     # universal resolver fails. The checks only run under the 3.12 venv.
-    "three-cubes-fitness @ git+https://github.com/three-cubes/fitness-engine.git@v0.4.0 ; python_version >= '3.12'",
+    "three-cubes-fitness @ git+https://github.com/three-cubes/fitness-engine.git@v0.4.1 ; python_version >= '3.12'",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -1510,7 +1510,7 @@ requires-dist = [
     { name = "sentence-transformers", marker = "extra == 'rerank'", specifier = ">=3.0,<6" },
     { name = "spacy", marker = "extra == 'nlp'", specifier = ">=3.7,<4" },
     { name = "tenacity", specifier = ">=8,<10" },
-    { name = "three-cubes-fitness", marker = "python_full_version >= '3.12' and extra == 'dev'", git = "https://github.com/three-cubes/fitness-engine.git?rev=v0.4.0" },
+    { name = "three-cubes-fitness", marker = "python_full_version >= '3.12' and extra == 'dev'", git = "https://github.com/three-cubes/fitness-engine.git?rev=v0.4.1" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.33.0.20260408" },
     { name = "usearch", specifier = ">=2.8,<3" },
@@ -5022,8 +5022,8 @@ wheels = [
 
 [[package]]
 name = "three-cubes-fitness"
-version = "0.4.0"
-source = { git = "https://github.com/three-cubes/fitness-engine.git?rev=v0.4.0#aba8de065f484421308307614fb024b0ccf7fed3" }
+version = "0.4.1"
+source = { git = "https://github.com/three-cubes/fitness-engine.git?rev=v0.4.1#324eb18b121161d009b8493e21afe8a229260a91" }
 
 [[package]]
 name = "tokenizers"


### PR DESCRIPTION
Bumps `three-cubes-fitness` `@v0.4.0 → @v0.4.1` to pick up the byte-stable `--staged` capturing dispatch (engine v0.4.1). Verdicts unchanged (only staged output format/stability). safe-commit full gate green. Completes the kairix v0.4.1 adoption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)