### PR TITLE
fix(test): land the residual isolation + wall-clock flakes (#493, #506)

### DIFF
--- a/.architecture/baseline/f82-files.txt
+++ b/.architecture/baseline/f82-files.txt
@@ -5,8 +5,6 @@
 # then delete the line.
 tests/agents/mcp/test_async_tool_handler_dispatch_pool.py
 tests/briefing/test_pipeline_async.py
-tests/cli/test_route_via_mcp.py
-tests/core/embed/test_embed_coalescer.py
 tests/core/test_health.py
 tests/e2e/test_composed_production_path.py
 tests/integration/test_outcome_bootstrap_cli.py

--- a/tests/checks/test_staged_selection.py
+++ b/tests/checks/test_staged_selection.py
@@ -254,24 +254,45 @@ def test_file_local_f26_forbidden_import_caught() -> None:
 
     This is the ONE retained end-to-end full ``_dispatch_staged`` smoke — it
     proves the real staged-dispatch wiring (selection → narrowing → in-process
-    ledger → exit code) is intact end-to-end on the per-commit path, AND it
-    carries the cluster's only clean-arm control through the full gate (the
-    sabotage arm below stages a clean probe and asserts the whole dispatch goes
-    green). The other file-local proofs (F8) use the cheaper single-rule
-    :func:`_run_one_narrowed`; only this one pays the whole-gate cost, by
-    design."""
+    ledger) is intact end-to-end on the per-commit path, AND it carries the
+    cluster's only clean-arm control through the full gate (the sabotage arm
+    below stages a clean probe and asserts F26 clears). The other file-local
+    proofs (F8) use the cheaper single-rule :func:`_run_one_narrowed`; only this
+    one pays the whole-gate cost, by design.
+
+    Robustness (#506): the assertions are scoped to **F26's own verdict in the
+    ledger**, never the aggregate exit code. ``_run_staged`` drives the FULL
+    ~40-rule staged gate, several of whose rules (F50 net-new-file vs baseline,
+    F92 catalogue-currency, F22 path-naming, the token scanners) read
+    whole-tree / git state — so a stray probe or ``__pycache__`` another test
+    left in the tree could flip the aggregate ``exit_code`` to 1 even when this
+    probe's own change is clean, failing a ``code2 == 0`` assertion for reasons
+    that have nothing to do with F26 (the flake this test hit 3x on a pin bump).
+    Asserting F26 specifically RAN and FAILED (violation arm) / RAN and did NOT
+    fail (clean arm) keeps the full e2e dispatch as the subject while making the
+    verdict immune to unrelated whole-tree rule state. The
+    ``_sweep_staged_probes`` session fixture above scrubs the most common
+    debris; this scoping is the structural complement that removes the
+    dependency on a globally-clean tree entirely."""
     with _probe_file(
         "kairix/core/zzz_staged_probe_f26.py",
         "from kairix.providers import something  # forbidden core→providers import\n",
     ) as rel:
-        code, out = _run_staged([rel])
-    assert code == 1, f"F26 violation must fail staged mode; ledger:\n{out}"
-    assert "F26" in _failed_rule_ids(out), f"F26 must be the failing rule; ledger:\n{out}"
+        _code, out = _run_staged([rel])
+    # Violation arm: F26 must have RUN (dispatch wiring intact) and FAILED on
+    # the forbidden import. Scoped to F26 — independent of any other rule's
+    # whole-tree verdict, so unrelated tree debris cannot make this flake.
+    assert "F26" in _ran_rule_ids(out), f"F26 must run end-to-end through the real dispatch; ledger:\n{out}"
+    assert "F26" in _failed_rule_ids(out), f"F26 must FAIL on the forbidden core→providers import; ledger:\n{out}"
     # Sabotage + clean-arm control (inline): the SAME probe without the import
-    # passes the FULL staged gate — the dispatch goes green on a clean change.
+    # still RUNS F26 but F26 must NOT fail — the verdict flips on the one-line
+    # edit. Again scoped to F26, not the aggregate exit code.
     with _probe_file("kairix/core/zzz_staged_probe_f26.py", "x = 1\n") as rel:
-        code2, out2 = _run_staged([rel])
-    assert code2 == 0, f"removing the forbidden import must clear F26 (sabotage + clean-arm); ledger:\n{out2}"
+        _code2, out2 = _run_staged([rel])
+    assert "F26" in _ran_rule_ids(out2), f"F26 must still run on the clean probe; ledger:\n{out2}"
+    assert "F26" not in _failed_rule_ids(out2), (
+        f"removing the forbidden import must clear F26 (sabotage + clean-arm); ledger:\n{out2}"
+    )
 
 
 # ── file-local marker: missing test category marker (F8) ────────────────

--- a/tests/cli/test_route_via_mcp.py
+++ b/tests/cli/test_route_via_mcp.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
-import time
 from typing import Any
 
 import pytest
@@ -114,35 +113,38 @@ def test_falls_back_to_in_process_when_mcp_down() -> None:
 
 
 @pytest.mark.unit
-def test_detection_budget_under_100ms_when_mcp_down() -> None:
-    """The detection probe must complete in <100ms when MCP is unreachable.
+def test_detection_probe_falls_through_when_mcp_unreachable() -> None:
+    """The real probe returns False (fall-through) when MCP is unreachable.
 
-    Uses the real :class:`HttpMcpDispatchClient` so the assertion
-    catches a regression in the underlying ``requests.head`` timeout
-    wiring. The endpoint points at a port we expect to be unbound;
-    on a system where that port IS bound, the test still passes as
-    long as the probe returns within budget — the wall-clock check is
-    the contract, not the specific is_responsive return value.
+    F82 rewrite (#493): the old shape asserted ``elapsed_ms < 150.0``
+    against a real ``requests.head`` probe — a wall-clock ceiling that
+    measures host scheduling, not kairix behaviour, and tripped under
+    concurrent-gate load. The *outcome* the budget exists to guarantee is
+    "MCP-down ⇒ fall through to in-process without blocking the CLI", and
+    that is deterministic: a ``HEAD`` to an unbound port is refused
+    immediately, so the real :class:`HttpMcpDispatchClient` returns
+    ``False`` every time. We assert that outcome instead of the elapsed
+    time. The companion deterministic proofs cover the rest of the budget
+    contract without a clock:
 
-    Sabotage-proof: changed ``_DETECTION_TIMEOUT_S`` from 0.1 to 2.0,
-    re-ran with KAIRIX_MCP_ENDPOINT pointing at an unbound port, and
-    confirmed the elapsed_ms reading went to ~2000ms — the assertion
-    fired with ``assert 2003.4 < 100.0`` as expected. Reverting the
-    timeout back to 0.1 restored green.
+    * the dispatcher passing the bounded ``detection_timeout_s`` through
+      to ``is_responsive`` — ``test_detection_probe_respects_timeout_budget``
+      (the real ``requests.head`` ``timeout=`` wiring regression that the
+      old wall-clock test claimed to catch);
+    * ``measure_detection_budget_ms`` returning a non-negative reading —
+      ``test_measure_detection_budget_ms_returns_non_negative``.
+
+    Sabotage-proof (executed): made ``HttpMcpDispatchClient.is_responsive``
+    ``return True`` unconditionally → this test failed (``assert False``
+    on the returned value). Restoring the real refused-connection branch
+    restored green. Deterministic on any host — no elapsed-time ceiling.
     """
-    deps = DispatcherDeps(
-        endpoint_fn=lambda: "http://127.0.0.1:1/mcp",  # port 1 is privileged + always unbound for user
-        routing_enabled_fn=lambda: True,
-        detection_timeout_s=0.1,
-        client=HttpMcpDispatchClient(),
-    )
+    client = HttpMcpDispatchClient()
+    # port 1 is privileged + always unbound for an unprivileged user, so
+    # the HEAD is refused immediately on every platform.
+    responsive = client.is_responsive("http://127.0.0.1:1/mcp", timeout_s=0.1)
 
-    elapsed_ms = measure_detection_budget_ms(deps=deps)
-
-    # 100ms ceiling per issue acceptance. Add a small slack (50ms) for
-    # CI variance — the contract is "doesn't block CLI startup", not
-    # "completes in exactly 100ms".
-    assert elapsed_ms < 150.0, f"detection budget breached: {elapsed_ms:.1f}ms (ceiling 150ms)"
+    assert responsive is False, "an unreachable MCP endpoint must probe as not-responsive (CLI falls through)"
 
 
 # ---------------------------------------------------------------------------
@@ -1033,28 +1035,37 @@ def test_http_client_call_tool_drives_async_mcp_session(monkeypatch) -> None:
 
 
 @pytest.mark.unit
-def test_dispatcher_does_not_block_caller_beyond_probe_budget() -> None:
-    """The dispatcher does not block beyond the probe's wall-clock budget.
+def test_dispatcher_falls_through_on_unresponsive_probe_without_extra_call() -> None:
+    """A non-responsive probe ⇒ fall-through with exactly one probe, no tool call.
 
-    Uses a fake that ``time.sleep(0.05)``-s on the probe to confirm
-    the dispatcher does not add its own sleep on top. Catches a
-    regression where someone introduces ``time.sleep`` for some
-    "give it a moment to reconnect" rationale.
+    F82 rewrite (#493): the old shape slept 50ms in the fake probe and
+    asserted ``elapsed < 0.150`` to prove "the dispatcher adds no sleep of
+    its own". That ceiling measures host scheduling and flakes under load.
+    The deterministic outcome the test actually protects is: when the
+    probe reports not-responsive, the dispatcher returns ``None``
+    (in-process fall-through) after exactly ONE ``is_responsive`` call and
+    makes ZERO ``call_tool`` calls — it does no extra round-trip / retry /
+    reconnect work. That is what a "give it a moment to reconnect"
+    regression (a ``time.sleep`` + re-probe, or a speculative
+    ``call_tool``) would break, and it is provable without a clock: such a
+    regression would add a second ``responsive_calls`` entry or a
+    ``calls`` entry.
 
-    Sabotage-proof: added ``time.sleep(0.2)`` after the probe in the
-    dispatcher; this test failed with elapsed > 0.15s. Removing the
-    sleep restored green.
+    Sabotage-proof (executed): added a re-probe (``client.is_responsive``
+    called twice) after the first not-responsive return in
+    ``try_dispatch_via_mcp`` → this test failed (``len(responsive_calls)
+    == 2``). Restoring the single-probe fall-through restored green.
+    Deterministic on any host — no elapsed-time ceiling.
     """
-    client = FakeMcpDispatchClient(responsive=False, responsiveness_delay_s=0.05)
+    client = FakeMcpDispatchClient(responsive=False)
     deps = DispatcherDeps(
         client=client,
         endpoint_fn=lambda: "http://localhost:8080/mcp",
         routing_enabled_fn=lambda: True,
     )
 
-    start = time.monotonic()
-    try_dispatch_via_mcp("search", ["q", "--json"], deps=deps)
-    elapsed = time.monotonic() - start
+    exit_code = try_dispatch_via_mcp("search", ["q", "--json"], deps=deps)
 
-    # Probe sleeps 50ms; budget for dispatcher overhead is generous (100ms)
-    assert elapsed < 0.150, f"dispatcher added overhead beyond probe budget: {elapsed * 1000:.1f}ms"
+    assert exit_code is None, "an unresponsive probe must fall through to in-process (return None)"
+    assert len(client.responsive_calls) == 1, "the dispatcher must probe exactly once (no retry/reconnect loop)"
+    assert client.calls == [], "no tool call may run after a not-responsive probe"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -418,6 +418,36 @@ def _reset_client_pool():
 
 
 @pytest.fixture(autouse=True)
+def _reset_vector_index_singleton():
+    """Drop the process-shared usearch vector-index singleton between tests (#506 / #504-sibling).
+
+    ``kairix.core.search.vec_index._VECTOR_INDEX`` is a process-global
+    handle built lazily by :func:`get_vector_index`. The first call wins
+    the cache and **every later call returns that same instance,
+    regardless of the ``db_path`` argument** — so once any test populates
+    it (e.g. a vec-index lifecycle/contract test loading a real on-disk
+    index in its ``tmp_path``), a later test that builds a default
+    ``build_search_pipeline`` inherits the *foreign* index instead of one
+    scoped to its own ``FakePaths`` db. The stale index then queries the
+    polluter's now-deleted metadata SQLite, the vector leg silently
+    returns ``[]`` (``no such table: documents``), and the test is only
+    green by luck of its BM25 leg — or flips outright when the stale rows
+    contaminate the result set. Resetting on teardown (closing the
+    metadata connection first, via ``reset_vector_index_singleton``)
+    makes every test's vector-search state isolated, mirroring the
+    pattern established by ``_reset_embed_coalescer`` /
+    ``_reset_client_pool``. This is the missing sibling of those resets:
+    ``_VECTOR_INDEX`` was the one process-shared search singleton with no
+    autouse reset, so a populator with a missing/interrupted module-local
+    reset could leak its index into an unrelated later test.
+    """
+    yield
+    from kairix.core.search.vec_index import reset_vector_index_singleton
+
+    reset_vector_index_singleton()
+
+
+@pytest.fixture(autouse=True)
 def _reset_workstream_b_caches():
     """Drop the process-shared brief + prep + source caches between tests (#396 W-B).
 

--- a/tests/core/embed/test_embed_coalescer.py
+++ b/tests/core/embed/test_embed_coalescer.py
@@ -118,12 +118,15 @@ def test_single_caller_unblocks_within_bounded_window() -> None:
         out = coalescer.embed("only-one")
         elapsed_ms = (time.monotonic() - start) * 1000
         assert out, "single caller should get a non-empty result"
-        # Window=100ms → dispatch fires somewhere in [100, ~250]ms band.
-        # The upper bound is generous so a slow CI box doesn't flake.
-        # Sabotage: drop the window timeout and elapsed_ms goes to
-        # multiple seconds (or the test hangs).
+        # The load-bearing, host-immune proof is the FLOOR: the caller
+        # waited at least ~the window (so the dispatcher fired on the
+        # window timeout, not instantly), and it returned at all. F82
+        # (#493): the old ``< 1000`` ceiling was a flaky wall-clock bound;
+        # the "never wakes ⇒ blocks forever" sabotage is caught
+        # deterministically by the suite-level ``--timeout`` (the
+        # ``embed`` call hangs, pytest-timeout kills it) — not by an
+        # elapsed-time ceiling that measures host scheduling.
         assert elapsed_ms >= 80, f"expected to wait at least ~window_ms; got {elapsed_ms:.1f}ms"
-        assert elapsed_ms < 1000, f"single caller should not block for >1s; got {elapsed_ms:.1f}ms"
     finally:
         coalescer.shutdown()
 
@@ -310,15 +313,17 @@ def test_window_zero_dispatches_synchronously() -> None:
     """
     fake = _CountingBatchFn()
     coalescer = EmbedCoalescer(embed_batch_fn=fake, coalesce_window_ms=0, max_batch_size=16)
-    # No dispatcher thread should be running in window=0 mode.
+    # The deterministic, host-immune proof that window=0 dispatches
+    # synchronously is structural: NO dispatcher thread is started in
+    # window=0 mode, so ``embed`` cannot enqueue-and-wait — it must run
+    # the synchronous single-text path inline. F82 (#493): the old
+    # ``elapsed_ms < 50`` ceiling was a flaky wall-clock bound that added
+    # nothing over this structural assertion.
     assert coalescer._dispatcher is None
 
-    start = time.monotonic()
     out = coalescer.embed("hello")
-    elapsed_ms = (time.monotonic() - start) * 1000
     assert out, "window=0 should still return a result"
-    assert elapsed_ms < 50, f"window=0 should dispatch immediately; took {elapsed_ms:.1f}ms"
-    # Each call is its own batch in window=0 mode.
+    # Each call is its own batch in window=0 mode (synchronous path).
     assert len(fake.calls) == 1
     assert fake.calls[0] == ["hello"]
 
@@ -417,28 +422,55 @@ def test_max_batch_full_wakes_dispatcher_early() -> None:
     self._cv.notify()`` and the dispatcher waits the full window even
     when the batch is full — defeats the latency benefit at high
     concurrency.
+
+    F82 rewrite (#493): the old shape asserted ``elapsed_ms < 400``, a
+    wall-clock ceiling that flaked under concurrent-gate CPU contention
+    (the 3 worker threads can be scheduled late on a loaded host even
+    when the early-wake path fired correctly). The deterministic property
+    is liveness, not latency: with a window set FAR longer than any test
+    budget (10s), the ONLY way all three callers can unblock promptly is
+    the batch-full ``notify()`` — a full-window wait would block them for
+    the entire 10s. So we set the long window and assert every worker
+    thread *finishes* (its blocking ``embed`` returned) within a generous
+    2s liveness join — which is 5x the contended-scheduling slack but
+    still 5x shorter than the window, so it passes on any host when
+    early-wake works and HANGS (join times out, ``is_alive()`` stays
+    True) when the notify is removed. This is a liveness floor, not a
+    tight per-commit ceiling, and it is not an ``assert elapsed < const``
+    shape.
+
+    Sabotage-proof (executed): removed the batch-full ``self._cv.notify()``
+    in ``EmbedCoalescer.embed`` → the workers blocked on the 10s window,
+    the 2s join timed out, ``alive`` was non-empty and this test failed.
+    Restoring the notify restored green.
     """
     fake = _CountingBatchFn()
-    # Long window so the only way the dispatcher fires "fast" is the
-    # max-batch notify path.
-    coalescer = EmbedCoalescer(embed_batch_fn=fake, coalesce_window_ms=500, max_batch_size=3)
+    # Window FAR longer than the liveness join below, so a prompt return
+    # can ONLY come from the max-batch notify path — never the window
+    # timeout. (A full-window wait would block the workers for 10s.)
+    coalescer = EmbedCoalescer(embed_batch_fn=fake, coalesce_window_ms=10_000, max_batch_size=3)
     try:
         results: list[list[float]] = [[] for _ in range(3)]
 
         def worker(i: int) -> None:
             results[i] = coalescer.embed(f"text-{i}")
 
-        start = time.monotonic()
         threads = [threading.Thread(target=worker, args=(i,)) for i in range(3)]
         for t in threads:
             t.start()
+        # Liveness floor: every worker must UNBLOCK well inside the 10s
+        # window. 2s is huge slack for thread scheduling under load yet
+        # 5x shorter than the window — so this can only pass via the
+        # early batch-full wake, and times out (hangs) if it's removed.
         for t in threads:
-            t.join()
-        elapsed_ms = (time.monotonic() - start) * 1000
+            t.join(timeout=2.0)
+        alive = [i for i, t in enumerate(threads) if t.is_alive()]
 
-        # Sabotage: if we waited the full 500ms window the test takes
-        # >400ms; the early-wake path completes well under that.
-        assert elapsed_ms < 400, f"batch-full should fire before window; took {elapsed_ms:.1f}ms"
+        assert not alive, (
+            f"batch-full must wake the dispatcher early; workers {alive} were still blocked "
+            "on the coalesce window after 2s (notify path broken)"
+        )
+        # The batch-full path drains exactly the one full batch of 3.
         assert len(fake.calls) == 1
         assert len(fake.calls[0]) == 3
     finally:
@@ -539,13 +571,21 @@ def test_high_concurrency_no_exceptions_and_batches_below_naive() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_window_100ms_single_call_latency_is_in_band() -> None:
-    """With window=100ms, a single call's latency lands in ~100-300ms.
+def test_window_100ms_single_call_latency_floor_proves_window_applied() -> None:
+    """With window=100ms, a single call waits at least ~the window.
 
-    Sabotage: change ``self._window_s = max(0.0, coalesce_window_ms) / 1000.0``
-    to ``... / 100.0`` (off-by-10) and a 100ms window becomes 1s — the
-    upper bound fires. Or set window_s to 0 by accident and the lower
-    bound fires.
+    The deterministic, host-immune property is the FLOOR: a single caller
+    that never fills the batch must wait for the window timer, so its
+    latency is at least ~window_ms. That catches the
+    window-collapsed-to-zero sabotage (``self._window_s`` accidentally 0 →
+    the call returns in <10ms and the floor fires). F82 (#493): the old
+    companion ``< 500`` ceiling (meant to catch an off-by-10 window
+    inflation) was a wall-clock ceiling that measured host scheduling and
+    flaked under load; the window-applied property the suite actually
+    relies on is the floor, which is slow-host-immune — a contended host
+    only makes the caller wait *longer*, never shorter. The
+    never-wakes-at-all hang remains caught by the suite-level
+    ``--timeout``.
     """
     fake = _CountingBatchFn()
     coalescer = EmbedCoalescer(embed_batch_fn=fake, coalesce_window_ms=100, max_batch_size=16)
@@ -553,12 +593,9 @@ def test_window_100ms_single_call_latency_is_in_band() -> None:
         start = time.monotonic()
         coalescer.embed("solo")
         elapsed_ms = (time.monotonic() - start) * 1000
-        # Sabotage on the lower side: if window=0 the call returns
-        # in <10ms — the assertion fires.
+        # Floor only: if the window collapsed to 0 the call returns in
+        # <10ms and this fires. A loaded host can only push elapsed up.
         assert elapsed_ms >= 80, f"single call returned too fast: {elapsed_ms:.1f}ms"
-        # Upper bound generous for CI flakes; off-by-10 sabotage fires
-        # because elapsed jumps into the 800-1200ms range.
-        assert elapsed_ms < 500, f"single call too slow: {elapsed_ms:.1f}ms"
     finally:
         coalescer.shutdown()
 


### PR DESCRIPTION
Follow-up to the #504 orphan-probe fix: resolves the four residual recurring test flakes. Each was root-caused with systematic debugging (reproduce → root-cause → structural fix → N×-stable verify → executed sabotage-proof), not papered over with a sleep/retry.

## 1. `tests/bdd/test_entity_summary_indexing.py` — un-reset vector-index singleton (#504-sibling)

- **Root cause:** `kairix.core.search.vec_index._VECTOR_INDEX` is a process-global singleton with **no autouse reset** between tests — the one process-shared search singleton missing from the `_reset_embed_coalescer` / `_reset_client_pool` family. Once a test populates it, `get_vector_index()` returns that **foreign** instance regardless of `db_path`, so a later default `build_search_pipeline` queries the polluter's index instead of one scoped to its own `FakePaths` db.
- **Reproduction:** populator (an index whose metadata resolves an `entity://` path matching the `[0.1]*1536` query vector) → the off-case BDD scenario asserting *no* `entity://` row → `expected no hit with prefix 'entity://'; got ['entity://Q42']`.
- **Fix:** added autouse `_reset_vector_index_singleton` to `tests/conftest.py`, mirroring the existing singleton-reset fixtures (closes the meta conn, drops the global). Defense-in-depth for the whole suite, not just BDD.
- **Sabotage-proof (executed):** neutered the reset → off-case fails with the contamination above; restored → green.

## 4. `test_detection_budget_under_100ms_when_mcp_down` (#493) — F82 wall-clock ceiling

- **Root cause:** real `HttpMcpDispatchClient` network probe + `assert elapsed_ms < 150.0` measures host scheduling; trips under concurrent-gate load.
- **Fix (F82):** rewrote to assert the **deterministic outcome** — the real probe returns `False` (fall-through) for an unreachable endpoint. The timeout-wiring leg the old test claimed to cover is already proven deterministically by `test_detection_probe_respects_timeout_budget` (asserts the bounded `timeout_s` is passed through). Also rewrote the sibling `test_dispatcher_does_not_block_caller_beyond_probe_budget` (was `assert elapsed < 0.150`) to assert exactly-one-probe / zero-tool-call fall-through. Removed `tests/cli/test_route_via_mcp.py` from the F82 baseline.
- **Sabotage-proofs (executed):** `is_responsive`→`return True` fails arm 1; an added reconnect re-probe fails arm 2.

## 3. `test_max_batch_full_wakes_dispatcher_early` — F82 wall-clock ceiling

- **Reproduction:** 2/12 failures under CPU contention (`assert elapsed_ms < 400`).
- **Fix (F82):** set the coalesce window to 10s and assert a **liveness floor** — every worker thread unblocks within a generous 2s join (only possible via the batch-full `notify()`; a full-window wait blocks them the entire 10s). Not an `assert elapsed < const` shape. Also paid down the file's three other wall-clock ceilings (kept the host-immune floors / structural assertions, dropped the flaky ceilings). Removed `tests/core/embed/test_embed_coalescer.py` from the F82 baseline.
- **Sabotage-proof (executed):** removed the batch-full notify → workers `[0,1,2]` blocked past 2s, test fails; restored → green. 0/12 under the same load that gave 2/12.

## 2. `test_staged_selection.py::test_file_local_f26_forbidden_import_caught` — whole-tree exit-code sensitivity

- **Root cause:** the clean-arm asserted the **aggregate** `exit_code == 0` of the full ~40-rule staged dispatch; unrelated whole-tree rules (F23/F50/F92/…) tripping on stray tree debris flip that code even when the probe's own change is F26-clean (flaked 3× on a pin bump).
- **Fix:** scope the assertions to **F26's own ledger verdict** (ran + failed on the forbidden import; ran + not-failed on the clean probe). Still drives the real `_dispatch_staged` end-to-end, now immune to unrelated whole-tree state.
- **Robustness-proof (executed):** with a README-less debris dir in the tree, F23 fails and the aggregate exit code goes to 1 — the OLD `code2 == 0` assertion would have flaked; the NEW F26-scoped assertion passes.

All four reproduced and fixed. Full `safe-commit.sh` green (10124 passed, 95.77% coverage, arch fitness + sonar ratchet clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)