### PR TITLE
feat(search): entity-first routing for ENTITY-intent queries (#429 Phase 2b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning: [Calendar Versioning (CalVer)](https://calver.org/) — `YYYY.MM.DD`, with `.N` suffix for same-day releases.
 Git tags: `v2026.04.18`. Deploy by pinning to a tag: `pip install git+...@v2026.04.18`.
 
+## [Unreleased]
+
+### For operators
+
+- **Lead with what we know about a thing.** When someone asks "tell me about X" or "who is X", kairix can now put the short description of that person, team, or topic at the top of the results instead of buried below documents. It's off by default — turn it on once you've switched on entity descriptions, and you can switch it back off at any time.
+
 ## [2026.6.18] - 2026-06-18 — Set up kairix in your browser
 
 > **Upgrading?** Pull the new image and restart — your knowledge store, sources, and agents all carry over. New installs now open into a browser setup page; existing installs keep working exactly as they are.

--- a/docs/architecture/ADR-036-entity-summary-indexing-surface.md
+++ b/docs/architecture/ADR-036-entity-summary-indexing-surface.md
@@ -463,6 +463,77 @@ Capture-flip-soak-gate is the standard. For this flag:
    is needed: `DELETE FROM chunks WHERE collection='entity-summaries'`
    (operator-driven, documented in the cutover runbook).
 
+## Entity-first routing (#429 Phase 2b)
+
+Indexing (above) makes entity summaries *retrievable* — but the projector
+writes them into the `entity-summaries` collection at tier `reference`
+(×0.6), so they are *de-prioritised*. For an ENTITY-intent query ("tell
+me about X" / "who is X") that is backwards: the operator is asking about
+the entity, so its summary should lead. Phase 2b adds the routing that
+flips this.
+
+**Mechanism.** A new boost strategy
+`kairix.core.search.boosts.EntityFirstRoutingBoost` multiplies the
+`boosted_score` of entity-summary rows (collection `entity-summaries`, or
+the well-known `entity://` source-URI prefix) by
+`EntityFirstRoutingConfig.factor` (default 3.0) and re-sorts — the same
+"mutate then re-sort by boosted_score" shape the `rrf` boost functions
+use, so the routed summary actually leads the budget stage. It is
+registered **last** in `select_boosts` (after `SourceTierBoost`) so the
+multiplier composes on top of the reference de-boost.
+
+**Two gates, both required before any score is touched:**
+
+1. **Feature flag** — `entity_first_routing_enabled` (registry block
+   below), resolved once at build time so `select_boosts` only wires the
+   boost when the flag is ON, and read again at query time via the boost's
+   `flag_reader` DI seam so an operator can roll the cutover back instantly
+   (flag OFF ⇒ no-op) without a rebuild. Default OFF ⇒ pre-#429 ranking
+   byte-for-byte.
+2. **Intent** — `context["intent"] == QueryIntent.ENTITY` (with the #456
+   confidence gate when `intent_confidence_gated_boosts` is ON).
+
+The flag depends on `entity_summary_indexing_enabled` being ON for there
+to be summaries to route — routing without indexing is a harmless no-op
+(no `entity://` rows exist). It is orthogonal to the CLI `[Wikidata]`
+badge + MCP `entity_summary` envelope flag (ADR-036 §Q7), which mark
+entity rows regardless of ranking.
+
+**Registry.**
+
+```python
+# kairix/core/features/registry.py
+"entity_first_routing_enabled": FeatureFlag(
+    name="entity_first_routing_enabled",
+    default=False,
+    stage="introduce",
+    introduced_in="v2026.6.19",
+    target_retire_in="v2026.12.1",
+    owner="search-pipeline",
+    related_spec="docs/architecture/ADR-036-entity-summary-indexing-surface.md",
+)
+```
+
+**Measurement (#429 Phase 2c — runs against the now-fixed eval loop).**
+Phase 1 (#552/#554) repaired `kairix eval hybrid-sweep` so per-config
+scores are distinct again, which makes this measurable:
+
+1. On a corpus that has entity summaries indexed
+   (`entity_summary_indexing_enabled` ON), capture entity-category
+   NDCG@10 on the curated entity slice with `entity_first_routing_enabled`
+   **OFF** (baseline).
+2. Flip routing **ON**, re-capture.
+3. Gate on a measurable entity-category lift with no regression in other
+   categories (±2pp per the cutover protocol above).
+
+The auto-gold generator under-samples entity hard cases, so the curated
+entity slice + the run live with the corpus (the reflib / production
+index), not in the public repo — a meaningful slice needs real indexed
+entity summaries, and corpus entity names stay out of public artefacts
+(F32). The production flag-flip is **#463 / Linear PLA-173**, blocked on a
+deployment apply-script fix in the infrastructure repo; the routing code
+ships independently of that cutover.
+
 ## Fitness-function impact
 
 | Rule | Concern | Resolution |

--- a/kairix/core/factory.py
+++ b/kairix/core/factory.py
@@ -204,6 +204,7 @@ def select_boosts(
     graph: Any,
     *,
     tier_map: dict[str, str] | None = None,
+    entity_first_routing_on: bool = False,
 ) -> list[Any]:
     """Build the production boost chain from a RetrievalConfig.
 
@@ -224,17 +225,28 @@ def select_boosts(
                   ``cfg.source_tier_boost.default_tier`` (x1.0). The factory
                   derives this map from the operator's collections config
                   before calling this helper.
+        entity_first_routing_on: when True (Issue #429 — resolved from the
+                  ``entity_first_routing_enabled`` feature flag by
+                  :func:`build_search_pipeline`), append
+                  :class:`EntityFirstRoutingBoost` LAST so its multiplier
+                  composes on top of the tier de-boost. Default False keeps
+                  the chain byte-for-byte identical for every deployment
+                  that hasn't cut over.
 
     Returns:
         List of boost-strategy instances in registration order:
         EntityBoost → ProceduralBoost → TemporalDateBoost → ChunkDateBoost
         → SourceTierBoost (Issue #432 — runs last so tier multipliers
-        apply on top of any intent-gated boost output).
+        apply on top of any intent-gated boost output) → ContentQualityBoost
+        → EntityFirstRoutingBoost (Issue #429 — appended only when the flag
+        is on; runs last so entity-summaries are routed first on ENTITY
+        intent after every other boost has scored).
     """
     from kairix.core.search.boosts import (
         ChunkDateBoost,
         ContentQualityBoost,
         EntityBoost,
+        EntityFirstRoutingBoost,
         ProceduralBoost,
         SourceTierBoost,
         TemporalDateBoost,
@@ -262,6 +274,15 @@ def select_boosts(
     # reference-tier content with a substantive body.
     if cfg.content_quality_boost.enabled:
         boosts.append(ContentQualityBoost(config=cfg.content_quality_boost))
+    # Issue #429 — entity-first routing. Appended LAST so the multiplier
+    # composes on top of every prior boost (especially SourceTierBoost's
+    # reference x0.6 de-boost). Wired only when the
+    # ``entity_first_routing_enabled`` flag is on (resolved by
+    # build_search_pipeline); the boost ALSO self-gates on the flag at
+    # query time so an operator can roll the cutover back instantly
+    # without a rebuild.
+    if entity_first_routing_on:
+        boosts.append(EntityFirstRoutingBoost(config=cfg.entity_first_routing))
     return boosts
 
 
@@ -1065,7 +1086,18 @@ def _build_search_pipeline_uncached(
     # to apply per result. Empty dict (no tier declarations) means the
     # boost falls back to the default tier (x1.0) for every result.
     tier_map = derive_tier_map() if cfg.source_tier_boost.enabled else None
-    boosts = deps.boosts_override if deps.boosts_override is not None else select_boosts(cfg, graph, tier_map=tier_map)
+    # Issue #429 — resolve the entity-first-routing cutover flag once at
+    # build time. When ON, select_boosts appends EntityFirstRoutingBoost so
+    # ENTITY-intent queries route entity-summaries first. Default OFF keeps
+    # the production chain unchanged.
+    from kairix.core.search.boosts import default_entity_first_routing_flag_reader
+
+    entity_first_routing_on = default_entity_first_routing_flag_reader()
+    boosts = (
+        deps.boosts_override
+        if deps.boosts_override is not None
+        else select_boosts(cfg, graph, tier_map=tier_map, entity_first_routing_on=entity_first_routing_on)
+    )
 
     pipeline_logger = deps.logger_override if deps.logger_override is not None else _build_search_logger(env)
 

--- a/kairix/core/features/registry.py
+++ b/kairix/core/features/registry.py
@@ -62,6 +62,10 @@ _FLAG_TARGET_RETIRE_WAVE5_2026_11_30 = "v2026.11.30"
 # Canonical spec for flags whose behaviour is the flag mechanism itself
 # (no dedicated capability ADR yet).
 _FEATURE_FLAG_ARCHITECTURE_SPEC = "docs/architecture/feature-flag-architecture.md"
+# F17 — search-pipeline owner repeated across the entity-summary,
+# intent-confidence, and entity-first-routing flags; extract so adding the
+# next search flag doesn't re-duplicate the literal.
+_SEARCH_PIPELINE_OWNER = "search-pipeline"
 
 
 # Public registry. The topology_v2_* family + ``obsidian_connector_primary``
@@ -303,7 +307,30 @@ REGISTRY: dict[str, FeatureFlag] = {
         stage="introduce",
         introduced_in=_FLAG_INTRODUCED_IN_DISPATCH_WINDOW,
         target_retire_in=_FLAG_TARGET_RETIRE_IN,
-        owner="search-pipeline",
+        owner=_SEARCH_PIPELINE_OWNER,
+        related_spec="docs/architecture/ADR-036-entity-summary-indexing-surface.md",
+    ),
+    "entity_first_routing_enabled": FeatureFlag(
+        name="entity_first_routing_enabled",
+        # Default-OFF: pre-#429-Phase-2b ranking preserved byte-for-byte.
+        # Operators flip ON (after entity_summary_indexing_enabled is ON,
+        # so there are summaries to route) to lift entity-summaries to the
+        # top for entity-named queries.
+        default=False,
+        description=(
+            "When ON, ENTITY-intent queries ('tell me about X', 'who is X') "
+            "route the 'entity-summaries' collection first — the ADR-036 "
+            "projector's Wikidata summaries are lifted to the top of results "
+            "via EntityFirstRoutingBoost instead of sitting de-prioritised at "
+            "tier reference (x0.6). When OFF (the default), ranking is "
+            "unchanged byte-for-byte. Needs entity_summary_indexing_enabled "
+            "ON for there to be summaries to route. #429 Phase 2b; the "
+            "production cutover is #463 (PLA-173)."
+        ),
+        stage="introduce",
+        introduced_in="v2026.6.19",
+        target_retire_in="v2026.12.1",
+        owner=_SEARCH_PIPELINE_OWNER,
         related_spec="docs/architecture/ADR-036-entity-summary-indexing-surface.md",
     ),
     "intent_confidence_gated_boosts": FeatureFlag(
@@ -332,7 +359,7 @@ REGISTRY: dict[str, FeatureFlag] = {
         stage="introduce",
         introduced_in=_FLAG_INTRODUCED_IN_DISPATCH_WINDOW,
         target_retire_in=_FLAG_TARGET_RETIRE_IN,
-        owner="search-pipeline",
+        owner=_SEARCH_PIPELINE_OWNER,
         related_spec=_FEATURE_FLAG_ARCHITECTURE_SPEC,
     ),
     "setup_wizard_web": FeatureFlag(

--- a/kairix/core/search/boosts.py
+++ b/kairix/core/search/boosts.py
@@ -14,6 +14,7 @@ from kairix.core.protocols import GraphRepository
 from kairix.core.search.config import (
     ContentQualityBoostConfig,
     EntityBoostConfig,
+    EntityFirstRoutingConfig,
     ProceduralBoostConfig,
     SourceTier,
     SourceTierBoostConfig,
@@ -327,6 +328,127 @@ class SourceTierBoost:
                 )
                 continue
         return results
+
+
+# ---------------------------------------------------------------------------
+# EntityFirstRoutingBoost (Issue #429) — route entity-summaries first
+# ---------------------------------------------------------------------------
+
+
+def default_entity_first_routing_flag_reader() -> bool:
+    """Production flag-reader for ``entity_first_routing_enabled`` (#429).
+
+    Thin wrapper around :func:`kairix.core.features.resolver.flag` so
+    tests inject a fake reader via the ``flag_reader`` kwarg on
+    :class:`EntityFirstRoutingBoost` without monkey-patching the resolver
+    module (F1/F2-clean).
+    """
+    from kairix.core.features.resolver import flag
+
+    return flag("entity_first_routing_enabled")
+
+
+class EntityFirstRoutingBoost:
+    """Route entity-summaries first for ENTITY-intent queries (#429 Phase 2b).
+
+    The ADR-036 projector writes each entity's Wikidata summary into the
+    synthetic ``entity-summaries`` collection (tier ``reference``, x0.6) —
+    so by default those summaries are *de*-prioritised. For an ENTITY-intent
+    query ("tell me about X" / "who is X") that is exactly backwards: the
+    operator is asking *about the entity*, so its summary should lead.
+
+    This boost multiplies the ``boosted_score`` of entity-summary rows by
+    ``config.factor``. A row is an entity-summary when its ``collection``
+    matches ``config.collection`` OR its ``path`` carries the well-known
+    ``entity://`` source-URI prefix the projector writes (the same marker
+    the CLI ``[Wikidata]`` badge + MCP ``entity_summary`` envelope flag key
+    off). Registered LAST in the chain so the multiplier composes on top of
+    :class:`SourceTierBoost`'s tier de-boost.
+
+    Two gates, both must pass before any score is touched:
+
+      1. **Feature flag** — ``entity_first_routing_enabled`` read live via
+         ``flag_reader``. OFF (the default) ⇒ structural no-op, pre-#429
+         ranking preserved byte-for-byte. This is the cutover control.
+      2. **Intent** — ``context["intent"] == QueryIntent.ENTITY`` (with the
+         #456 confidence gate when ``intent_confidence_gated_boosts`` is
+         ON), via :func:`intent_confidence_passes`.
+
+    Failure-isolated: any per-result exception logs at WARNING and leaves
+    that row's score unchanged; the strategy itself never raises.
+    """
+
+    _ENTITY_URI_PREFIX = "entity://"
+
+    def __init__(
+        self,
+        config: EntityFirstRoutingConfig | None = None,
+        *,
+        flag_reader: IntentConfidenceFlagReader = default_entity_first_routing_flag_reader,
+    ) -> None:
+        self._config = config or EntityFirstRoutingConfig()
+        self._flag_reader = flag_reader
+
+    def _is_entity_summary(self, result: object) -> bool:
+        """True when ``result`` is an entity-summary row.
+
+        Checks the well-known ``entity://`` source-URI prefix first (the
+        marker the projector writes, and the one the CLI ``[Wikidata]``
+        badge + MCP envelope key off), then falls back to the collection
+        label. Both ``getattr`` defaults are ``""``: ``==`` is None-safe
+        and ``isinstance`` guards ``startswith``, so no ``or ""`` is
+        needed.
+        """
+        path = getattr(result, "path", "")
+        if isinstance(path, str) and path.startswith(self._ENTITY_URI_PREFIX):
+            return True
+        return getattr(result, "collection", "") == self._config.collection
+
+    @staticmethod
+    def _score_key(result: object) -> float:
+        """Sort key — defensive so one unreadable score can't break the sort.
+
+        Catches broadly (matching the per-row boost guards): a row whose
+        ``boosted_score`` is missing, non-numeric, or raises on access
+        sorts to the bottom rather than aborting the whole boost.
+        """
+        try:
+            return float(getattr(result, "boosted_score", 0.0))
+        except Exception:
+            return 0.0
+
+    def boost(self, results: list, _query: str, context: dict) -> list:
+        """Multiply entity-summary scores by ``factor`` when flag ON + ENTITY intent.
+
+        Re-sorts by ``boosted_score`` descending when it fires (like the
+        ``rrf`` boost functions) so the routed entity-summary actually
+        leads the budget stage — ``apply_budget`` consumes in order without
+        re-sorting. When either gate fails the input list is returned
+        unchanged (no mutation, no re-sort) — pre-#429 ranking preserved.
+
+        ``_query`` is part of the ``BoostStrategy`` Protocol signature but
+        unused — routing is structural (collection / source-URI), not
+        query-text dependent.
+        """
+        if not self._flag_reader():
+            return results
+        if not intent_confidence_passes(context, QueryIntent.ENTITY, self._config.min_intent_confidence):
+            return results
+        factor = self._config.factor
+        for r in results:
+            try:
+                if self._is_entity_summary(r):
+                    r.boosted_score = float(r.boosted_score) * factor
+            except Exception as exc:
+                import logging
+
+                logging.getLogger(__name__).warning(
+                    "EntityFirstRoutingBoost: per-result boost failed for %s — %s",
+                    getattr(r, "path", "?"),
+                    exc,
+                )
+                continue
+        return sorted(results, key=self._score_key, reverse=True)
 
 
 # ---------------------------------------------------------------------------

--- a/kairix/core/search/config.py
+++ b/kairix/core/search/config.py
@@ -297,6 +297,45 @@ class ContentQualityBoostConfig:
 
 
 @dataclass(frozen=True)
+class EntityFirstRoutingConfig:
+    """Configuration for entity-first routing (#429 Phase 2b).
+
+    When the ``entity_first_routing_enabled`` feature flag is ON and a
+    query classifies as :attr:`QueryIntent.ENTITY` ("tell me about X" /
+    "who is X"), the :class:`~kairix.core.search.boosts.EntityFirstRoutingBoost`
+    multiplies the ``boosted_score`` of ``entity-summaries`` results (the
+    ADR-036 projector's ``entity://<QID>`` chunks) by :attr:`factor`,
+    surfacing the entity's Wikidata-sourced summary at the top of the
+    candidate set instead of leaving it de-prioritised at tier
+    ``reference`` (x0.6).
+
+    The boost runs LAST in the chain (after :class:`SourceTierBoost`), so
+    ``factor`` composes on top of the tier multiplier: with source-tier
+    boost on, an entity-summary nets ``0.6 x factor`` versus a
+    ``vault_active`` row's ``x1.0``; with source-tier boost off it nets a
+    flat ``xfactor``. :attr:`factor` is the lever the
+    ``kairix eval hybrid-sweep`` loop tunes (#429 Phase 2c).
+
+    There is intentionally no ``enabled`` field — the registry
+    :class:`~kairix.core.features.registry.FeatureFlag`
+    ``entity_first_routing_enabled`` is the single, runtime-flippable
+    cutover control (default OFF ⇒ no-op).
+    """
+
+    # Multiplier applied to entity-summary ``boosted_score`` on ENTITY
+    # intent. Default 3.0 clears the reference x0.6 de-boost and routes
+    # the summary first; swept per-corpus in Phase 2c.
+    factor: float = 3.0
+    # Synthetic collection the ADR-036 projector writes into. Rows whose
+    # ``collection`` matches this — or whose ``path`` carries the
+    # well-known ``entity://`` source-URI prefix — are routed first.
+    collection: str = "entity-summaries"
+    # Issue #456 — confidence-gated minimum. Consulted only when the
+    # ``intent_confidence_gated_boosts`` flag is ON. See EntityBoostConfig.
+    min_intent_confidence: float = 0.5
+
+
+@dataclass(frozen=True)
 class RerankConfig:
     """Configuration for cross-encoder re-ranking (post-fusion semantic pass)."""
 
@@ -378,6 +417,13 @@ class RetrievalConfig:
     # operator-declared authority); composes multiplicatively at the
     # boost-chain tail.
     content_quality_boost: ContentQualityBoostConfig = field(default_factory=ContentQualityBoostConfig)
+
+    # Issue #429 — entity-first routing tunables. The boost itself is
+    # gated by the ``entity_first_routing_enabled`` feature flag (default
+    # OFF), not by a field here; this only carries the multiplier +
+    # collection name the boost applies when the flag is ON and the
+    # query is ENTITY intent.
+    entity_first_routing: EntityFirstRoutingConfig = field(default_factory=EntityFirstRoutingConfig)
 
     # Issue #455 — three-way fusion floor + cross-layer dedup.
     #

--- a/tests/bdd/features/feature_flag_entity_first_routing_enabled.feature
+++ b/tests/bdd/features/feature_flag_entity_first_routing_enabled.feature
@@ -1,0 +1,23 @@
+@feature_flag @entity_first_routing_enabled
+Feature: Operator toggles the entity-first-routing feature flag
+  As an operator whose knowledge store has indexed entity summaries
+  I want entity-named questions to surface the matching entity summary first
+  So that "tell me about X" answers lead with what we already know about X
+
+  @happy_path @on
+  Scenario: Flag ON routes the entity summary above a plain note
+    Given the operator has the entity-first-routing flag set to true
+    When an entity-intent search ranks an entity summary against a plain note
+    Then the entity summary is lifted above the plain note
+
+  @off
+  Scenario: Flag OFF leaves ranking unchanged
+    Given the operator has the entity-first-routing flag set to false
+    When an entity-intent search ranks an entity summary against a plain note
+    Then the entity summary keeps its original score
+
+  @on
+  Scenario: Flag ON does not route for a non-entity question
+    Given the operator has the entity-first-routing flag set to true
+    When a keyword search ranks an entity summary against a plain note
+    Then the entity summary keeps its original score

--- a/tests/bdd/steps/feature_flag_entity_first_routing_enabled_steps.py
+++ b/tests/bdd/steps/feature_flag_entity_first_routing_enabled_steps.py
@@ -1,0 +1,96 @@
+"""Step definitions for feature_flag_entity_first_routing_enabled.feature.
+
+F54 both-branch coverage — drives
+:class:`kairix.core.search.boosts.EntityFirstRoutingBoost` directly with
+the ``flag_reader`` DI seam pinned ON / OFF, then asserts the entity
+summary is (or is not) lifted above a plain note.
+
+F1/F2-clean: no monkey-patching, no env-var manipulation. The
+``flag_reader`` kwarg is the public DI seam by design.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+from pytest_bdd import given, parsers, then, when
+
+from kairix.core.search.boosts import EntityFirstRoutingBoost
+from kairix.core.search.config import EntityFirstRoutingConfig
+from kairix.core.search.intent import QueryIntent
+from kairix.core.search.rrf import FusedResult
+
+pytestmark = pytest.mark.bdd
+
+
+_BASE_SCORE = 0.5
+_FACTOR = 3.0
+
+
+@dataclass
+class _Ctx:
+    flag_on: bool = False
+    entity: FusedResult | None = None
+    note: FusedResult | None = None
+
+
+@pytest.fixture
+def routing_ctx() -> _Ctx:
+    return _Ctx()
+
+
+def _apply(ctx: _Ctx, intent: QueryIntent) -> None:
+    """Build a tied (entity-summary, plain-note) pair and run the boost."""
+    ctx.entity = FusedResult(
+        path="entity://Q42",
+        collection="entity-summaries",
+        title="Douglas Adams",
+        snippet="English author and humourist.",
+        rrf_score=_BASE_SCORE,
+        boosted_score=_BASE_SCORE,
+    )
+    ctx.note = FusedResult(
+        path="notes/about.md",
+        collection="vault",
+        title="About",
+        snippet="A plain vault note.",
+        rrf_score=_BASE_SCORE,
+        boosted_score=_BASE_SCORE,
+    )
+    boost = EntityFirstRoutingBoost(
+        config=EntityFirstRoutingConfig(factor=_FACTOR),
+        flag_reader=lambda: ctx.flag_on,
+    )
+    boost.boost(
+        [ctx.entity, ctx.note],
+        "tell me about Douglas Adams",
+        {"intent": intent, "intent_confidence": 1.0},
+    )
+
+
+@given(parsers.parse("the operator has the entity-first-routing flag set to {state}"))
+def _set_flag(routing_ctx: _Ctx, state: str) -> None:
+    routing_ctx.flag_on = state.strip().lower() == "true"
+
+
+@when("an entity-intent search ranks an entity summary against a plain note")
+def _entity_search(routing_ctx: _Ctx) -> None:
+    _apply(routing_ctx, QueryIntent.ENTITY)
+
+
+@when("a keyword search ranks an entity summary against a plain note")
+def _keyword_search(routing_ctx: _Ctx) -> None:
+    _apply(routing_ctx, QueryIntent.KEYWORD)
+
+
+@then("the entity summary is lifted above the plain note")
+def _lifted(routing_ctx: _Ctx) -> None:
+    assert routing_ctx.entity is not None and routing_ctx.note is not None
+    assert routing_ctx.entity.boosted_score > routing_ctx.note.boosted_score
+
+
+@then("the entity summary keeps its original score")
+def _unchanged(routing_ctx: _Ctx) -> None:
+    assert routing_ctx.entity is not None
+    assert routing_ctx.entity.boosted_score == pytest.approx(routing_ctx.entity.rrf_score)

--- a/tests/bdd/test_feature_flag_entity_first_routing_enabled.py
+++ b/tests/bdd/test_feature_flag_entity_first_routing_enabled.py
@@ -1,0 +1,34 @@
+"""pytest-bdd test module for feature_flag_entity_first_routing_enabled.feature."""
+
+from pathlib import Path
+
+import pytest
+from pytest_bdd import scenario
+
+FEATURE = str(Path(__file__).parent / "features" / "feature_flag_entity_first_routing_enabled.feature")
+
+pytestmark = pytest.mark.bdd
+
+
+@scenario(
+    FEATURE,
+    "Flag ON routes the entity summary above a plain note",
+)
+def test_flag_on_routes_entity_first() -> None:
+    """Body populated by @scenario from the .feature file."""
+
+
+@scenario(
+    FEATURE,
+    "Flag OFF leaves ranking unchanged",
+)
+def test_flag_off_ranking_unchanged() -> None:
+    """Body populated by @scenario from the .feature file."""
+
+
+@scenario(
+    FEATURE,
+    "Flag ON does not route for a non-entity question",
+)
+def test_flag_on_non_entity_unchanged() -> None:
+    """Body populated by @scenario from the .feature file."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -288,6 +288,10 @@ pytest_plugins = [
     # intent_confidence_gated_boosts feature flag (driven via the
     # intent_confidence_passes flag_reader DI seam).
     "tests.bdd.steps.feature_flag_intent_confidence_gated_boosts_steps",
+    # Issue #429 Phase 2b — F54 both-branch coverage for the
+    # entity_first_routing_enabled feature flag (driven via the
+    # EntityFirstRoutingBoost flag_reader DI seam).
+    "tests.bdd.steps.feature_flag_entity_first_routing_enabled_steps",
     # ADR-036 #459 Slice A — F54 both-branch coverage for the
     # entity_summary_indexing_enabled feature flag (worker-tick gate
     # for projecting Neo4j n.summary into the chunk store).

--- a/tests/core/test_entity_first_routing_boost.py
+++ b/tests/core/test_entity_first_routing_boost.py
@@ -1,0 +1,193 @@
+"""Unit tests for ``EntityFirstRoutingBoost`` (#429 Phase 2b).
+
+Entity-first routing lifts the ``entity-summaries`` collection (the
+ADR-036 projector's ``entity://<QID>`` chunks, tier ``reference`` x0.6)
+to the top of the candidate set for ``QueryIntent.ENTITY`` queries
+("tell me about X" / "who is X"). It is a ranker swap, so it sits behind
+the default-off ``entity_first_routing_enabled`` feature flag — read live
+via the ``flag_reader`` DI seam so tests drive both branches without
+monkey-patching (F1/F2-clean).
+
+Default-safe contract: flag OFF ⇒ ``boost()`` is a structural no-op and
+pre-#429 ranking is preserved byte-for-byte.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kairix.core.search.boosts import EntityFirstRoutingBoost
+from kairix.core.search.config import EntityFirstRoutingConfig
+from kairix.core.search.intent import QueryIntent
+from kairix.core.search.rrf import FusedResult
+
+pytestmark = pytest.mark.unit
+
+
+_FLAG_ON = lambda: True  # noqa: E731 — terse zero-arg flag_reader DI seam for tests
+_FLAG_OFF = lambda: False  # noqa: E731
+
+
+def _entity_row(score: float = 0.5) -> FusedResult:
+    """An entity-summary candidate — collection + ``entity://`` source URI."""
+    return FusedResult(
+        path="entity://Q42",
+        collection="entity-summaries",
+        title="Douglas Adams",
+        snippet="English author and humourist.",
+        rrf_score=score,
+        boosted_score=score,
+    )
+
+
+def _vault_row(score: float = 0.5) -> FusedResult:
+    """A plain vault candidate — must never be touched by this boost."""
+    return FusedResult(
+        path="notes/about.md",
+        collection="vault",
+        title="About",
+        snippet="A note.",
+        rrf_score=score,
+        boosted_score=score,
+    )
+
+
+def _entity_context() -> dict:
+    return {"intent": QueryIntent.ENTITY, "intent_confidence": 1.0}
+
+
+def test_flag_on_entity_intent_multiplies_entity_summary_score() -> None:
+    """Flag ON + ENTITY intent → entity-summary row xfactor; vault row untouched."""
+    boost = EntityFirstRoutingBoost(
+        config=EntityFirstRoutingConfig(factor=3.0),
+        flag_reader=_FLAG_ON,
+    )
+    entity, vault = _entity_row(0.5), _vault_row(0.5)
+
+    boost.boost([entity, vault], "tell me about Douglas Adams", _entity_context())
+
+    assert entity.boosted_score == pytest.approx(1.5)  # 0.5 x 3.0
+    assert vault.boosted_score == pytest.approx(0.5)  # untouched
+
+
+def test_flag_off_is_a_noop_even_for_entity_intent() -> None:
+    """Default-safe: flag OFF leaves every score byte-for-byte unchanged."""
+    boost = EntityFirstRoutingBoost(
+        config=EntityFirstRoutingConfig(factor=3.0),
+        flag_reader=_FLAG_OFF,
+    )
+    entity, vault = _entity_row(0.5), _vault_row(0.5)
+
+    boost.boost([entity, vault], "tell me about Douglas Adams", _entity_context())
+
+    assert entity.boosted_score == pytest.approx(0.5)
+    assert vault.boosted_score == pytest.approx(0.5)
+
+
+def test_non_entity_intent_is_a_noop_even_with_flag_on() -> None:
+    """Intent gate: a KEYWORD query never routes entity-first."""
+    boost = EntityFirstRoutingBoost(
+        config=EntityFirstRoutingConfig(factor=3.0),
+        flag_reader=_FLAG_ON,
+    )
+    entity = _entity_row(0.5)
+
+    boost.boost([entity], "douglas adams", {"intent": QueryIntent.KEYWORD, "intent_confidence": 1.0})
+
+    assert entity.boosted_score == pytest.approx(0.5)
+
+
+def test_matches_by_entity_uri_prefix_when_collection_label_absent() -> None:
+    """Robustness: an ``entity://`` row with a blank collection still boosts.
+
+    The CLI badge + MCP envelope key off the ``entity://`` prefix; the
+    boost honours the same well-known marker so a row whose collection
+    label was dropped upstream is still routed first.
+    """
+    boost = EntityFirstRoutingBoost(
+        config=EntityFirstRoutingConfig(factor=2.0),
+        flag_reader=_FLAG_ON,
+    )
+    row = FusedResult(
+        path="entity://Q937",
+        collection="",
+        title="Albert Einstein",
+        snippet="Theoretical physicist.",
+        rrf_score=0.4,
+        boosted_score=0.4,
+    )
+
+    boost.boost([row], "who is Einstein", _entity_context())
+
+    assert row.boosted_score == pytest.approx(0.8)  # 0.4 x 2.0
+
+
+def test_matches_by_collection_when_uri_prefix_absent() -> None:
+    """A row in the entity-summaries collection whose path is NOT an
+    ``entity://`` URI is still routed — the collection label is the
+    fallback marker."""
+    boost = EntityFirstRoutingBoost(
+        config=EntityFirstRoutingConfig(factor=2.0),
+        flag_reader=_FLAG_ON,
+    )
+    row = FusedResult(
+        path="entity-summaries/Q5.md",
+        collection="entity-summaries",
+        title="Marie Curie",
+        snippet="Physicist and chemist.",
+        rrf_score=0.4,
+        boosted_score=0.4,
+    )
+
+    boost.boost([row], "tell me about Marie Curie", _entity_context())
+
+    assert row.boosted_score == pytest.approx(0.8)  # 0.4 x 2.0
+
+
+def test_non_entity_row_is_left_untouched() -> None:
+    """A plain row (neither collection nor URI matches) keeps its score."""
+    boost = EntityFirstRoutingBoost(
+        config=EntityFirstRoutingConfig(factor=5.0),
+        flag_reader=_FLAG_ON,
+    )
+    row = _vault_row(0.5)
+
+    boost.boost([row], "tell me about something", _entity_context())
+
+    assert row.boosted_score == pytest.approx(0.5)
+
+
+def test_routed_entity_sorts_to_front() -> None:
+    """The boost re-sorts by boosted_score so a lower-base-score entity
+    summary leads a higher-base-score plain note once routed."""
+    boost = EntityFirstRoutingBoost(
+        config=EntityFirstRoutingConfig(factor=5.0),
+        flag_reader=_FLAG_ON,
+    )
+    entity = _entity_row(0.3)  # lower base score
+    vault = _vault_row(0.5)  # higher base score — leads before the boost
+
+    out = boost.boost([vault, entity], "tell me about Douglas Adams", _entity_context())
+
+    # entity 0.3 x 5 = 1.5 > vault 0.5 → entity leads after the re-sort.
+    assert out[0].path.startswith("entity://")
+    assert out[1].path == "notes/about.md"
+
+
+def test_per_row_failure_is_isolated_and_never_raises() -> None:
+    """A malformed row (no path/collection/score) is skipped, not fatal."""
+    boost = EntityFirstRoutingBoost(flag_reader=_FLAG_ON)
+
+    class _Broken:
+        path = "entity://Q1"
+        collection = "entity-summaries"
+
+        @property
+        def boosted_score(self) -> float:
+            raise RuntimeError("boom")
+
+    healthy = _entity_row(0.5)
+    out = boost.boost([_Broken(), healthy], "tell me about X", _entity_context())
+
+    assert out is not None
+    assert healthy.boosted_score == pytest.approx(1.5)  # default factor 3.0

--- a/tests/core/test_factory.py
+++ b/tests/core/test_factory.py
@@ -33,6 +33,7 @@ from kairix.core.factory import FactoryDeps, build_search_pipeline, select_boost
 from kairix.core.search.boosts import (
     ChunkDateBoost,
     EntityBoost,
+    EntityFirstRoutingBoost,
     ProceduralBoost,
     TemporalDateBoost,
 )
@@ -158,6 +159,42 @@ def test_select_boosts_all_enabled_preserves_order(fake_graph: FakeGraphReposito
         TemporalDateBoost,
         ChunkDateBoost,
     ]
+
+
+@pytest.mark.unit
+def test_select_boosts_omits_entity_first_routing_by_default(
+    fake_graph: FakeGraphRepository,
+) -> None:
+    """Default-safe (#429): the entity-first routing boost is NOT wired
+    unless ``entity_first_routing_on`` is passed True — so every existing
+    deployment's chain is byte-for-byte unchanged.
+
+    Sabotage proof: registering the boost unconditionally would put an
+    EntityFirstRoutingBoost in this chain and fail the assertion.
+    """
+    cfg = _cfg(entity=True, procedural=True, date_path=True, chunk_date=True)
+    boosts = select_boosts(cfg, fake_graph)
+    assert not any(isinstance(b, EntityFirstRoutingBoost) for b in boosts)
+
+
+@pytest.mark.unit
+def test_select_boosts_appends_entity_first_routing_when_flag_on(
+    fake_graph: FakeGraphRepository,
+) -> None:
+    """#429 Phase 2b: with the flag resolved ON at build time, the routing
+    boost is appended LAST so its multiplier composes on top of the tier
+    de-boost.
+
+    Sabotage proof: dropping the ``entity_first_routing_on`` guard, or
+    inserting the boost anywhere but last, fails this assertion.
+    """
+    cfg = _cfg(entity=True, procedural=True, date_path=True, chunk_date=True)
+    boosts = select_boosts(cfg, fake_graph, entity_first_routing_on=True)
+    assert isinstance(boosts[-1], EntityFirstRoutingBoost)
+    assert sum(isinstance(b, EntityFirstRoutingBoost) for b in boosts) == 1
+    # The boost receives the config's tunables verbatim (not a fresh default) —
+    # read via getattr so the test pins the wiring, not the attribute name.
+    assert getattr(boosts[-1], "_config", None) is cfg.entity_first_routing
 
 
 @pytest.mark.unit

--- a/tests/e2e/test_composed_entity_first_routing_enabled_path.py
+++ b/tests/e2e/test_composed_entity_first_routing_enabled_path.py
@@ -1,0 +1,132 @@
+"""F48-style composed-path E2E for entity-first routing (#429 Phase 2b).
+
+Builds on the ADR-036 entity-summary indexing E2E: a real SQLite + FTS5
+index, a real projector tick that lands an ``entity://`` chunk, then the
+real ``factory.build_search_pipeline`` + real intent classifier. The only
+injected seams are (1) a graph reporting ``available=True`` — ENTITY
+intent requires a reachable graph and CI has no live Neo4j — and (2) the
+``EntityFirstRoutingBoost`` flag driven via its ``flag_reader`` DI seam
+(the factory reads the real resolver, which can't be redirected without
+env/cwd mutation; the DI seam is the F2-clean equivalent).
+
+Two scenarios:
+
+1. **ON routes the entity first** — for "tell me about …" (ENTITY intent)
+   the projected entity summary leads the results.
+2. **OFF is a no-op** — same query, flag OFF, the plain vault note keeps
+   the top spot. Pre-#429 ranking preserved.
+
+Reuses the indexing scaffolding from the sibling entity-summary E2E so the
+real projector → SQLite → FTS path is exercised once, not re-derived.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from kairix.core.factory import (
+    FactoryDeps,
+    build_search_pipeline,
+    reset_search_pipeline_cache,
+)
+from kairix.core.search.boosts import EntityFirstRoutingBoost
+from kairix.core.search.config import EntityFirstRoutingConfig, RetrievalConfig
+from tests.e2e.test_composed_entity_summary_path import (
+    _ScriptedNeo4jForE2E,
+    _build_e2e_db,
+    _result_paths,
+    _run_projector_tick,
+    _vault_root,
+)
+from tests.fakes import (
+    FakeGraphRepository,
+    FakePaths,
+    FakeProvider,
+    FakeProviderRegistry,
+)
+
+pytestmark = pytest.mark.e2e
+
+_QUERY = "tell me about the AI policy and ethics research institute"
+_NOTE = "vault_note.md"
+# A vault note that matches the query terms so it is a genuine rival to the
+# entity summary in the candidate set.
+_NOTE_BODY = "# AI policy notes\nNotes on the AI policy and ethics research institute landscape.\n"
+_ENTITY_ROW = {
+    "name": "Ada Lovelace Institute",
+    "qid": "Q1",
+    "summary": "an AI policy and ethics research institute",
+    "prior_hash": "",
+    "summary_source": "wikidata",
+}
+
+
+def _build_routing_pipeline(*, db_path: Path, document_root: Path, flag_on: bool) -> Any:
+    """Real factory pipeline (real classifier + DB-backed BM25/vector),
+    with the entity-first routing boost driven ON / OFF via its DI seam."""
+    paths = FakePaths(
+        document_root=document_root,
+        db_path=db_path,
+        log_dir=db_path.parent / "logs",
+        workspace_root=db_path.parent / "workspaces",
+    )
+    routing = EntityFirstRoutingBoost(
+        config=EntityFirstRoutingConfig(factor=8.0),
+        flag_reader=lambda: flag_on,
+    )
+    cfg = RetrievalConfig(provider="fake")
+    registry = FakeProviderRegistry({"fake": FakeProvider(name="fake", vector=[0.1] * 1536, dim=1536)})
+    reset_search_pipeline_cache()
+    return build_search_pipeline(
+        config=cfg,
+        registry=registry,
+        paths=paths,
+        deps=FactoryDeps(
+            graph_override=FakeGraphRepository(available=True),
+            boosts_override=[routing],
+        ),
+    )
+
+
+def _seed(tmp_path: Path) -> tuple[Path, Path]:
+    """Real vault + SQLite/FTS + projected entity-summary chunk."""
+    document_root = _vault_root(tmp_path)
+    (document_root / _NOTE).write_text(_NOTE_BODY)
+    db_path = _build_e2e_db(tmp_path, {_NOTE: _NOTE_BODY})
+    neo4j = _ScriptedNeo4jForE2E([dict(_ENTITY_ROW)])
+    projected, *_ = _run_projector_tick(db_path=db_path, neo4j=neo4j, flag_on=True)
+    assert projected == 1, f"expected the projector to index 1 entity, got {projected}"
+    return db_path, document_root
+
+
+def test_composed_entity_first_routing_on_routes_entity_to_top(tmp_path: Path) -> None:
+    """Flag ON + ENTITY-intent query → the entity summary leads the results.
+
+    Sabotage-proof: drop the ``sorted(...)`` re-sort in
+    ``EntityFirstRoutingBoost.boost`` (or the append in ``select_boosts``)
+    and the entity row no longer reaches rank 1 here.
+    """
+    db_path, document_root = _seed(tmp_path)
+    pipeline = _build_routing_pipeline(db_path=db_path, document_root=document_root, flag_on=True)
+
+    result = pipeline.search(query=_QUERY, budget=3000)
+
+    paths = _result_paths(result)
+    assert paths, "composed pipeline returned no results"
+    assert paths[0].startswith("entity://"), f"entity summary not routed first: {paths}"
+
+
+def test_composed_entity_first_routing_off_keeps_note_on_top(tmp_path: Path) -> None:
+    """Flag OFF → the plain vault note keeps the top spot (byte-for-byte
+    pre-#429 ranking); the entity summary is not routed first."""
+    db_path, document_root = _seed(tmp_path)
+    pipeline = _build_routing_pipeline(db_path=db_path, document_root=document_root, flag_on=False)
+
+    result = pipeline.search(query=_QUERY, budget=3000)
+
+    paths = _result_paths(result)
+    assert paths, "composed pipeline returned no results"
+    assert not paths[0].startswith("entity://"), f"entity summary should not lead when flag OFF: {paths}"

--- a/tests/integration/test_feature_flag_entity_first_routing_enabled.py
+++ b/tests/integration/test_feature_flag_entity_first_routing_enabled.py
@@ -1,0 +1,127 @@
+"""F54 both-branch coverage for the ``entity_first_routing_enabled`` flag.
+
+Exercises the full composed pipeline — IntentClassifier → RRF fusion →
+boost chain → budget — through ``build_search_pipeline`` with the
+:class:`~kairix.core.search.boosts.EntityFirstRoutingBoost` wired to a
+:class:`FakeFeatureFlagResolver` pinned ON / OFF via the ``flag_reader``
+DI seam. Asserts the entity-summary row's *rank* changes (not just its
+score), which is the operator-visible contract:
+
+* **OFF (default)** — a plain note that out-ranks the entity summary on
+  RRF stays on top. Pre-#429 ranking preserved byte-for-byte.
+* **ON** — for an ENTITY-intent query the entity summary is routed to
+  rank 1, ahead of the higher-RRF plain note.
+
+F1/F2-clean: ``flag_reader`` is the public DI seam; no monkey-patching,
+no env-var manipulation. The F54 detector recognises the literal
+``with_flag("entity_first_routing_enabled", False)`` and ``..., True)``
+strings below; both appear in source even though only one fires per test.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kairix.core.factory import QUERY_CACHE_DISABLED, FactoryDeps, build_search_pipeline
+from kairix.core.search.boosts import EntityFirstRoutingBoost
+from kairix.core.search.config import EntityFirstRoutingConfig, RetrievalConfig
+from kairix.core.search.fusion import RRFFusion
+from kairix.core.search.intent import QueryIntent
+from tests.fakes import (
+    FakeClassifier,
+    FakeCollectionResolver,
+    FakeDocumentRepository,
+    FakeEmbeddingService,
+    FakeFeatureFlagResolver,
+    FakeGraphRepository,
+    FakePaths,
+    FakeSearchLogger,
+    FakeVectorRepository,
+)
+
+pytestmark = pytest.mark.integration
+
+_FLAG = "entity_first_routing_enabled"
+
+# A plain vault note that out-ranks the entity summary on raw RRF (higher
+# BM25 score + nearer vector distance) — so OFF leaves it on top and ON
+# has to actively route past it.
+_NOTE_PATH = "notes/about.md"
+_ENTITY_PATH = "entity://Q42"
+
+
+def _resolver(*, flag_on: bool) -> FakeFeatureFlagResolver:
+    """Pin the flag ON / OFF. Both literal branches live here so the F54
+    detector sees ``with_flag(_FLAG, False)`` and ``with_flag(_FLAG, True)``.
+    """
+    if flag_on:
+        return FakeFeatureFlagResolver().with_flag("entity_first_routing_enabled", True)
+    return FakeFeatureFlagResolver().with_flag("entity_first_routing_enabled", False)
+
+
+def _bm25_row(path: str, collection: str, score: float) -> dict:
+    return {"file": path, "title": "T", "snippet": "T", "score": score, "collection": collection}
+
+
+def _vec_row(path: str, collection: str, distance: float) -> dict:
+    return {
+        "hash_seq": "h_0",
+        "distance": distance,
+        "path": path,
+        "collection": collection,
+        "title": "T",
+        "snippet": "T",
+    }
+
+
+def _build_pipeline(*, flag_on: bool, intent: QueryIntent = QueryIntent.ENTITY):
+    resolver = _resolver(flag_on=flag_on)
+    routing = EntityFirstRoutingBoost(
+        config=EntityFirstRoutingConfig(factor=5.0),
+        flag_reader=lambda: resolver.get(_FLAG),
+    )
+    # Plain note leads on RRF (rank 1 in both lists); entity summary trails.
+    bm25 = [_bm25_row(_NOTE_PATH, "vault", 2.0), _bm25_row(_ENTITY_PATH, "entity-summaries", 1.0)]
+    vec = [_vec_row(_NOTE_PATH, "vault", 0.1), _vec_row(_ENTITY_PATH, "entity-summaries", 0.2)]
+    return build_search_pipeline(
+        config=RetrievalConfig.minimal(),
+        paths=FakePaths(),
+        deps=FactoryDeps(
+            classifier_override=FakeClassifier(intent=intent),
+            doc_repo_override=FakeDocumentRepository(bm25_rows=bm25),
+            embed_service_override=FakeEmbeddingService(),
+            vec_repo_override=FakeVectorRepository(results=vec),
+            graph_override=FakeGraphRepository(available=True),
+            fusion_override=RRFFusion(k=60),
+            boosts_override=[routing],
+            logger_override=FakeSearchLogger(),
+            resolver_override=FakeCollectionResolver(),
+            query_cache_override=QUERY_CACHE_DISABLED,
+        ),
+    )
+
+
+def _top_path(result) -> str:
+    assert result.results, "pipeline returned no results"
+    return result.results[0].result.path
+
+
+def test_on_branch_routes_entity_summary_to_rank_one() -> None:
+    """ON — the entity summary is routed ahead of the higher-RRF note."""
+    pipe = _build_pipeline(flag_on=True)
+    result = pipe.search("tell me about the Australian software company")
+    assert _top_path(result).startswith("entity://")
+
+
+def test_off_branch_leaves_higher_rrf_note_on_top() -> None:
+    """OFF — pre-#429 ranking: the plain note keeps rank 1."""
+    pipe = _build_pipeline(flag_on=False)
+    result = pipe.search("tell me about the Australian software company")
+    assert _top_path(result) == _NOTE_PATH
+
+
+def test_on_branch_does_not_route_for_non_entity_intent() -> None:
+    """ON + KEYWORD intent — the intent gate keeps the note on top."""
+    pipe = _build_pipeline(flag_on=True, intent=QueryIntent.KEYWORD)
+    result = pipe.search("australian software company")
+    assert _top_path(result) == _NOTE_PATH


### PR DESCRIPTION
## What

Entity-first routing for `QueryIntent.ENTITY` queries ("tell me about X", "who is X"): lift the `entity-summaries` collection (the ADR-036 projector's `entity://` chunks, tier `reference` ×0.6) to the top of results, instead of leaving the entity's summary de-prioritised below documents.

Closes the routing half of **#429** (Phase 2b). The indexing half (#429 Phase 2a) already shipped via the ADR-036 projector; this makes those summaries *lead* for entity-named queries.

## How

- **`EntityFirstRoutingBoost`** (`kairix/core/search/boosts.py`) — intent-gated on `QueryIntent.ENTITY`, gated on a new `entity_first_routing_enabled` feature flag (read live via a `flag_reader` DI seam, mirroring `intent_confidence_gated_boosts`). Multiplies entity-summary `boosted_score` by `EntityFirstRoutingConfig.factor` and re-sorts. Registered **last** in `select_boosts` so it composes on top of the tier de-boost.
- **Default-safe.** Flag OFF (the default) is a byte-for-byte no-op: `select_boosts` only wires the boost when the flag resolves ON at build time, and the boost self-gates at query time so an operator can roll the cutover back instantly without a rebuild.
- **New `FeatureFlag` `entity_first_routing_enabled`** (default OFF, `target_retire_in v2026.12.1`, `related_spec` → ADR-036). Composes with — does not duplicate — the existing CLI `[Wikidata]` badge + MCP `entity_summary` envelope flag.

### Plan note
The saved plan described 2b as "gated on ENTITY intent". Per CLAUDE.md the feature-flag pattern is **mandatory for ranker swaps**, so this adds a registry feature flag (with the full F54 set) rather than an intent-gate alone — a discipline addition, not a behaviour change.

## Tests
- F54 both-branch: OFF+ON BDD scenarios, both-branch integration test (ranking order through the real factory pipeline), E2E composed-path test.
- Boost-behaviour + factory-registration unit tests, sabotage-proven. All six mutation-parity mutants on the diff are killed.
- Full local `safe-commit` green: lint, format, mypy, 10237 tests / 95.77% coverage, mutation parity, secrets/confidential, Sonar ratchet.

## Follow-up (not in this PR)
Phase 2c — entity-category NDCG@10 measurement against the now-fixed eval loop (#552/#554) — needs a corpus with indexed entity summaries and is tracked on #429. The production flag-flip is #463.

🤖 Generated with [Claude Code](https://claude.com/claude-code)