### PR TITLE
fix(eval): repair the retrieval measurement loop (#554 per-config caches + #552 deployment db-path)

### DIFF
--- a/kairix/core/factory.py
+++ b/kairix/core/factory.py
@@ -53,10 +53,15 @@ _PIPELINE_CACHE: dict[RetrievalConfig, SearchPipeline] = {}
 _PIPELINE_CACHE_LOCK = threading.Lock()
 
 
-# Process-shared QueryResultCache (#281). One instance per process,
-# wired into every SearchPipeline constructed by build_search_pipeline.
-# Lazy-initialised so the env-var bounds are read once at first use.
-_QUERY_CACHE: QueryResultCache | None = None
+# Per-config QueryResultCache instances, keyed by the resolved
+# RetrievalConfig's cfg_hash (#281, #554). A single shared instance
+# returned config #1's cached results for every other config evaluated
+# in the same process — the hybrid-sweep "identical scores for every
+# config" bug (#554). Keying by cfg_hash gives each config its own cache
+# (exactly one in production, N during a sweep) and matches the on-disk
+# cache schema, which is already cfg_hash-scoped. Lazy-initialised so the
+# env-var bounds are read once per cfg_hash at first use.
+_QUERY_CACHES: dict[str, QueryResultCache] = {}
 _QUERY_CACHE_LOCK = threading.Lock()
 
 
@@ -73,8 +78,8 @@ def reset_search_pipeline_cache() -> None:
     with _PIPELINE_CACHE_LOCK:
         _PIPELINE_CACHE.clear()
     with _QUERY_CACHE_LOCK:
-        if _QUERY_CACHE is not None:
-            _QUERY_CACHE.clear()
+        for cache in _QUERY_CACHES.values():
+            cache.clear()
 
 
 def _lookup_cached_pipeline(cfg: RetrievalConfig, flag_reader: Any) -> SearchPipeline | None:
@@ -147,7 +152,12 @@ def _resolve_query_cache_path() -> Any:
 
 
 def _get_or_create_query_cache(cfg_hash: str = "") -> QueryResultCache:
-    """Return the process-shared :class:`QueryResultCache`, building it lazily.
+    """Return the :class:`QueryResultCache` for ``cfg_hash``, building it lazily.
+
+    One cache instance per distinct ``cfg_hash`` (#554) — production runs
+    a single config so it has one cache; a hybrid-sweep evaluates many
+    configs in one process and each gets its own cache, so config #1's
+    cached results never collide with config #2's.
 
     Bounds are read from env vars on first construction (#281):
       - ``KAIRIX_QUERY_CACHE_MAX_ENTRIES`` (int, default 500)
@@ -155,38 +165,38 @@ def _get_or_create_query_cache(cfg_hash: str = "") -> QueryResultCache:
 
     F4-clean: env reads route through :mod:`kairix.paths`.
 
-    ``cfg_hash`` scopes the persistent cache rows to the current
-    pipeline configuration (#411 Phase 2). Passing the empty string
-    keeps the cache cfg-scope-disabled — rows persist under the empty
-    bucket. Production callers thread the resolved cfg_hash through
-    so a config change invalidates persisted entries automatically.
+    ``cfg_hash`` also scopes the persistent cache rows to the pipeline
+    configuration (#411 Phase 2) — matching the in-memory keying above.
     """
-    global _QUERY_CACHE
     with _QUERY_CACHE_LOCK:
-        if _QUERY_CACHE is None:
+        cache = _QUERY_CACHES.get(cfg_hash)
+        if cache is None:
             from kairix.paths import read_float_env, read_int_env
 
             max_entries = read_int_env("KAIRIX_QUERY_CACHE_MAX_ENTRIES", default=DEFAULT_MAX_ENTRIES)
             max_age_s = read_float_env("KAIRIX_QUERY_CACHE_MAX_AGE_S", default=DEFAULT_MAX_AGE_S)
             path = _resolve_query_cache_path()
-            _QUERY_CACHE = QueryResultCache(
+            cache = QueryResultCache(
                 max_entries=max_entries,
                 max_age_s=max_age_s,
                 path=path,
                 cfg_hash=cfg_hash,
             )
-        return _QUERY_CACHE
+            _QUERY_CACHES[cfg_hash] = cache
+        return cache
 
 
 def get_query_cache() -> QueryResultCache:
-    """Return the process-shared query cache (lazily built on first call).
+    """Return the query cache for the production retrieval config.
 
     Public accessor for the onboard check + any other diagnostic that
-    wants to read :meth:`QueryResultCache.stats`. Going through this
-    helper keeps the module-global hidden so callers can't accidentally
-    rebind ``_QUERY_CACHE``.
+    wants to read :meth:`QueryResultCache.stats`. Resolves the top-level
+    production ``RetrievalConfig`` and returns its cfg_hash-scoped cache —
+    the same instance the production pipeline uses — so the stats reflect
+    real hit rates rather than an empty default bucket (#554).
     """
-    return _get_or_create_query_cache()
+    cfg = _resolve_retrieval_config(None)
+    return _get_or_create_query_cache(_compute_cfg_hash(cfg))
 
 
 def select_boosts(

--- a/kairix/quality/eval/cli.py
+++ b/kairix/quality/eval/cli.py
@@ -13,7 +13,7 @@ Usage:
   kairix eval enrich --suite suites/v2-real-world.yaml --output suites/v2-enriched.yaml
   kairix eval monitor --suite suites/canary.yaml
   kairix eval report --days 30
-  kairix eval chunk-stats --db-path ~/.cache/kairix/index.sqlite
+  kairix eval chunk-stats   # resolves the deployment's index automatically
 """
 
 from __future__ import annotations
@@ -22,10 +22,28 @@ import argparse
 import sys
 from pathlib import Path
 
-_DEFAULT_DB_PATH = str(Path.home() / ".cache/kairix/index.sqlite")
 _DEFAULT_DEPLOYMENT = "gpt-4o-mini"
 _DEFAULT_AGENT = "shape"
 _AGENT_HELP = "Agent for retrieval scoping (default: shape)"
+_DB_HELP = "kairix SQLite index path (default: the deployment's index, e.g. /var/lib/kairix/index.sqlite)"
+
+
+def _resolve_db_path(explicit: str | None) -> str:
+    """Resolve the eval index path (#552).
+
+    Returns the explicit ``--db`` value when given; otherwise the
+    deployment's canonical index via :func:`kairix.paths.index_path`
+    (``/var/lib/kairix/index.sqlite`` on a system/container install, the
+    XDG data dir on a user install) — never a hardcoded ``~/.cache``
+    path that only exists on a dev laptop, so ``kairix eval`` works
+    out-of-the-box on a standard docker/system deployment.
+    """
+    if explicit:
+        return explicit
+    from kairix.paths import index_path
+
+    return str(index_path())
+
 
 # F17 — argparse action keyword repeated across boolean-flag declarations; one
 # constant keeps the well-known sentinel in a single edit site.
@@ -45,7 +63,7 @@ def _cmd_generate(args: argparse.Namespace) -> int:
     # FakeXxx fakes.
     suite_gen = SuiteGenerator()
     result = suite_gen.generate_suite(
-        db_path=args.db,
+        db_path=_resolve_db_path(args.db),
         output_path=args.output,
         n_cases=args.count,
         categories=args.categories.split(",") if args.categories else None,
@@ -88,7 +106,7 @@ def _cmd_enrich(args: argparse.Namespace) -> int:
     result = suite_gen.enrich_suite(
         suite_path=args.suite,
         output_path=args.output,
-        db_path=args.db,
+        db_path=_resolve_db_path(args.db),
         deployment=args.deployment,
         agent=args.agent,
     )
@@ -447,7 +465,7 @@ def _cmd_chunk_stats(args: argparse.Namespace) -> int:
     """
     from kairix.quality.eval.chunk_stats import emit_chunk_stats
 
-    db_path = Path(args.db_path).expanduser()
+    db_path = Path(_resolve_db_path(args.db_path)).expanduser()
     return emit_chunk_stats(db_path, sys.stdout)
 
 
@@ -503,13 +521,13 @@ def main(argv: list[str] | None = None) -> None:
     p_gen.add_argument("--categories", help="Comma-separated categories (default: all)")
     p_gen.add_argument(
         "--db",
-        default=_DEFAULT_DB_PATH,
-        help="kairix SQLite path (default: ~/.cache/kairix/index.sqlite)",
+        default=None,
+        help=_DB_HELP,
     )
     p_gen.add_argument(
         "--deployment",
         default=_DEFAULT_DEPLOYMENT,
-        help="Azure deployment (default: gpt-4o-mini)",
+        help="Azure deployment name override; ignored when the configured provider resolves its own model",
     )
     p_gen.add_argument("--no-calibrate", action=_STORE_TRUE, help="Skip calibration anchor check")
     p_gen.add_argument("--seed", type=int, default=None, help="Random seed for reproducibility")
@@ -521,13 +539,13 @@ def main(argv: list[str] | None = None) -> None:
     p_enr.add_argument("--output", required=True, help="Output suite YAML path")
     p_enr.add_argument(
         "--db",
-        default=_DEFAULT_DB_PATH,
-        help="kairix SQLite path",
+        default=None,
+        help=_DB_HELP,
     )
     p_enr.add_argument(
         "--deployment",
         default=_DEFAULT_DEPLOYMENT,
-        help="Azure deployment (default: gpt-4o-mini)",
+        help="Azure deployment name override; ignored when the configured provider resolves its own model",
     )
     p_enr.add_argument("--agent", default=_DEFAULT_AGENT, help=_AGENT_HELP)
 
@@ -618,8 +636,8 @@ def main(argv: list[str] | None = None) -> None:
     )
     p_chunk.add_argument(
         "--db-path",
-        default=_DEFAULT_DB_PATH,
-        help="kairix SQLite path (default: ~/.cache/kairix/index.sqlite)",
+        default=None,
+        help=_DB_HELP,
     )
 
     # --- sweep ---

--- a/kairix/use_cases/prep.py
+++ b/kairix/use_cases/prep.py
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 
 # Process-shared PrepSummaryCache. Lazy-initialised on first prep call
 # so the env-var bounds (if any) are read once at startup. Mirrors the
-# ``_QUERY_CACHE`` pattern in ``kairix.core.factory`` so the operator
+# ``_QUERY_CACHES`` pattern in ``kairix.core.factory`` so the operator
 # surface (``probe caches``) sees both caches via the same accessor
 # pattern.
 _PREP_SUMMARY_CACHE: PrepSummaryCache | None = None

--- a/tests/eval/test_cli_unit.py
+++ b/tests/eval/test_cli_unit.py
@@ -124,6 +124,32 @@ def test_generate_no_calibrate_flag_bypasses_calibration_check(monkeypatch, tmp_
     assert code == 0
 
 
+def test_generate_db_path_defaults_to_deployment_index(monkeypatch, tmp_path: Path) -> None:
+    """No --db -> generate_suite gets the deployment's index, not ~/.cache (#552).
+
+    Pre-fix the CLI defaulted --db to ~/.cache/kairix/index.sqlite, so on a
+    standard docker/system install (index at /var/lib/kairix/index.sqlite) every
+    invocation needed a manual --db override. The handler now resolves via
+    kairix.paths.index_path() — the same mode-aware path the worker writes.
+
+    Sabotage-proven: reverting the db-path resolver to the hardcoded ~/.cache
+    string makes the captured db_path != str(index_path()) and fails the first assert.
+    """
+    import kairix.quality.eval.generate as gen_mod
+    from kairix.paths import index_path
+
+    fake_gen = _FakeSuiteGenerator(generate_result=_gen_result())
+    monkeypatch.setattr(gen_mod, "SuiteGenerator", lambda: fake_gen)
+
+    # No --db -> the deployment's canonical index for the current mode.
+    _drive(["generate", "--output", str(tmp_path / "o.yaml")])
+    assert fake_gen.generate_calls[-1]["db_path"] == str(index_path())
+
+    # An explicit --db is respected verbatim.
+    _drive(["generate", "--output", str(tmp_path / "o2.yaml"), "--db", "/custom/index.sqlite"])
+    assert fake_gen.generate_calls[-1]["db_path"] == "/custom/index.sqlite"
+
+
 # ---------------------------------------------------------------------------
 # enrich
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_query_cache_per_config.py
+++ b/tests/integration/test_query_cache_per_config.py
@@ -1,0 +1,92 @@
+"""#554 regression: each retrieval config gets its own QueryResultCache.
+
+Pre-fix: ``build_search_pipeline`` wired every config to a single
+process-shared ``_QUERY_CACHE`` singleton. The in-memory cache key omits
+the ``RetrievalConfig`` (``make_cache_key`` keys on query/scope/agent/
+collections only), so config #1's cached result for query ``Q`` was
+returned for config #2's identical ``Q`` — the ``hybrid-sweep`` "byte-
+identical scores for every config" bug. In the sweep, config #1 ran
+(~159s); configs #2..N returned cached results in ~0.1s and could never
+recommend a config change.
+
+Post-fix: ``_get_or_create_query_cache`` keys caches by ``cfg_hash``, so
+two materially different configs receive two different
+``QueryResultCache`` instances and never share results. Production runs a
+single config and therefore still has exactly one cache.
+
+Sabotage proof (executed during development): reverting ``factory.py`` to
+the singleton (``_QUERY_CACHE``) makes both configs wire the same cache
+instance, so the first assertion (``pa.query_cache is not pb.query_cache``)
+fails.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from kairix.core.db.schema import create_schema
+from kairix.core.factory import build_search_pipeline, reset_search_pipeline_cache
+from kairix.core.search.config import RetrievalConfig
+from tests.fakes import FakePaths, FakeProvider, FakeProviderRegistry
+
+pytestmark = pytest.mark.integration
+
+
+def _bootstrap_db(db_path: Path) -> None:
+    """Create an empty schema + one active doc so the factory build path is happy."""
+    db = sqlite3.connect(str(db_path))
+    create_schema(db)
+    now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    db.execute(
+        "INSERT OR REPLACE INTO documents "
+        "(collection, path, hash, source_name, source_uri, source_modified_at, "
+        "sensitivity, created_at, modified_at, active) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1)",
+        ("default", "seed.md", "seed-hash", "seed.md", "src://default/seed.md", now, "internal", now, now),
+    )
+    db.commit()
+    db.close()
+
+
+def test_distinct_configs_get_distinct_query_caches(tmp_path: Path) -> None:
+    """Two materially different retrieval configs must not share a query cache (#554)."""
+    db_path = tmp_path / "index.sqlite"
+    _bootstrap_db(db_path)
+    paths = FakePaths(
+        document_root=tmp_path / "vault",
+        db_path=db_path,
+        log_dir=tmp_path / "logs",
+        workspace_root=tmp_path / "workspaces",
+    )
+    registry = FakeProviderRegistry(
+        {"fake": FakeProvider(name="fake", vector=[0.1] * 1536, dim=1536)},
+    )
+    reset_search_pipeline_cache()
+
+    # Two configs that differ (different cfg_hash) — the shape a sweep evaluates.
+    cfg_a = RetrievalConfig(provider="fake", rrf_k=60)
+    cfg_b = RetrievalConfig(provider="fake", rrf_k=20)
+    assert cfg_a != cfg_b, "test precondition: the two configs must differ"
+
+    pa = build_search_pipeline(config=cfg_a, registry=registry, paths=paths)
+    pb = build_search_pipeline(config=cfg_b, registry=registry, paths=paths)
+
+    # The #554 fix: distinct configs resolve to distinct cache instances, so
+    # config A's cached results can never be served to config B (the bug).
+    assert pa.query_cache is not pb.query_cache, (
+        "distinct retrieval configs shared one QueryResultCache — config #1's "
+        "results would leak into config #2 (the hybrid-sweep #554 bug). "
+        "fix: _get_or_create_query_cache must key caches by cfg_hash."
+    )
+
+    # Same config → same cache instance (config-stable, so production keeps one).
+    pa2 = build_search_pipeline(config=cfg_a, registry=registry, paths=paths)
+    assert pa.query_cache is pa2.query_cache, (
+        "the same config resolved to two different query caches — cfg_hash keying broken."
+    )
+
+    reset_search_pipeline_cache()

--- a/uv.lock
+++ b/uv.lock
@@ -1477,7 +1477,7 @@ requires-dist = [
     { name = "bandit", extras = ["toml"], marker = "extra == 'dev'", specifier = ">=1.7" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.34,<2" },
     { name = "caldav", marker = "extra == 'caldav'", specifier = ">=1.3,<4" },
-    { name = "cryptography", marker = "extra == 'connect'", specifier = ">=43,<49" },
+    { name = "cryptography", marker = "extra == 'connect'", specifier = ">=43,<50" },
     { name = "detect-secrets", marker = "extra == 'dev'", specifier = ">=1.4" },
     { name = "google-auth", marker = "extra == 'connect'", specifier = ">=2.40,<3" },
     { name = "google-auth-oauthlib", marker = "extra == 'connect'", specifier = ">=1.2,<2" },
@@ -1506,7 +1506,7 @@ requires-dist = [
     { name = "python-pptx", marker = "extra == 'pptx'", specifier = ">=1.0,<2" },
     { name = "pyyaml", specifier = ">=6.0,<7" },
     { name = "requests", specifier = ">=2.33.1,<3" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.16" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.17" },
     { name = "sentence-transformers", marker = "extra == 'rerank'", specifier = ">=3.0,<6" },
     { name = "spacy", marker = "extra == 'nlp'", specifier = ">=3.7,<4" },
     { name = "tenacity", specifier = ">=8,<10" },
@@ -4357,27 +4357,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.16"
+version = "0.15.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a6/bd/5f7ec371001337d8fa61701c186ff8b613ecac1651848c5950f4c4d5f2e9/ruff-0.15.16.tar.gz", hash = "sha256:d05e78d38c78caf020b03789e25106c93017db5a0cb6e2819885018c61343b78", size = 4714267, upload-time = "2026-06-04T16:33:09.974Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/a9/3abdf488f1bf3d24c699415e454ed554a6350d5d89ce183be1ee0a3361ac/ruff-0.15.17.tar.gz", hash = "sha256:2ec446937fd16c8c4de2674a209cc5af64d9c6f17d21fbf1151054fa0bcf5219", size = 4743346, upload-time = "2026-06-11T17:54:47.663Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/42/53ef1c3953f157956db9bf7861e3bc50b9b887ce93300aa48cdba8336fe6/ruff-0.15.16-py3-none-linux_armv6l.whl", hash = "sha256:6ac3c0b3969cc6cf6b158c4e2f8f682acb58e7d700d8a44b65ecdc72d66ab0b2", size = 10709025, upload-time = "2026-06-04T16:32:51.935Z" },
-    { url = "https://files.pythonhosted.org/packages/93/9a/a79159346f19134a956607754e57d8d128f7a4c00f4ad2f7514d224c172c/ruff-0.15.16-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:197c207ed75ffba54a0dec23db4aa939a27a3053073e085e0042433cbdc58e4a", size = 11063550, upload-time = "2026-06-04T16:32:42.24Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/72/3ce2ac000a5299ec238e01f51397b3b653c93b077d9b1bfe8715bb895f20/ruff-0.15.16-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3a39fec45ab316cc23e7558f23fea4a70403ddb5648ea9a4a3854a16973d0071", size = 10421345, upload-time = "2026-06-04T16:32:37.251Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/c2/cc7fad3ec9169373f5b6a18f1917b91080feec40c3f9658334a1d28e2f03/ruff-0.15.16-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba93191d79003116b95128c9d306e045200fdbd0bccb782b110f3cd1d4abc5cf", size = 10757217, upload-time = "2026-06-04T16:32:54.722Z" },
-    { url = "https://files.pythonhosted.org/packages/69/d2/3474009eaa0a65b31fa7152a2fad5e2f050c640ceb1e6b02ee6922e94c82/ruff-0.15.16-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c6ee4b90520630120ef032aa5cc10db483852dff950e78b1d717e2993a61ac8d", size = 10507035, upload-time = "2026-06-04T16:33:05.343Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/81/b7ae6ccbd11f0c8dc3d5d67fc4be9b57ff57ca86ba56152021378e1277f2/ruff-0.15.16-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4e4215bc938bc3c8215c1472c1aa437e310fee20cd427335fec9d7e609563628", size = 11255291, upload-time = "2026-06-04T16:32:49.49Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/e1/46e526f1a7cc90857ce6ddf25fbb77eb6568651ac38d71b033af07076dd5/ruff-0.15.16-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c8d26be963b090f10e29abc8b3e74a2a321f6fa34e02424e30b5af89350ecbb", size = 12124922, upload-time = "2026-06-04T16:33:07.821Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/da/5c791b088b596b24d0deb967fa28ae02ad751a140c0b9ea81c5ab915d6c0/ruff-0.15.16-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f198cf4123602a2280ed46c307bcbafe41758d6fee5b456b6b6058ca1514b3b4", size = 11332186, upload-time = "2026-06-04T16:33:02.971Z" },
-    { url = "https://files.pythonhosted.org/packages/72/11/5da87abe20047c8962361473923ebb2f62b595250126aadfad8c20649c1e/ruff-0.15.16-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb27515fa6240fb586ae82b901a59e67d24acff86f2190b433dc542fe0435aeb", size = 11373541, upload-time = "2026-06-04T16:32:47.007Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/2a/8554754c23a854ae3fd6b507e36ad61ddb121e298c6d5d617dec94ed0f14/ruff-0.15.16-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a267c46ba1593fc26b8eecbea050b39d40c0b6bb7781ee11c90a02cd10032951", size = 11353014, upload-time = "2026-06-04T16:32:34.795Z" },
-    { url = "https://files.pythonhosted.org/packages/62/25/62ea41529ec89f742ea3fed9cb1059c72877ec7cf9b9e99ac9cf3294d1d9/ruff-0.15.16-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:528c68f39a91498a8d50e91ff5985df3d105782bab49cc378e73ac26bff083e8", size = 10737467, upload-time = "2026-06-04T16:32:26.348Z" },
-    { url = "https://files.pythonhosted.org/packages/90/17/334d3ad9de4d40f9dd58fdd09e35ce64553bb501e2f19a839e2fb6be14fc/ruff-0.15.16-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7ed55c58950df60589a9a7a5d2f8fa5f54ebd287163be805adfe6ee95a9de123", size = 10521910, upload-time = "2026-06-04T16:32:32.54Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/bd/3ac7c6ae77a885c1004b3dda2446ea401768d24f851c14b4ad4b24f6639c/ruff-0.15.16-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d482feaf51512b50f9790ceb417a56a61dd1e9d9bf967662b9ed27c01b34f53a", size = 10979190, upload-time = "2026-06-04T16:32:57.492Z" },
-    { url = "https://files.pythonhosted.org/packages/33/d7/609546e6a413c3f216fbf2a50c928f97c80939154f6a0503114094a86191/ruff-0.15.16-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1e15bc8c94513dae2a40cc9ef07c94fdd4ecc9e29dabebeebe170f952322c9e3", size = 11477014, upload-time = "2026-06-04T16:32:44.687Z" },
-    { url = "https://files.pythonhosted.org/packages/74/0d/f2cd247ad32633a5c36e97141a2c21b11c6279f7957bc2ff360b1e08fddd/ruff-0.15.16-py3-none-win32.whl", hash = "sha256:580378f7bd4aa25f72e74aa54948a9622f142b1e509521dd10902e886681cc1e", size = 10735541, upload-time = "2026-06-04T16:32:30.145Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/9e/02e845ef151b1dee585e55c4739f8e1734ae1d9f1221dff65761c162208b/ruff-0.15.16-py3-none-win_amd64.whl", hash = "sha256:408256017284eddf98fff77b29aa4fb30f586042d535b2d9befc6512f400aaec", size = 11843403, upload-time = "2026-06-04T16:32:39.76Z" },
-    { url = "https://files.pythonhosted.org/packages/15/19/016553f86f207450aebebc2b2b5088d086b901cc8186c02ac4284db3bd88/ruff-0.15.16-py3-none-win_arm64.whl", hash = "sha256:8cd61783afb39638a7133ef0d2dfb1e91277593962f81b5a8423eb0b888a6121", size = 11134555, upload-time = "2026-06-04T16:33:00.136Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4d/e11259f5da07cb6afb2d074c31bf09da9671993f7329d4f15d2fdc458301/ruff-0.15.17-py3-none-linux_armv6l.whl", hash = "sha256:d9feddb927fc68bd295f5eebc587a7e42cfaf9b65f60ca4a2386febff575da8f", size = 10856677, upload-time = "2026-06-11T17:54:49.533Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3e/772d679e1a0dc058e58875bd2c0cb713a0530877b4a76fee3c7966df0d49/ruff-0.15.17-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:25805a226d741c47d274a35ad5c10a7dde175fcddfa511d7cf3da0a21eb3eab7", size = 11223443, upload-time = "2026-06-11T17:55:00.573Z" },
+    { url = "https://files.pythonhosted.org/packages/68/58/bd41f7688b2fd5623012605130ed70e60aa7f2244baa3d5066bdd61530c8/ruff-0.15.17-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f6ad73b14c2d18a3bf8ad7cb6974294d7f613a7898604826058e6ac64918ef4d", size = 10566458, upload-time = "2026-06-11T17:55:07.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5b/733371013fcf1ec339e477ece6ab42bfe10bdd9bba8ee88a9516aa56bfc0/ruff-0.15.17-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ba0c1e4f95bcb3869d0d30cbd5917071ef2e28665abfec970cdab0492c713ed", size = 10914483, upload-time = "2026-06-11T17:55:05.501Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/cc/6f24251cc0252f7239391ccb85833f320efad14ebe5b443943f37ced6332/ruff-0.15.17-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:81647960f10bff57d2e51cadd0c3950fe598400c852863a038720ef5b8cca91e", size = 10647497, upload-time = "2026-06-11T17:54:57.733Z" },
+    { url = "https://files.pythonhosted.org/packages/68/dd/0d10c17ce1a1624d6fc3156309c3f834fdb5dfaad026ec90c85684f3990e/ruff-0.15.17-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e01a84ddbc8c16c23055ba3924476850f1bbc1917cebbb9376665a63e74260d", size = 11416967, upload-time = "2026-06-11T17:54:51.461Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/91/556bfb156f6144f355e831c23db00b2fc4120f86b3ce81cc5f7fd2df51f3/ruff-0.15.17-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:84fe9f653152f8f294f9f7e03bf3a453d8b4a27f7a59c78c8666167f2b17b96c", size = 12335770, upload-time = "2026-06-11T17:54:45.793Z" },
+    { url = "https://files.pythonhosted.org/packages/88/82/8b5999aa13355e926f06d9f42a32dcca862f623bf0363785ff89d607dffd/ruff-0.15.17-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c0fe88a7676e7a05b73174d4d4a59cb2ac21ff8263583f87a81a6018475a978", size = 11575441, upload-time = "2026-06-11T17:54:32.661Z" },
+    { url = "https://files.pythonhosted.org/packages/11/93/f10377bb04109ca0e8cbc483ff1982c54b6d418210041776f93e8cdc7fa9/ruff-0.15.17-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecfc3c7878fff94633ab0348524e093f9ce3243080416dd7d14f8ba400174719", size = 11557614, upload-time = "2026-06-11T17:54:34.698Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/a6/eeeae7f7d5493df41649ab3db92f086b2d0a30199e4efdf8e3dd7a033f24/ruff-0.15.17-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:b8461180b22420b1bdc289909410930761629fddf2a5aaf60fae1ab26cedc4c4", size = 11544450, upload-time = "2026-06-11T17:54:39.042Z" },
+    { url = "https://files.pythonhosted.org/packages/32/88/5991ce565129a24dd4a00db1254b3b5db2e53018cbe4018ea5a89738e727/ruff-0.15.17-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:6eccbe50a038b503e7140b441aa9c7fc8c1f36edf23ebef9f4165c2f28f568b7", size = 10892524, upload-time = "2026-06-11T17:55:09.432Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/1d/0fdd248313425f55223968af04b0a42125466a8d88d21c1d99c6af0a51e8/ruff-0.15.17-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:382fc0521025f5a8ad447d8bdd523545d0d7646adb718eb1c2dac5065ec27c0f", size = 10659573, upload-time = "2026-06-11T17:54:36.824Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/0e/072e8260deb9461062ce9311ced27a8e541229a6ffd483013dd37661e43e/ruff-0.15.17-py3-none-musllinux_1_2_i686.whl", hash = "sha256:456d41fcd1b2777ad63f09a6e7121d43f7b688bbc76a800c10f7f8fb1f912c3f", size = 11127818, upload-time = "2026-06-11T17:55:03.124Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/b4/55060a34163121498014696b5f656db5b8c6963768f227dbf0d76b311073/ruff-0.15.17-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b1a04bcc94ae6194e9db05d16ad31f298a7194bfbcb08258bbe589cee1d587b8", size = 11655901, upload-time = "2026-06-11T17:54:53.562Z" },
+    { url = "https://files.pythonhosted.org/packages/49/71/9b29d6b87cef468d697f43c6a91e3fae4a80185779d7d5a4ef27d173439f/ruff-0.15.17-py3-none-win32.whl", hash = "sha256:596065960ab1ff593f744220c9fe6580eda00a95003cffa9f4048bb5b1bf0392", size = 10925574, upload-time = "2026-06-11T17:54:55.723Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b2/8fc77f3723228836fa5d12497eb71c808f83782e10d058d2b15cfa14640b/ruff-0.15.17-py3-none-win_amd64.whl", hash = "sha256:6769e5fa1710b179b92e0bfa5a51735b35baea9013dadb06d5f44cbcf9547084", size = 12058788, upload-time = "2026-06-11T17:54:41.042Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c7/c53e8dbff9c9dc4b7928773421ae294a5d28fcb8dcda1a089579d3a7e510/ruff-0.15.17-py3-none-win_arm64.whl", hash = "sha256:f3be1fbb34bcdfd146240d8fb92a709d4c2c8191348580a3c044ec60fa0b4456", size = 11355275, upload-time = "2026-06-11T17:54:43.635Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

We want to improve retrieval quality, but we currently **can't measure what helps**. Two defects make any retrieval change unfalsifiable, so they're the prerequisite for everything else:

- **#554** — `kairix eval hybrid-sweep` returns byte-identical scores for *every* config, so a sweep can never recommend a change (so "the config is at its optimum" is unverified).
- **#552** — the eval CLIs assume a dev laptop (`~/.cache/...`), so they don't run on a standard docker/system deployment without manual flag overrides.

## #554 — per-config query caches

The process-shared `QueryResultCache` was a single lazy singleton wired into every `SearchPipeline`. Its in-memory key (`make_cache_key`) omits the `RetrievalConfig`, so in a multi-config process — the sweep — config #1's cached result for query Q was served to config #2's identical Q (config #1 ran ~159s; #2..N returned in ~0.1s).

Fix: `_get_or_create_query_cache` keys caches by `cfg_hash` (a dict), matching the on-disk cache schema which is already `cfg_hash`-scoped. **Production runs one config → one cache (unchanged); a sweep gets one cache per config → no cross-config collision.** `get_query_cache()` resolves the production `cfg_hash` so onboard/diagnostics still read the live cache.

## #552 — eval db-path resolves the deployment

`kairix eval generate|enrich|chunk-stats` defaulted `--db`/`--db-path` to `~/.cache/kairix/index.sqlite`. The three handlers now resolve through a `_resolve_db_path()` helper → `kairix.paths.index_path()` (the mode-aware FHS path, `/var/lib/kairix/index.sqlite` on a system/container install — the same path the worker writes). `--deployment` is left functional but its help corrected: `ProviderEvalChatBackend` ignores it (the provider plugin resolves its own model), so it was a no-op — the db-path was the actionable defect.

## Tests (both sabotage-proven)

- `tests/integration/test_query_cache_per_config.py` — distinct configs build pipelines with distinct `query_cache` instances; same config shares one. (A fixed-key singleton fails it.)
- `tests/eval/test_cli_unit.py::test_generate_db_path_defaults_to_deployment_index` — drives the public CLI; asserts `generate_suite` receives the `index_path()`-resolved db with no `--db`, and the explicit value otherwise. (Reverting the resolver to `~/.cache` fails it.)

Also folds in a stale `uv.lock` → `pyproject.toml` sync (cryptography<50, ruff 0.15.17) that was blocking commits on the branch base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)