### PR TITLE
feat(release): skip_vm_deploy input on release-alpha.yml (cut alpha without Customer-Zero deploy)

### DIFF
--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -23,6 +23,11 @@ on:
         required: false
         default: '1'
         type: string
+      skip_vm_deploy:
+        description: 'Skip the Customer-Zero VM auto-deploy (for fresh-VM / manual verification of the alpha)'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write   # required to create tags + pre-releases
@@ -152,11 +157,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           DATE_VERSION: ${{ inputs.date_version }}
           ALPHA_N: ${{ inputs.alpha_n }}
+          SKIP_VM_DEPLOY: ${{ inputs.skip_vm_deploy }}
         run: |
           TAG="v${DATE_VERSION}a${ALPHA_N}"
           gh workflow run docker-publish.yml --ref main -f ref="$TAG" -f is_alpha=true
           gh workflow run publish-pypi.yml   --ref main -f ref="$TAG" -f is_alpha=true
-          gh workflow run release-vm-deploy.yml --ref main -f tag="$TAG"
+          if [ "$SKIP_VM_DEPLOY" = "true" ]; then
+            echo "skip_vm_deploy=true — NOT dispatching release-vm-deploy.yml (the Customer-Zero webhook); deploy the alpha manually for verification."
+          else
+            gh workflow run release-vm-deploy.yml --ref main -f tag="$TAG"
+          fi
 
       - name: Summary
         env:


### PR DESCRIPTION
Adds an opt-in `skip_vm_deploy` workflow_dispatch input to `release-alpha.yml`. When true, the alpha tags + publishes the image/wheel + attaches the corpus asset, but **does not** dispatch `release-vm-deploy.yml` (the Customer-Zero webhook). Lets us cut v2026.6.16a1 for a **fresh-VM verification** without touching the live dogfood instance (shape host). Default false — normal alphas are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)