### PR TITLE
Follow-ups: wizard out-of-box (cutover) + release-gate #548 + SonarCloud baseline #547

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -748,6 +748,14 @@ jobs:
   # sonar-per-file*.json) deterministically — no live leak period, no skip
   # flag (the KAIRIX_SKIP_SONAR_PARITY escape hatch was retired in #499
   # Phase 2). It is not gated through this job's pass/fail.
+  #
+  # New Code definition = PREVIOUS_VERSION (#547). The server-side "New
+  # Code" window for main is set to "Previous version" (a one-time API
+  # action; tooling at scripts/sonar/reset_new_code.py via the
+  # 5b · SonarCloud new-code baseline reset workflow). This scan emits
+  # `sonar.projectVersion` (below) so each release bumps the version and
+  # rolls the leak period forward, instead of pre-existing debt drifting
+  # back into the "new code" set and failing the gate on old code.
   # TODO(#499): confirm gating intent — the job header comment below still
   # reads "branch protection should gate on this job"; reconcile that with the
   # current branch-protection contexts before promoting Sonar to a hard gate.
@@ -774,10 +782,40 @@ jobs:
           name: coverage-data
         continue-on-error: true  # artifact missing on path-filtered runs; Sonar still scans without it
 
+      - name: Derive project version for New Code boundary (#547)
+        id: ver
+        env:
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # The version boundary that drives PREVIOUS_VERSION new-code mode.
+          # setuptools-scm (the project's version source) resolves the nearest
+          # tag + dev distance; on a tagged commit it is the clean release. We
+          # fall back to `git describe` then the short SHA so the scan always
+          # has a non-empty version.
+          # F83: each capture is guarded with `|| VAR=""` so a transient
+          # resolver failure leaves the var empty (we fall through to the next
+          # source) rather than tripping errexit at the assignment (#483 class).
+          VERSION=""
+          VERSION="$(python3 -m setuptools_scm 2>/dev/null)" || VERSION=""
+          if [ -z "$VERSION" ]; then
+            VERSION="$(git describe --tags --always 2>/dev/null)" || VERSION=""
+          fi
+          if [ -z "$VERSION" ]; then
+            VERSION="${HEAD_SHA:0:12}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "sonar.projectVersion = $VERSION"
+
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          # PREVIOUS_VERSION new-code boundary (#547) — bumps per release so
+          # genuinely-old code drops out of the leak period.
+          args: >
+            -Dsonar.projectVersion=${{ steps.ver.outputs.version }}
 
   # ── Docker build verification ──────────────────────────────────────────────
   docker:

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -76,24 +76,77 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.sha }}
+          REPO: ${{ github.repository }}
         run: |
-          # Defers to scripts/ci/check_release_gate.py which mirrors
-          # ci.yml's paths-ignore exactly. Old strict-equality check
-          # failed every time a docs-only commit landed on main between
-          # the last code change and the alpha cut. The Python gate
-          # walks LAST_SUCCESS_SHA..HEAD and accepts the gap only if
-          # every commit there is docs-only. Regression-locked by
+          set -euo pipefail
+          # "Releasable == mergeable" (#548). The merge-blocking signal is
+          # the `CI gate` fan-in CHECK-RUN conclusion on HEAD, NOT the
+          # umbrella ci.yml RUN conclusion. An informational job (SonarCloud
+          # `# fan-in: informational`, Publish to PyPI) failing flips the
+          # whole-run conclusion to `failure` even when `CI gate` is green —
+          # keying off `gh run list --status=success` then mis-blocks a
+          # perfectly releasable HEAD. So:
+          #   (1) directly resolve HEAD's own `CI gate` check-run; if green,
+          #       pass --head-gate-conclusion success and the script short-
+          #       circuits to pass (common case: ci.yml ran on HEAD, CI gate
+          #       green, an advisory job red).
+          #   (2) if HEAD has no `CI gate` check-run (a pure docs-only commit
+          #       ci.yml's paths-ignore skipped), derive LAST_SUCCESS_SHA from
+          #       the newest main SHA whose `CI gate` check-run is success and
+          #       run the docs-only-gap walk. We do NOT use the run-conclusion
+          #       filter, since a run-failure SHA can still have a green CI gate.
+          # The network `gh api` calls stay HERE so check_release_gate.py stays
+          # a pure, fakeable-via-args function (F1/F2). Regression-locked by
           # tests/scripts/test_check_release_gate.py.
-          LAST_SUCCESS_SHA="$(gh run list \
+
+          # `first(... | select(.name=="CI gate")) | .conclusion` — most recent
+          # CI gate check-run by API ordering. If re-runs ever produce multiple
+          # CI gate check-runs on one SHA, prefer sorting by completed_at desc;
+          # only one exists per HEAD today.
+          # F83: capture guarded with `|| HEAD_GATE=""` so a transient gh/api
+          # failure leaves HEAD_GATE empty (falls through to the safe walk)
+          # instead of tripping errexit at the assignment (#483 class).
+          HEAD_GATE=""
+          HEAD_GATE="$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
+              --jq 'first(.check_runs[] | select(.name=="CI gate")) | .conclusion // ""')" \
+              || HEAD_GATE=""
+
+          if [ "$HEAD_GATE" = "success" ]; then
+            python3 scripts/ci/check_release_gate.py \
+                --head-sha "$HEAD_SHA" \
+                --last-success-sha "" \
+                --head-gate-conclusion success
+            exit 0
+          fi
+
+          # HEAD has no green CI gate check-run — find the newest main SHA whose
+          # `CI gate` check-run IS success and hand it to the docs-only-gap walk.
+          # F83: candidate capture guarded so an empty/failed listing leaves
+          # CANDIDATES empty rather than tripping errexit.
+          CANDIDATES=""
+          CANDIDATES="$(gh run list \
               --workflow=ci.yml \
               --branch=main \
-              --status=success \
-              --limit=1 \
+              --limit=30 \
               --json headSha \
-              --jq '.[0].headSha // empty')"
+              --jq '.[].headSha')" || CANDIDATES=""
+
+          LAST_SUCCESS_SHA=""
+          for sha in $CANDIDATES; do
+            CONCLUSION=""
+            CONCLUSION="$(gh api "repos/${REPO}/commits/${sha}/check-runs" \
+                --jq 'first(.check_runs[] | select(.name=="CI gate")) | .conclusion // ""')" \
+                || CONCLUSION=""
+            if [ "$CONCLUSION" = "success" ]; then
+              LAST_SUCCESS_SHA="$sha"
+              break
+            fi
+          done
+
           python3 scripts/ci/check_release_gate.py \
               --head-sha "$HEAD_SHA" \
-              --last-success-sha "$LAST_SUCCESS_SHA"
+              --last-success-sha "$LAST_SUCCESS_SHA" \
+              --head-gate-conclusion ""
 
       - name: Tag main HEAD
         env:

--- a/.github/workflows/sonar-new-code-reset.yml
+++ b/.github/workflows/sonar-new-code-reset.yml
@@ -1,0 +1,41 @@
+name: "5b · SonarCloud new-code baseline reset (manual)"
+
+# Workflow_dispatch-only. Resets SonarCloud's "New Code" period for the
+# main branch to PREVIOUS_VERSION (#547). The New Code window had drifted
+# so pre-existing code was counted as "new", failing the server-side
+# Quality Gate on accumulated debt and flipping the whole ci.yml run to
+# failure.
+#
+# This is a one-time, deliberate, shared-infra action — it is gated
+# behind a manual dispatch on purpose. Setting "Previous version" is a
+# Web-API-or-UI-only operation (NOT a scanner property), so the script
+# drives the API directly with the admin-scoped SONAR_TOKEN. Once reset,
+# the scan's `sonar.projectVersion` (emitted per release in ci.yml) rolls
+# the window forward automatically — no further manual resets needed.
+#
+# The script is idempotent: it prints the New Code period before and
+# after, so a re-run on an already-reset project is a no-op observation.
+
+on:
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  reset-new-code:
+    name: Reset New Code period for main to PREVIOUS_VERSION
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Reset SonarCloud New Code baseline
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: python3 scripts/sonar/reset_new_code.py

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -87,6 +87,21 @@ This starts two services:
 
 > **Port 8080 already in use?** If you're already running caddy, nginx, or another reverse proxy on host 8080, set `KAIRIX_HOST_PORT=8090` (or any unused port) in your `.env` before `docker compose up -d`. See [OPERATIONS §"Deploying behind a reverse proxy"](../operations/OPERATIONS.md#deploying-behind-a-reverse-proxy-caddy--nginx--cloudflared).
 
+### A4b. Set up in your browser (optional)
+
+Once the container is up, open the in-box setup wizard:
+
+```
+http://localhost:8080/setup
+```
+
+It walks you through picking a provider, adding your key, choosing a documents folder, and a first search — the same steps as the rest of this guide, in a browser. The wizard ships ready to use out of the box; no flag to flip.
+
+- **On the same machine** (localhost): no token needed.
+- **From another machine** (you opened the port to the network): you need the operator token. On first boot the container prints a one-time link to its logs (`docker compose logs kairix | grep setup`); follow that link. See the operator-token note in `.env.example` to pin your own token instead.
+
+Prefer a no-browser setup? Skip the wizard and run [`kairix setup`](#no-browser-setup-kairix-setup) on the command line — it drives the same steps headless.
+
 ### A5. Index your documents
 
 ```bash
@@ -186,6 +201,8 @@ kairix mcp serve --transport http --port 8080
 
 For long-running deployments use a systemd unit — see [`docs/operations/SHARED-HOSTS.md`](../operations/SHARED-HOSTS.md) for the unit-file pointer.
 
+Once `kairix mcp serve` is running, you can set up in your browser at `http://localhost:8080/setup` (use the port you passed to `--port`) — the same in-box wizard described in the Docker path. It's ready out of the box; same-machine access needs no token, remote access needs the operator token. Prefer the command line? See [No-browser setup](#no-browser-setup-kairix-setup) below.
+
 ### B4. Index your documents
 
 ```bash
@@ -200,6 +217,28 @@ kairix onboard check --json   # structured
 ```
 
 Same shape as the Docker path. The JSON envelope is the canonical signal for any healthcheck or CI gate.
+
+---
+
+## No-browser setup (`kairix setup`)
+
+Prefer the command line, or running somewhere with no browser (a headless server, an SSH session, a CI job)? `kairix setup` drives the same onboarding steps on the terminal — pick a provider, add your key, choose a documents folder — and writes your config. It works whether or not the web wizard is on.
+
+```bash
+# Docker
+docker compose exec -it kairix kairix setup
+
+# Pip
+kairix setup
+```
+
+For scripts and CI, add `--non-interactive` to skip every prompt and take the defaults:
+
+```bash
+kairix setup --non-interactive
+```
+
+Both write the same `kairix.config.yaml` the rest of this guide edits by hand. Run `kairix config validate` afterwards to confirm the result.
 
 ---
 
@@ -260,6 +299,7 @@ Run `kairix features status` to see the live registry. The current flags:
 | Observability | `pipeline_status_emit` | off | Write per-item per-stage status rows for `kairix worker inspect` |
 | Agent queue | `agent_query_queue` | off | Queue slow searches and carry results to the agent's next call |
 | CLI routing | `cli_routes_through_warm_mcp` | **on** | Text-mode CLI subcommands route through a warm MCP when one is responsive |
+| Onboarding | `setup_wizard_web` | **on** | Serve the in-box setup wizard at `/setup` (same-machine open is unauthenticated; remote needs the operator token) |
 
 To turn a connector on:
 

--- a/kairix.config.example.yaml
+++ b/kairix.config.example.yaml
@@ -171,6 +171,12 @@ retrieval:
 #
 #   # ── CLI routing (default-ON; set false to force the in-process path)
 #   cli_routes_through_warm_mcp: false
+#
+#   # ── Onboarding (default-ON; set false to NOT serve the /setup wizard).
+#   # The in-box web setup wizard serves at /setup out of the box. Same-machine
+#   # access is unauthenticated by design; remote access requires the operator
+#   # token. Set false to keep /setup unmounted (requests there 404).
+#   setup_wizard_web: false
 
 # ──────────────────────────────────────────────────────────────────────────
 # topology_v2 — connectors / collections / scope profiles / skills

--- a/kairix/agents/mcp/transport.py
+++ b/kairix/agents/mcp/transport.py
@@ -271,8 +271,11 @@ class ColdStartMiddleware:
 def _default_setup_wizard_enabled() -> bool:
     """Default reader for the ``setup_wizard_web`` feature flag.
 
-    Lazy-imported so MCP transport composition doesn't pay the feature
-    flag resolver import cost when the wizard stays OFF (the default).
+    The flag defaults ON (cutover) — the wizard is the out-of-the-box
+    onboarding surface — so an env-unset / config-unset install resolves
+    to True here and mounts ``/setup``. Lazy-imported so MCP transport
+    composition only pays the feature-flag resolver import cost when the
+    mount is actually being decided.
     """
     from kairix.core.features import flag
 

--- a/kairix/core/features/registry.py
+++ b/kairix/core/features/registry.py
@@ -337,22 +337,34 @@ REGISTRY: dict[str, FeatureFlag] = {
     ),
     "setup_wizard_web": FeatureFlag(
         name="setup_wizard_web",
-        # Default-OFF: merging the wizard is structurally a no-op — no
-        # /setup routes exist until an operator flips this ON, so the
-        # MCP server's HTTP surface is byte-for-byte unchanged.
-        default=False,
+        # Default-ON cutover: the wizard is now the out-of-the-box
+        # onboarding surface, so /setup is mounted on a default install
+        # (env-unset, config-unset). After the onboarding-UX work
+        # (#469-#481) and the fresh-install smoke proving GET /setup=200 +
+        # POST choreography + the #500 remote-access token, "wizard
+        # reachable" IS the validated behaviour — so default=True is the
+        # default-safe value post-validation (feature-flag-architecture
+        # §2.1), not a violation. Loopback peers reach it unauthenticated
+        # by design (the laptop-first install); non-loopback callers still
+        # need the X-Kairix-Operator-Token / kairix-infra-operator-token
+        # secret, so default-ON does NOT widen remote exposure. Operators
+        # opt OUT via KAIRIX_FEATURE_SETUP_WIZARD_WEB=false or
+        # `features: {setup_wizard_web: false}`. Cutover endgame mirrors
+        # cli_routes_through_warm_mcp: delete the gate, keep the mount
+        # unconditional once dogfood confirms no operator overrode it OFF.
+        default=True,
         description=(
-            "When ON, the MCP server also serves the in-box web setup "
-            "wizard at /setup (same container, same port): welcome → "
+            "When ON (default), the MCP server also serves the in-box web "
+            "setup wizard at /setup (same container, same port): welcome → "
             "provider → key → folder → indexing → capability tour → "
             "connect-agent → done, rendered server-side against the "
-            "SetupService boundary. When OFF (default), no /setup routes "
-            "are mounted and requests there 404 exactly as before the "
-            "wizard landed. Non-loopback requests additionally require "
-            "the X-Kairix-Operator-Token header matching the "
+            "SetupService boundary. When OFF, no /setup routes are mounted "
+            "and requests there 404 exactly as before the wizard landed. "
+            "Non-loopback requests additionally require the "
+            "X-Kairix-Operator-Token header matching the "
             "kairix-infra-operator-token secret."
         ),
-        stage="introduce",
+        stage="cutover",
         introduced_in="v2026.6.11",
         # SCM+6mo per the F51 retire-deadline rule, anchored to the
         # v2026.6.9 release the wizard lands on top of.

--- a/scripts/checks/check-fresh-install-smoke.sh
+++ b/scripts/checks/check-fresh-install-smoke.sh
@@ -9,8 +9,8 @@
 #   stage 1  container-healthy   /healthz/ready returns 200 (bounded wait)
 #   stage 2  mcp-handshake       POST initialize + tools/list to /mcp
 #                                returns more than zero tools
-#   stage 3  setup-wizard        with KAIRIX_FEATURE_SETUP_WIZARD_WEB=1,
-#                                GET /setup/ returns 200 (in-container
+#   stage 3  setup-wizard        out-of-the-box (setup_wizard_web defaults
+#                                ON), GET /setup/ returns 200 (in-container
 #                                loopback curl — the wizard's operator-token
 #                                guard intentionally skips loopback peers)
 #   stage 3b wizard-choreography POST /setup/folder/scan returns the HTMX
@@ -142,7 +142,9 @@ cp "${REPO_ROOT}/kairix.config.example.yaml" "${WORKDIR}/kairix.config.yaml"
     echo "# fresh-install smoke overrides"
     echo "KAIRIX_IMAGE_TAG=${IMAGE_TAG}"
     echo "KAIRIX_HOST_PORT=${HOST_PORT}"
-    echo "KAIRIX_FEATURE_SETUP_WIZARD_WEB=1"
+    # setup_wizard_web defaults ON (cutover) — no env override here, so the
+    # wizard stages below prove the OOTB default reaches /setup, not an
+    # env-forced enable. This guards against an accidental future default-revert.
     # #500 — pin a deterministic operator token so the browser-shaped stage
     # below can open the tokened URL without scraping the first-boot log.
     # (Unset, the container mints + prints one; pinning keeps the smoke
@@ -231,7 +233,7 @@ if [[ "$TOOL_COUNT" -lt 1 ]]; then
 fi
 echo "stage 2 mcp-handshake: OK (${TOOL_COUNT} tools)"
 
-# ── stage 3: setup wizard answers with the flag ON ───────────────────────────
+# ── stage 3: setup wizard answers out-of-the-box (default-ON) ─────────────────
 # In-container loopback curl: the wizard's operator-token guard skips
 # loopback peers by design (host-side requests arrive from the docker
 # bridge gateway and would need the kairix-infra-operator-token secret).
@@ -239,7 +241,7 @@ WIZARD_CODE=$(compose exec -T kairix curl -s -o /dev/null -w '%{http_code}' \
     "http://127.0.0.1:8080/setup/" || true)
 if [[ "$WIZARD_CODE" != "200" ]]; then
     fail_stage "setup-wizard" \
-        "GET /setup/ returned ${WIZARD_CODE} (expected 200) with KAIRIX_FEATURE_SETUP_WIZARD_WEB=1 — the in-box wizard is not reachable on a fresh install." \
+        "GET /setup/ returned ${WIZARD_CODE} (expected 200) on a default install (setup_wizard_web defaults ON) — the in-box wizard is not reachable out-of-the-box." \
         "reproduce: docker compose exec kairix curl -v http://127.0.0.1:8080/setup/"
 fi
 echo "stage 3 setup-wizard: OK (200)"

--- a/scripts/ci/check_release_gate.py
+++ b/scripts/ci/check_release_gate.py
@@ -7,11 +7,24 @@ cut, because ci.yml's ``paths-ignore`` skips docs commits — so
 LAST_SUCCESS_SHA never advances to a docs-only HEAD, and the strict-
 equality gate fails.
 
-The fix: the gate passes when **every commit since the last green
-ci.yml run is docs-only** (i.e., would have been skipped by ci.yml
-itself). HEAD == LAST_SUCCESS_SHA stays the happy path; HEAD ahead
-by docs-only commits is also green; HEAD ahead by even one code
-commit is still a fail (that's the real "untested code" case).
+"Releasable" means "mergeable" — the signal is the ``CI gate`` fan-in
+**check-run** conclusion on main HEAD, not the umbrella ci.yml *run*
+conclusion. An informational job (SonarCloud, Publish to PyPI, ...)
+failing flips the whole-run conclusion to ``failure`` even when the
+merge-blocking ``CI gate`` aggregator is green; keying off the run
+conclusion mis-blocks a perfectly releasable HEAD (#548). The workflow
+resolves HEAD's ``CI gate`` check-run conclusion and passes it in via
+``--head-gate-conclusion``; when it is ``success`` the gate short-
+circuits to pass immediately, before any git-walking.
+
+Fallback (docs-only-gap walk): when HEAD has no ``CI gate`` check-run
+at all — a pure docs-only commit ci.yml's ``paths-ignore`` skipped —
+``--head-gate-conclusion`` is empty and the gate instead checks that
+**every commit since the last commit whose ``CI gate`` check-run was
+green is docs-only** (i.e., would have been skipped by ci.yml itself).
+HEAD == LAST_SUCCESS_SHA stays the happy path; HEAD ahead by docs-only
+commits is also green; HEAD ahead by even one code commit is still a
+fail (that's the real "untested code" case).
 
 Mirrors ci.yml's paths-ignore exactly:
   - ``docs/**``
@@ -21,11 +34,14 @@ Mirrors ci.yml's paths-ignore exactly:
 Run from the workflow:
     python3 scripts/ci/check_release_gate.py \\
         --head-sha "$HEAD_SHA" \\
-        --last-success-sha "$LAST_SUCCESS_SHA"
+        --last-success-sha "$LAST_SUCCESS_SHA" \\
+        --head-gate-conclusion "$HEAD_GATE"
 
 Exit codes:
-  0 — gate passes (HEAD == last green, or only docs-only commits past it)
-  1 — gate fails (code commits past last green ci.yml run)
+  0 — gate passes (HEAD's CI gate check-run is green, HEAD == last
+      commit whose CI gate was green, or only docs-only commits past it)
+  1 — gate fails (code commits past the last commit whose CI gate
+      check-run was green)
   2 — usage / unrecoverable error
 """
 
@@ -99,12 +115,31 @@ def main() -> int:
     parser.add_argument(
         "--last-success-sha",
         required=True,
-        help="Most recent SHA where ci.yml ran green on main",
+        help="Most recent SHA whose `CI gate` check-run was green on main",
+    )
+    parser.add_argument(
+        "--head-gate-conclusion",
+        default="",
+        help=(
+            "HEAD's own `CI gate` check-run conclusion, resolved by the workflow "
+            "(e.g. 'success'). When 'success' the gate short-circuits to pass — "
+            "the mergeable signal overrides the git-walk. Empty/missing means HEAD "
+            "had no `CI gate` check-run (a docs-only commit ci.yml skipped), so the "
+            "docs-only-gap walk against --last-success-sha runs instead."
+        ),
     )
     args = parser.parse_args()
 
     head_sha = args.head_sha
     last_success_sha = args.last_success_sha
+
+    # #548: "releasable == mergeable". When the workflow has already resolved
+    # HEAD's own `CI gate` check-run to success, that IS the gate — short-
+    # circuit before any git-walking so an informational job (SonarCloud,
+    # Publish to PyPI) failing the umbrella run can't mis-block the release.
+    if args.head_gate_conclusion == "success":
+        print(f"CI gate check-run on HEAD ({head_sha}) is green — releasable")
+        return 0
 
     if not last_success_sha:
         print("::error::no successful CI gate run found on main", file=sys.stderr)

--- a/scripts/sonar/reset_new_code.py
+++ b/scripts/sonar/reset_new_code.py
@@ -1,0 +1,171 @@
+"""Reset SonarCloud's "New Code" period for the ``main`` branch.
+
+Why this exists (#547)
+----------------------
+SonarCloud's per-branch "New Code" definition drifts: pre-existing code
+that passed at the prior green analysis ends up inside the "new code"
+window, so the server-side Quality Gate fails main on accumulated debt
+(``new_reliability_rating``, ``new_code_smells``). Because
+``sonar.qualitygate.wait=true`` makes the in-CI scan exit WITH the gate
+verdict, that flips the whole ci.yml run to ``failure`` — which (until
+#548) blocked the alpha release-gate.
+
+The durable fix is a one-time reset of the New Code reference, then
+``type=PREVIOUS_VERSION`` mode so each release rolls the window forward
+(the scanner emits ``sonar.projectVersion`` per release; see ci.yml).
+Setting "Previous version" / "Specific analysis" / "Specific date" is a
+Web-API-or-UI-only action — it is NOT a scanner property — so this
+script drives the API directly, mirroring ``triage_hotspots.py``'s
+Bearer-token pattern so the decision is reviewable in git history rather
+than a hand-typed UI click.
+
+Usage (locally with an admin SONAR_TOKEN env var):
+    SONAR_TOKEN=xxxx python3 scripts/sonar/reset_new_code.py
+
+Usage (CI):
+    Triggered via .github/workflows/sonar-new-code-reset.yml
+    workflow_dispatch. The workflow reads SONAR_TOKEN from GH secrets.
+
+Idempotent: prints the New Code period before and after the set, so a
+re-run is a no-op observation when already on PREVIOUS_VERSION.
+
+References:
+- https://sonarcloud.io/web_api/api/new_code_periods
+- POST /api/new_code_periods/set — set a branch's New Code definition.
+- GET  /api/new_code_periods/show — read the current definition.
+
+Exit codes:
+  0 — reset applied (or already in the requested state)
+  1 — the API call failed (non-2xx) — fails closed, nothing was changed
+  2 — usage error (SONAR_TOKEN unset)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Protocol
+
+SONAR_BASE = "https://sonarcloud.io"
+PROJECT_KEY = "three-cubes_kairix"
+BRANCH = "main"
+# "Previous version" — the only New Code mode drivable purely by a scanner
+# property (sonar.projectVersion, emitted per release in ci.yml). Clean for
+# trunk-based single-main analysis; self-maintaining via release bumps.
+NEW_CODE_TYPE = "PREVIOUS_VERSION"
+
+
+class ApiCaller(Protocol):
+    """Transport seam: ``(method, path, **form_params) -> parsed JSON``.
+
+    Injected so the reset logic is exercised with a fake in tests (no
+    real network, no monkeypatch — F1/F2). The production default is
+    ``_default_caller`` below.
+    """
+
+    def __call__(self, method: str, path: str, **params: str) -> dict: ...
+
+
+def _default_caller(token: str) -> ApiCaller:
+    """Real SonarCloud transport — Bearer-token urllib POST/GET.
+
+    Mirrors ``scripts/sonar/triage_hotspots.py``'s ``_api`` helper.
+    Raises ``urllib.error.HTTPError`` on non-2xx; the caller fails closed.
+    """
+
+    def _call(method: str, path: str, **params: str) -> dict:
+        url = SONAR_BASE + path
+        body: bytes | None = None
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "kairix-sonar-reset/1.0",
+        }
+        if method == "GET" and params:
+            url = f"{url}?{urllib.parse.urlencode(params)}"
+        elif params:
+            body = urllib.parse.urlencode(params).encode("utf-8")
+            headers["Content-Type"] = "application/x-www-form-urlencoded"
+        req = urllib.request.Request(url, data=body, headers=headers, method=method)
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            raw = resp.read().decode("utf-8")
+        return json.loads(raw) if raw else {}
+
+    return _call
+
+
+def show_period(caller: ApiCaller) -> dict:
+    """Return the current New Code period for ``BRANCH`` (GET /show)."""
+    return caller(
+        "GET",
+        "/api/new_code_periods/show",
+        project=PROJECT_KEY,
+        branch=BRANCH,
+    )
+
+
+def set_period(caller: ApiCaller) -> None:
+    """Set the New Code period for ``BRANCH`` to ``NEW_CODE_TYPE`` (POST /set).
+
+    The /set endpoint returns an empty 204 body on success.
+    """
+    caller(
+        "POST",
+        "/api/new_code_periods/set",
+        project=PROJECT_KEY,
+        branch=BRANCH,
+        type=NEW_CODE_TYPE,
+    )
+
+
+def reset_new_code(caller: ApiCaller) -> int:
+    """Read → set → read the New Code period. Fails closed on any HTTP error.
+
+    Returns the process exit code (0 ok, 1 API failure).
+    """
+    try:
+        before = show_period(caller)
+        print(f"before: {json.dumps(before, sort_keys=True)}")
+        set_period(caller)
+        print(f"set: project={PROJECT_KEY} branch={BRANCH} type={NEW_CODE_TYPE}")
+        after = show_period(caller)
+        print(f"after: {json.dumps(after, sort_keys=True)}")
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")[:200]
+        print(
+            f"::error::SonarCloud new-code reset failed — HTTP {exc.code} {exc.reason}: {detail}",
+            file=sys.stderr,
+        )
+        print(
+            "::error::fix: confirm SONAR_TOKEN has Administer permission on the project; "
+            "next: re-run the workflow once the token scope is corrected",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+def main(caller: ApiCaller | None = None, token: str | None = None) -> int:
+    """Run the reset.
+
+    ``caller`` injects the transport (a fake in tests, F1/F2-clean). When
+    omitted, the real ``_default_caller`` is built from ``token`` — which
+    itself defaults to the ``SONAR_TOKEN`` env var at the boundary. Tests
+    drive the missing-token branch by passing ``token=""`` explicitly, so
+    no process-env mutation is needed.
+    """
+    if caller is None:
+        if token is None:
+            token = os.environ.get("SONAR_TOKEN", "")
+        if not token:
+            print("ERROR: SONAR_TOKEN env var not set", file=sys.stderr)
+            return 2
+        caller = _default_caller(token)
+    return reset_new_code(caller)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/test_feature_flag_setup_wizard_web.py
+++ b/tests/integration/test_feature_flag_setup_wizard_web.py
@@ -5,10 +5,14 @@ Composes the real ASGI app via
 OFF and ON through ``FakeFeatureFlagResolver`` (the canonical F54
 pattern). Asserts:
 
-* **OFF (default)** — no ``/setup`` routes exist (404); the MCP
+* **OFF (seam-injected)** — no ``/setup`` routes exist (404); the MCP
   transport + health surfaces are byte-for-byte the pre-flag shape.
 * **ON** — the wizard serves the full journey surface; the MCP
   transport + health surfaces are unchanged alongside it.
+
+The flag now defaults ON (cutover), so the OFF branch sets the flag
+off explicitly through the seam rather than leaning on the default;
+``test_registry_default_is_on_cutover_stage`` pins the cutover itself.
 
 F1/F2-clean: flag state comes from the resolver fake through the
 ``setup_wizard_enabled`` seam — no env vars, no REGISTRY mutation.
@@ -47,7 +51,27 @@ def _compose(resolver: FakeFeatureFlagResolver, service: FakeSetupService) -> Te
     return TestClient(app, client=_LOOPBACK)
 
 
+def test_registry_default_is_on_cutover_stage() -> None:
+    """Pin the cutover: the wizard ships reachable out-of-the-box.
+
+    A default install (env-unset, config-unset) resolves the registry
+    default, so default=True is what makes GET /setup=200 on a fresh
+    Docker/pip boot. stage="cutover" records that this is a deliberate,
+    validated default-flip — not the introduce-stage default-OFF the
+    wizard landed under. Sabotage-proof for the flip: reverting either
+    field turns this red.
+    """
+    from kairix.core.features.registry import REGISTRY
+
+    entry = REGISTRY["setup_wizard_web"]
+    assert entry.default is True
+    assert entry.stage == "cutover"
+
+
 def test_off_branch_mounts_no_setup_routes() -> None:
+    # default-ON now, so the OFF branch must set the flag off explicitly
+    # (don't lean on the registry default) — the seam injection keeps
+    # F54's OFF-branch (404) coverage valid post-cutover.
     resolver = FakeFeatureFlagResolver().with_flag("setup_wizard_web", False)
     client = _compose(resolver, FakeSetupService())
 

--- a/tests/platform/setup/test_setup_wizard_web_routes.py
+++ b/tests/platform/setup/test_setup_wizard_web_routes.py
@@ -93,11 +93,17 @@ def test_flag_off_means_no_setup_routes() -> None:
     assert client.get("/mcp").status_code == 200
 
 
-def test_flag_default_reader_keeps_wizard_off() -> None:
-    """No ``setup_wizard_enabled`` seam → the registry default (OFF) wins."""
+def test_flag_default_reader_mounts_wizard_out_of_box() -> None:
+    """No ``setup_wizard_enabled`` seam, no env/overlay → the production
+    default reader resolves the registry default (now ON, cutover) and
+    mounts ``/setup``, so a fresh install reaches the wizard out of the box.
+
+    Sabotage-proof for the cutover: reverting the registry default back to
+    False turns this 200 into a 404.
+    """
     app = build_mcp_app(FakeMcpTransportServer())
     client = TestClient(app, client=_LOOPBACK)
-    assert client.get("/setup", follow_redirects=True).status_code == 404
+    assert client.get("/setup", follow_redirects=True).status_code == 200
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scripts/test_check_release_gate.py
+++ b/tests/scripts/test_check_release_gate.py
@@ -54,9 +54,23 @@ def _commit(repo: Path, files: dict[str, str], message: str) -> str:
     return _git(repo, "rev-parse", "HEAD")
 
 
-def _run_gate(repo: Path, head_sha: str, last_success_sha: str) -> subprocess.CompletedProcess[str]:
+def _run_gate(
+    repo: Path,
+    head_sha: str,
+    last_success_sha: str,
+    head_gate_conclusion: str = "",
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        [sys.executable, str(SCRIPT), "--head-sha", head_sha, "--last-success-sha", last_success_sha],
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--head-sha",
+            head_sha,
+            "--last-success-sha",
+            last_success_sha,
+            "--head-gate-conclusion",
+            head_gate_conclusion,
+        ],
         cwd=repo,
         capture_output=True,
         text=True,
@@ -96,6 +110,43 @@ def test_gate_fails_when_code_commit_is_past_last_success(tmp_path: Path) -> Non
     bad = _commit(repo, {"src/y.py": "print(2)\n"}, "code: untested change")
 
     result = _run_gate(repo, bad, last_green)
+    assert result.returncode == 1
+    assert "untested code commits" in result.stderr
+    assert bad[:8] in result.stderr
+
+
+def test_gate_passes_when_head_gate_conclusion_is_success(tmp_path: Path) -> None:
+    """#548 regression lock: when HEAD's own `CI gate` check-run is green
+    (the workflow passes --head-gate-conclusion success), the gate must
+    short-circuit to pass EVEN IF a code commit sits past last_success.
+
+    This is the exact defect #548 fixes: keying off the umbrella ci.yml
+    RUN conclusion mis-blocked a HEAD whose `CI gate` was green but whose
+    run was red because of an informational job (SonarCloud, Publish to
+    PyPI). The check-run signal must override the git-walk."""
+    repo = _init_repo(tmp_path)
+    last_green = _commit(repo, {"src/x.py": "print()\n"}, "initial code")
+    # A CODE commit past last_success — the fallback git-walk would REJECT
+    # this. The green check-run signal must override that.
+    bad = _commit(repo, {"src/y.py": "print(2)\n"}, "code: real change with green CI gate")
+
+    result = _run_gate(repo, bad, last_green, head_gate_conclusion="success")
+    assert result.returncode == 0, f"stdout={result.stdout} stderr={result.stderr}"
+    assert "CI gate check-run on HEAD" in result.stdout
+    assert "releasable" in result.stdout
+
+
+def test_gate_falls_through_to_docs_walk_when_head_gate_empty(tmp_path: Path) -> None:
+    """When HEAD has no `CI gate` check-run (empty --head-gate-conclusion,
+    e.g. a docs-only commit ci.yml skipped), the gate must fall through to
+    the existing docs-only-gap walk — a code commit past last_success
+    still fails. Proves the #548 short-circuit did not regress the
+    fallback semantics."""
+    repo = _init_repo(tmp_path)
+    last_green = _commit(repo, {"src/x.py": "print()\n"}, "initial code")
+    bad = _commit(repo, {"src/y.py": "print(2)\n"}, "code: untested change")
+
+    result = _run_gate(repo, bad, last_green, head_gate_conclusion="")
     assert result.returncode == 1
     assert "untested code commits" in result.stderr
     assert bad[:8] in result.stderr

--- a/tests/scripts/test_reset_new_code.py
+++ b/tests/scripts/test_reset_new_code.py
@@ -1,0 +1,133 @@
+"""Outcome tests for ``scripts/sonar/reset_new_code.py`` (#547).
+
+The script POSTs to SonarCloud's ``/api/new_code_periods/set`` to reset
+the drifted New Code window for ``main``. These tests inject a FAKE
+``ApiCaller`` transport (no real network, no monkeypatch — F1/F2) and
+assert: (a) it reads → sets → reads with the right endpoints + params,
+and (b) it fails CLOSED (exit 1) on a non-2xx API response without
+having silently "succeeded".
+
+The module lives outside the ``kairix`` package, so it is loaded by
+path like the other ``scripts/`` outcome tests.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import urllib.error
+from pathlib import Path
+
+import pytest
+
+# Load the reset module directly — it lives outside the kairix package.
+_SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "sonar" / "reset_new_code.py"
+_spec = importlib.util.spec_from_file_location("_reset_new_code", _SCRIPT_PATH)
+assert _spec is not None and _spec.loader is not None
+_reset = importlib.util.module_from_spec(_spec)
+sys.modules["_reset_new_code"] = _reset
+_spec.loader.exec_module(_reset)
+
+
+pytestmark = pytest.mark.unit
+
+
+class _RecordingCaller:
+    """Fake ApiCaller — records every (method, path, params) call and
+    returns canned JSON. Optionally raises a given exception on the first
+    call to simulate an API failure."""
+
+    def __init__(self, *, raise_on_first: Exception | None = None) -> None:
+        self.calls: list[tuple[str, str, dict[str, str]]] = []
+        self._raise_on_first = raise_on_first
+        self._fired = False
+
+    def __call__(self, method: str, path: str, **params: str) -> dict:
+        self.calls.append((method, path, dict(params)))
+        if self._raise_on_first and not self._fired:
+            self._fired = True
+            raise self._raise_on_first
+        return {"newCodePeriod": {"type": "PREVIOUS_VERSION"}}
+
+
+def _http_error(code: int) -> urllib.error.HTTPError:
+    import io
+
+    return urllib.error.HTTPError(
+        url="https://sonarcloud.io/api/new_code_periods/set",
+        code=code,
+        msg="Forbidden",
+        hdrs=None,  # type: ignore[arg-type]  # urllib accepts None hdrs; not read in the fail path
+        fp=io.BytesIO(b"Insufficient privileges"),
+    )
+
+
+def test_reset_posts_set_endpoint_with_correct_params() -> None:
+    caller = _RecordingCaller()
+    rc = _reset.main(caller=caller)
+
+    assert rc == 0
+    # The POST /set is the load-bearing call — endpoint + params must be exact.
+    posts = [c for c in caller.calls if c[0] == "POST"]
+    assert len(posts) == 1, f"expected exactly one POST, got {caller.calls}"
+    _method, path, params = posts[0]
+    assert path == "/api/new_code_periods/set"
+    assert params == {
+        "project": "three-cubes_kairix",
+        "branch": "main",
+        "type": "PREVIOUS_VERSION",
+    }
+
+
+def test_reset_reads_period_before_and_after_set() -> None:
+    caller = _RecordingCaller()
+    rc = _reset.main(caller=caller)
+
+    assert rc == 0
+    # show → set → show ordering proves the script observes the change.
+    methods_paths = [(c[0], c[1]) for c in caller.calls]
+    assert methods_paths == [
+        ("GET", "/api/new_code_periods/show"),
+        ("POST", "/api/new_code_periods/set"),
+        ("GET", "/api/new_code_periods/show"),
+    ]
+
+
+def test_reset_fails_closed_on_non_2xx() -> None:
+    """A 403 (token lacks Administer permission) must fail CLOSED — exit 1,
+    not a silent success. The HTTPError surfaces on the very first GET so
+    the POST never fires (nothing is half-applied)."""
+    caller = _RecordingCaller(raise_on_first=_http_error(403))
+    rc = _reset.main(caller=caller)
+
+    assert rc == 1
+    # Only the first GET was attempted; no POST went out.
+    assert [c[0] for c in caller.calls] == ["GET"]
+
+
+def test_reset_fails_closed_when_set_itself_errors() -> None:
+    """If the POST /set is the call that 4xx's, the script must still fail
+    closed (exit 1) rather than reporting the reset as applied."""
+
+    class _SetFails(_RecordingCaller):
+        def __call__(self, method: str, path: str, **params: str) -> dict:
+            self.calls.append((method, path, dict(params)))
+            if method == "POST":
+                raise _http_error(400)
+            return {"newCodePeriod": {"type": "PREVIOUS_VERSION"}}
+
+    caller = _SetFails()
+    rc = _reset.main(caller=caller)
+
+    assert rc == 1
+    # The set was attempted; the trailing "after" read never ran.
+    assert [c[0] for c in caller.calls] == ["GET", "POST"]
+
+
+def test_main_returns_2_when_token_unset() -> None:
+    """No caller injected + an empty token → usage error (exit 2). The
+    empty token is passed explicitly through the ``token=`` seam, so the
+    missing-credential branch is exercised WITHOUT mutating process env
+    (F1/F2-clean — no monkeypatch on the boundary)."""
+    rc = _reset.main(token="")
+    assert rc == 2


### PR DESCRIPTION
## Follow-up resolutions (post fresh-install GA / alpha)

Three resolutions from the alpha-verification review, in disjoint file sets.

### 1. Wizard reachable out-of-box (cutover)
`setup_wizard_web` flag **default → True**, `stage="cutover"`. A fresh Docker/pip install now serves `/setup` without the operator setting `KAIRIX_FEATURE_SETUP_WIZARD_WEB`. Loopback is unauthenticated by design; remote still requires the operator-token grant (the #500 guard), so default-ON doesn't widen exposure. Opt out via `KAIRIX_FEATURE_SETUP_WIZARD_WEB=false` or `features: {setup_wizard_web: false}`. F54 both-branch tests stay green (OFF branch now seam-injected). Quick-start documents the browser route **and** `kairix setup` (the no-browser CLI onboarding, which already existed).

### 2. #548 — release-gate keys off the `CI gate` check-run
`check_release_gate.py` gains `--head-gate-conclusion`; `release-alpha.yml` queries HEAD's `CI gate` check-run and short-circuits when green — so an **informational** job (SonarCloud, etc.) failing the umbrella run no longer blocks a release. The docs-only-gap walk is preserved byte-for-byte as the fallback. Regression-locked by a new test.

### 3. #547 — scriptable SonarCloud new-code baseline reset
`scripts/sonar/reset_new_code.py` (POST `new_code_periods/set`, `PREVIOUS_VERSION`, via the admin-scoped `SONAR_TOKEN`) + `sonar.projectVersion` in the CI scan + a `workflow_dispatch` workflow. **The live reset is NOT run here** — it's a manual, HITL-authorized dispatch. Tooling + tests only.

Closes #548, #547. (#550 — example-config divergence — filed separately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
