### PR TITLE
fix(wizard): a11y labels on tour/source templates — clear SonarCloud new-code gate (unblock alpha)

### DIFF
--- a/kairix/platform/setup/web/templates/setup/source.html
+++ b/kairix/platform/setup/web/templates/setup/source.html
@@ -8,14 +8,14 @@
 <div class="kx-provider-grid">
   {% for option in options %}
   {% if option.oauth %}
-  <a class="kx-provider-card" href="/setup/source/connect?provider={{ option.key }}">
+  <a class="kx-provider-card" aria-label="Connect {{ option.label }}" href="/setup/source/connect?provider={{ option.key }}">
     <div class="kx-provider-body">
       <strong>{{ option.label }}</strong>
       <div class="kx-provider-meta"><span>{{ option.description }}</span></div>
     </div>
   </a>
   {% else %}
-  <a class="kx-provider-card" href="/setup/folder">
+  <a class="kx-provider-card" aria-label="Use a local folder for {{ option.label }}" href="/setup/folder">
     <div class="kx-provider-body">
       <strong>{{ option.label }}</strong>
       <div class="kx-provider-meta"><span>{{ option.description }}</span></div>

--- a/kairix/platform/setup/web/templates/setup/tour.html
+++ b/kairix/platform/setup/web/templates/setup/tour.html
@@ -21,7 +21,7 @@
   <form hx-post="/setup/search" hx-target="#tour-search-result" hx-swap="innerHTML"
         hx-indicator="#tour-search-indicator">
     <div class="kx-search-row">
-      <input type="text" name="query" value="What are the main topics in my documents?" class="kx-search-input">
+      <input type="text" aria-label="Search query" name="query" value="What are the main topics in my documents?" class="kx-search-input">
       <button type="submit" class="kx-btn-outline">Run it</button>
     </div>
   </form>
@@ -39,7 +39,7 @@
   <form hx-post="/setup/tour/prep" hx-target="#tour-prep-result" hx-swap="innerHTML"
         hx-indicator="#tour-prep-indicator">
     <div class="kx-search-row">
-      <input type="text" name="query" value="What do my documents say about current projects?" class="kx-search-input">
+      <input type="text" aria-label="Context-pack topic" name="query" value="What do my documents say about current projects?" class="kx-search-input">
       <button type="submit" class="kx-btn-outline">Run it</button>
     </div>
   </form>
@@ -58,7 +58,7 @@
   <form hx-post="/setup/tour/remember" hx-target="#tour-remember-result" hx-swap="innerHTML"
         hx-indicator="#tour-remember-indicator">
     <div class="kx-search-row">
-      <input type="text" name="content" class="kx-search-input"
+      <input type="text" aria-label="Memory to save" name="content" class="kx-search-input"
              value="Setup finished today — this knowledge store is live and agents can connect.">
       <button type="submit" class="kx-btn-outline">Run it</button>
     </div>
@@ -95,7 +95,7 @@
   <form hx-post="/setup/tour/timeline" hx-target="#tour-timeline-result" hx-swap="innerHTML"
         hx-indicator="#tour-timeline-indicator">
     <div class="kx-search-row">
-      <input type="text" name="query" value="What changed in the last week?" class="kx-search-input">
+      <input type="text" aria-label="Timeline query" name="query" value="What changed in the last week?" class="kx-search-input">
       <button type="submit" class="kx-btn-outline">Run it</button>
     </div>
   </form>


### PR DESCRIPTION
## Why
SonarCloud-on-main's quality gate fails (`new_reliability_rating=C`, `new_code_smells=1`) on **pre-existing tranche-3 template a11y issues** that a drifted new-code baseline counts as 'new' — which makes the main run conclusion 'failure' and blocks the alpha release-gate (it keys off run=success). Not from the GA push (main CI gate itself is green).

## Fix (real a11y bugs, no visual change)
- `tour.html`: `aria-label` on the 4 sample-query inputs (Web:InputWithoutLabelCheck — the reliability bug).
- `source.html`: distinct `aria-label`s on the oauth-connect vs local-folder cards so the same-text/different-target links get distinct accessible names (Web:LinksIdenticalTextsDifferentTargetsCheck — the code smell).

Clears both gate conditions → main run goes green → unblocks the v2026.x alpha.

Separately tracked: reset the SonarCloud new-code baseline (root cause of the drift) + make the alpha release-gate key off the CI-gate check rather than the run conclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)