### PR TITLE
fix(ci): unblock main — skip 3.12-only fitness suites on 3.10/3.11 + alpha corpus asset

### DIFF
--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -101,6 +101,27 @@ jobs:
           git tag -a "$TAG" -m "kairix alpha $TAG"
           git push origin "$TAG"
 
+      - name: Build reference-library corpus tarball (#450)
+        # The reference-library corpus is NOT bundled in the wheel
+        # (mixed-license, ~50 MB). `kairix benchmark install-corpus` fetches
+        # it from this per-release asset, sha256-verified fail-closed. The
+        # asset name matches the URL template in
+        # kairix/quality/benchmark/corpus.py (reference-library-v{version}.tar.gz,
+        # where the alpha tag is v{version}). Mirrors release.yml so an alpha is
+        # benchmark-provable, not just the stable release.
+        env:
+          DATE_VERSION: ${{ inputs.date_version }}
+          ALPHA_N: ${{ inputs.alpha_n }}
+        run: |
+          TAG="v${DATE_VERSION}a${ALPHA_N}"
+          tarball="reference-library-${TAG}.tar.gz"
+          tar czf "$tarball" reference-library/
+          sha256sum "$tarball" | awk '{print $1}' > "${tarball}.sha256"
+          echo "::group::Corpus asset"
+          ls -lh "$tarball" "${tarball}.sha256"
+          cat "${tarball}.sha256"
+          echo "::endgroup::"
+
       - name: Create GitHub pre-release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -108,11 +129,15 @@ jobs:
           ALPHA_N: ${{ inputs.alpha_n }}
         run: |
           TAG="v${DATE_VERSION}a${ALPHA_N}"
+          # Attach the corpus tarball + sha256 sidecar (#450) so
+          # `kairix benchmark install-corpus` can fetch + verify them on the alpha.
           gh release create "$TAG" \
               --title "kairix $TAG (alpha)" \
               --notes "Alpha pre-release for validation. Do not use in production." \
               --prerelease \
-              --verify-tag
+              --verify-tag \
+              "reference-library-${TAG}.tar.gz" \
+              "reference-library-${TAG}.tar.gz.sha256"
 
       - name: Fan out to docker-publish + publish-pypi + vm-deploy (alpha mode)
         # All three downstream workflows are triggered explicitly because

--- a/tests/architecture/conftest.py
+++ b/tests/architecture/conftest.py
@@ -1,0 +1,18 @@
+"""Skip the architecture suite when the 3.12-only ``tc_fitness`` engine is absent.
+
+``three-cubes-fitness`` (the shared fitness engine, EPIC #499) is pinned
+``python_version >= '3.12'`` in ``pyproject.toml`` — on the 3.10/3.11 CI legs it
+is deliberately not installed, so the tests in this directory (which import
+``tc_fitness`` at collection time, directly or via ``scripts/checks``) cannot be
+collected there. They assert code *structure* (CI fan-in parity, prod/test import
+boundaries), which is Python-version-independent and runs in full on the 3.12 leg,
+so skipping their collection on 3.10/3.11 loses no coverage — it just stops the
+``ModuleNotFoundError: No module named 'tc_fitness'`` from erroring the whole
+Stage-2 leg. See the ``three-cubes-fitness ... python_version >= '3.12'`` marker
+in pyproject.toml.
+"""
+
+import importlib.util
+
+# tc_fitness absent (3.10/3.11) → ignore this directory's test collection.
+collect_ignore_glob = ["*"] if importlib.util.find_spec("tc_fitness") is None else []

--- a/tests/checks/conftest.py
+++ b/tests/checks/conftest.py
@@ -1,0 +1,18 @@
+"""Skip the fitness-rule suite when the 3.12-only ``tc_fitness`` engine is absent.
+
+``three-cubes-fitness`` (the shared fitness engine, EPIC #499) is pinned
+``python_version >= '3.12'`` in ``pyproject.toml`` — on the 3.10/3.11 CI legs it
+is deliberately not installed, so the tests in this directory (which import
+``tc_fitness`` at collection time, directly or via ``scripts/checks``) cannot be
+collected there. They assert code *structure* (rule catalogue, layering, check
+wiring), which is Python-version-independent and runs in full on the 3.12 leg, so
+skipping their collection on 3.10/3.11 loses no coverage — it just stops the
+``ModuleNotFoundError: No module named 'tc_fitness'`` from erroring the whole
+Stage-2 leg. See the ``three-cubes-fitness ... python_version >= '3.12'`` marker
+in pyproject.toml.
+"""
+
+import importlib.util
+
+# tc_fitness absent (3.10/3.11) → ignore this directory's test collection.
+collect_ignore_glob = ["*"] if importlib.util.find_spec("tc_fitness") is None else []


### PR DESCRIPTION
## Why

`main`'s CI gate has been **red since 80a64c99 (2026-06-15)** — predates the fresh-install GA push. `three-cubes-fitness` (the shared fitness engine, EPIC #499) is pinned `python_version >= '3.12'` (pyproject.toml:204), but the push-to-main matrix runs 3.10/3.11/3.12 and `tests/checks/` + `tests/architecture/` import `tc_fitness` at collection → 3.10/3.11 error with `ModuleNotFoundError` → CI gate red. This blocks **all** alpha cuts (the release gate requires a green CI-gate on main HEAD).

## Fix
- `tests/checks/conftest.py` + `tests/architecture/conftest.py`: `collect_ignore_glob = ["*"]` guarded by `importlib.util.find_spec("tc_fitness")` — on 3.10/3.11 (engine absent) these **version-independent architecture/fitness suites** skip collection cleanly; on 3.12 they run in full (no coverage loss — they assert code *structure*, not runtime behaviour).
- `release-alpha.yml`: attach the `reference-library-v{version}.tar.gz` + sha256 corpus asset (mirrors release.yml) so `kairix benchmark install-corpus` (#450) is provable on an alpha.

## Verification
Confirmed locally (3.12): both dirs still collect with `tc_fitness` present; `collect_ignore_glob` flips to `["*"]` when absent. The 3.10/3.11 green is validated by this PR's CI / the post-merge main push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)