### PR TITLE
fix(release): install tc_fitness deps before F49/KFEAT-018 release gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,19 @@ jobs:
             exit 1
           fi
 
+      # The F49 baseline check imports the shared three-cubes-fitness
+      # package (tc_fitness, [dev] group) via _rule_catalogue.py. Since
+      # EPIC #499 (2026-06-16) moved the catalogue schema into tc_fitness,
+      # running these scripts under the bare system interpreter crashes
+      # with ModuleNotFoundError (the bash wrapper masks it as a false
+      # "baselines did not shrink"). Sync the venv via the org-shared
+      # composite, then run the checks under it — mirrors the Stage 0
+      # arch-fitness job in ci.yml.
+      - uses: three-cubes/ci-workflows/actions/setup-uv-cached@main
+        with:
+          python-version: "3.12"
+          sync-args: "--all-extras --all-groups"
+
       - name: F49 — baselines shrink per release
         # Each release must reduce the F30/F46/F47 test-discipline
         # baselines by at least one entry vs the previous release
@@ -136,7 +149,7 @@ jobs:
         # docs/architecture/test-discipline-hardening.md §3 (F49).
         # Runs only here, not per-commit — baselines don't change
         # between commits within a release window.
-        run: bash scripts/checks/check-baseline-shrinking.sh
+        run: uv run bash scripts/checks/check-baseline-shrinking.sh
 
       - name: KFEAT-018 — paydown doc snapshot currency
         # The State table in docs/architecture/grandfathering-paydown.md
@@ -145,7 +158,7 @@ jobs:
         # extension comment with rationale). Mirrors the F49 invocation
         # above: release-time only, not per-commit.
         # See docs/features/KFEAT-018-paydown-doc-refresh/BRIEF.md.
-        run: python3 scripts/checks/check_paydown_doc_currency.py
+        run: uv run python3 scripts/checks/check_paydown_doc_currency.py
 
       - name: Extract release notes from CHANGELOG
 


### PR DESCRIPTION
## Problem

The `v2026.6.18` stable release ([failed run 27731723505](https://github.com/three-cubes/kairix/actions/runs/27731723505)) crashed at the **F49 — baselines shrink** step:

```
ModuleNotFoundError: No module named 'tc_fitness'
```

The `release` job runs `check-baseline-shrinking.sh` (F49) and `check_paydown_doc_currency.py` (KFEAT-018) but only does `actions/checkout` — **no venv / deps setup**. Since **EPIC #499** (2026-06-16) moved the catalogue schema into the shared `tc_fitness` package, `_rule_catalogue.py` now imports it, so F49 crashes under the bare system interpreter. `check-baseline-shrinking.sh` then masks the crash as a misleading `F49: baselines did not shrink`.

`v2026.6.18` is the **first stable release cut since #499**, so the gap surfaced now — the release job was still configured against the pre-#499 (self-contained catalogue) layout.

## Fix

Mirror the **Stage 0 arch-fitness** job in `ci.yml`: add the org-shared `setup-uv-cached` composite (python 3.12, `--all-extras --all-groups`), then run the two release-time checks via `uv run`.

## Verification

Locally, with no activated venv (CI condition):
- `python3 check_baseline_shrinking.py` → `ModuleNotFoundError` (reproduces the failure)
- `uv run bash scripts/checks/check-baseline-shrinking.sh` → `F49: all governed baselines shrunk (or stayed at zero). OK`
- `uv run python3 scripts/checks/check_paydown_doc_currency.py` → `within 7-day window. OK`

Both release-time gates (F49, KFEAT-018) and the alpha-gate were independently confirmed green before this PR, so once it merges, re-dispatching `release.yml` should complete the `v2026.6.18` cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)