### PR TITLE
docs(eval): align eval CLI docs with the resolved db-path (#552 follow-up)

### DIFF
--- a/docs/evaluation/EVALUATION.md
+++ b/docs/evaluation/EVALUATION.md
@@ -147,7 +147,7 @@ To add a new canary: append a case to `suites/per-type-canary-suite.yaml` with `
 ### Chunk-size distribution telemetry
 
 ```bash
-kairix eval chunk-stats --db-path ~/.cache/kairix/index.sqlite
+kairix eval chunk-stats   # resolves the deployment's index automatically
 ```
 
 Emits per-source-type chunk-size statistics:

--- a/docs/user-guide/eval-guide.md
+++ b/docs/user-guide/eval-guide.md
@@ -56,8 +56,8 @@ kairix eval generate \
   --output PATH           # Required. Output suite YAML path.
   [--count N]             # Target case count (default: 100)
   [--categories LIST]     # Comma-separated: recall,temporal,entity,conceptual,multi_hop,procedural
-  [--db PATH]             # Kairix database path (default: ~/.cache/kairix/index.sqlite)
-  [--deployment NAME]     # Azure deployment (default: gpt-4o-mini)
+  [--db PATH]             # Kairix index path (default: the deployment's index, e.g. /var/lib/kairix/index.sqlite)
+  [--deployment NAME]     # Azure deployment override; ignored when the provider resolves its own model
   [--no-calibrate]        # Skip calibration anchor check (faster, less safe)
   [--seed N]              # Random seed for reproducibility
   [--agent NAME]          # Agent for retrieval scoping (default: shape)
@@ -95,8 +95,8 @@ Use this when you have an existing suite (e.g. manually curated or created when 
 kairix eval enrich \
   --suite PATH            # Required. Input suite YAML.
   --output PATH           # Required. Output suite YAML (can equal --suite for in-place).
-  [--db PATH]             # Kairix database path
-  [--deployment NAME]     # Azure deployment (default: gpt-4o-mini)
+  [--db PATH]             # Kairix index path (default: the deployment's index, e.g. /var/lib/kairix/index.sqlite)
+  [--deployment NAME]     # Azure deployment override; ignored when the provider resolves its own model
   [--agent NAME]          # Agent for retrieval scoping (default: shape)
 ```
 
@@ -260,7 +260,7 @@ To increase acceptance rate: use `--count` larger than your target (the pipeline
 The LLM judge is returning unexpected grades on anchor cases. Possible causes:
 
 - API endpoint misconfigured (returns errors or empty responses)
-- Model deployment renamed (update `KAIRIX_LLM_MODEL` or use `--deployment`)
+- Judge model misconfigured — set the model in the configured provider's section of `kairix.config.yaml`
 - Temporary API degradation — retry in a few minutes
 
 Use `--no-calibrate` to bypass for development/testing. Do not bypass calibration in production generation runs.
@@ -269,7 +269,7 @@ Use `--no-calibrate` to bypass for development/testing. Do not bypass calibratio
 
 - Check `--db` path points to a populated kairix index
 - Run `kairix embed` if the index is empty
-- Verify the index has documents: `sqlite3 ~/.cache/kairix/index.sqlite "SELECT COUNT(*) FROM documents;"`
+- Verify the index has documents: `sqlite3 /var/lib/kairix/index.sqlite "SELECT COUNT(*) FROM documents;"` (or your `--db` path)
 
 ### NDCG scores look too low
 


### PR DESCRIPTION
Docs-only follow-up to #560 (#552). The eval CLI now resolves the deployment's index (`kairix.paths.index_path()`, e.g. `/var/lib/kairix/index.sqlite`) instead of defaulting to `~/.cache/kairix/index.sqlite`, and `--deployment` is ignored by the provider-resolving backend.

Updates `docs/user-guide/eval-guide.md` + `docs/evaluation/EVALUATION.md` to match:
- `--db` help → 'the deployment's index' (not the `~/.cache` literal)
- `--deployment` help → 'override; ignored when the provider resolves its own model'
- `chunk-stats` example drops the stale `--db-path ~/.cache` arg
- troubleshooting examples use the FHS path

The other `~/.cache` references in OPERATIONS/runbooks are the *general* DB-path resolver (unchanged by #552) and were deliberately left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)