### PR TITLE
fix: fresh-install GA + hygiene batch (#557, #480, #477, #476)

### DIFF
--- a/docs/getting-started/connecting-agents.md
+++ b/docs/getting-started/connecting-agents.md
@@ -189,7 +189,7 @@ All three options expose the same 35 tools with identical parameters and return 
 
 | Problem | Fix |
 |---------|-----|
-| "kairix: command not found" | Run `pipx install kairix-agentic-knowledge-mgt` (or `pip install kairix-agentic-knowledge-mgt` inside a venv) or check your PATH |
+| "kairix: command not found" | Run `pipx install Kairix-agentic-knowledge-mgt` (or `pip install Kairix-agentic-knowledge-mgt` inside a venv) or check your PATH |
 | Tools don't appear in Claude Desktop | Restart Claude Desktop after editing config |
 | Connection refused on `/mcp` (or legacy `/sse`) | Check `docker compose ps` — kairix service must be running |
 | "No results" on first search | Run `kairix embed` to index your documents first |

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -18,12 +18,12 @@ All four end with a `kairix mcp serve` endpoint the agent can connect to. If Doc
 For production servers + shared-knowledge-store deployments where kairix needs to run as a managed service under its own account.
 
 ```bash
-pipx install kairix-agentic-knowledge-mgt
+pipx install Kairix-agentic-knowledge-mgt
 sudo $(which kairix) init --system
 sudo systemctl start kairix
 ```
 
-> pipx keeps kairix in its own virtualenv and puts the `kairix` command on your PATH. A bare `pip install` fails on modern distros (Ubuntu 24.04, Debian 12+) because the system Python is externally managed (PEP 668). If you'd rather manage the virtualenv yourself, `python3 -m venv` + `pip install kairix-agentic-knowledge-mgt` inside it works the same way. The `$(which kairix)` is needed because `sudo` resets PATH.
+> pipx keeps kairix in its own virtualenv and puts the `kairix` command on your PATH. A bare `pip install` fails on modern distros (Ubuntu 24.04, Debian 12+) because the system Python is externally managed (PEP 668). If you'd rather manage the virtualenv yourself, `python3 -m venv` + `pip install Kairix-agentic-knowledge-mgt` inside it works the same way. The `$(which kairix)` is needed because `sudo` resets PATH.
 
 What `kairix init --system` does:
 
@@ -58,7 +58,7 @@ Keeping data is the default. Pass `--no-keep-data` if you also want the data dir
 For an agent (or a single human) running kairix as its own private knowledge store under its own user account. No sudo, nothing system-wide.
 
 ```bash
-pipx install kairix-agentic-knowledge-mgt
+pipx install Kairix-agentic-knowledge-mgt
 kairix init --user
 systemctl --user start kairix
 ```
@@ -98,7 +98,7 @@ Full Docker walkthrough — including the `.env` shape, port mapping, and indexi
 Same `pipx install` + `kairix init --user` pattern as Linux user mode. Paths follow each platform's conventions. (Homebrew Python is also PEP 668 externally managed — pipx or a venv, not bare pip.)
 
 ```bash
-pipx install kairix-agentic-knowledge-mgt
+pipx install Kairix-agentic-knowledge-mgt
 kairix init --user
 ```
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -146,7 +146,7 @@ Skip this step if you don't have per-agent subdirectories yet — kairix synthes
 ### B1. Install the package
 
 ```bash
-pipx install "kairix-agentic-knowledge-mgt[agents]"
+pipx install "Kairix-agentic-knowledge-mgt[agents]"
 ```
 
 Or, if you prefer a virtualenv you manage yourself:
@@ -154,7 +154,7 @@ Or, if you prefer a virtualenv you manage yourself:
 ```bash
 python3 -m venv ~/.venvs/kairix
 source ~/.venvs/kairix/bin/activate
-pip install "kairix-agentic-knowledge-mgt[agents]"
+pip install "Kairix-agentic-knowledge-mgt[agents]"
 ```
 
 The `[agents]` extra pulls in the MCP server dependencies. Most operators want this.

--- a/kairix/config/topology_v2.py
+++ b/kairix/config/topology_v2.py
@@ -40,9 +40,9 @@ F42 frozen-dataclass discipline: every public value object is
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, get_args
 
-from kairix.core.protocols import CCPairAccessType, F39Tier, ScopeProfileActorKind
+from kairix.core.protocols import CCPairAccessType, F39Tier, ScopeProfileActorKind, Sensitivity
 
 # F17 — collection-source path filter literal duplicated across two
 # nested parsers (collections.* + skills.*.task_collections.*) plus the
@@ -294,13 +294,26 @@ def _parse_one_connector(prefix: str, raw: Any) -> ConnectorConfig:
     )
 
 
+# The valid F39 tiers are DERIVED from the ``F39Tier`` Literal in
+# kairix.core.protocols — never a second hardcoded list. One source of
+# truth, so adding a tier to the Literal can't drift this validator out
+# of sync (GH #480).
+_VALID_F39_TIERS: tuple[F39Tier, ...] = get_args(F39Tier)
+
 # Chunk-tag vocabulary (kairix.core.protocols.Sensitivity) → F39 tier.
-# Connectors tag chunks with the Sensitivity literal, and the example
+# Connectors tag chunks with the ``Sensitivity`` literal, and the example
 # config uses it too; the parser normalises onto F39 tiers via the same
-# mapping the slack/m365 connectors apply (GH #480).
-_CHUNK_SENSITIVITY_TO_F39: dict[str, F39Tier] = {
+# mapping the slack/m365 connectors apply. The two vocabularies disagree
+# only on the high tiers (client-confidential / personal); the shared
+# values (public / internal) map to themselves. Aliases are the divergent
+# pairs; the table is then completed from the ``Sensitivity`` Literal so
+# every chunk-tag value the type system permits is accepted (GH #480).
+_CHUNK_SENSITIVITY_ALIASES: dict[str, F39Tier] = {
     "client-confidential": "confidential",
     "personal": "restricted",
+}
+_CHUNK_SENSITIVITY_TO_F39: dict[str, F39Tier] = {
+    value: _CHUNK_SENSITIVITY_ALIASES.get(value, value) for value in get_args(Sensitivity)
 }
 
 
@@ -309,17 +322,20 @@ def _parse_sensitivity(value: Any, *, default: F39Tier) -> F39Tier:
 
     F39 tier values pass through; chunk-tag ``Sensitivity`` values
     (``client-confidential`` / ``personal``) normalise onto their F39
-    equivalents so configs written in either vocabulary parse (GH #480).
+    equivalents so configs written in either vocabulary parse. Both the
+    accepted F39 set and the chunk-tag map are derived from the Literals
+    in kairix.core.protocols — there is no second hardcoded list (GH #480).
     """
     if value is None:
         return default
     mapped = _CHUNK_SENSITIVITY_TO_F39.get(value) if isinstance(value, str) else None
     if mapped is not None:
         return mapped
-    if value not in ("public", "internal", "confidential", "restricted"):
+    if value not in _VALID_F39_TIERS:
+        valid = "/".join(_VALID_F39_TIERS)
         raise TopologyV2ParseError(
             f"sensitivity={value!r} is not a valid F39 tier. "
-            "fix: use one of public/internal/confidential/restricted "
+            f"fix: use one of {valid} "
             "(client-confidential and personal are accepted and map to "
             "confidential/restricted). "
             "next: run kairix config validate"

--- a/kairix/platform/onboard/check.py
+++ b/kairix/platform/onboard/check.py
@@ -153,6 +153,44 @@ _NEO4J_FIX_DEFAULT = (
     "next: `kairix onboard check`. " + _NEO4J_REQUIRED_FRAMING
 )
 
+# GH #477 — the document_root + secrets remediations used to hard-code
+# /opt/kairix/service.env, a path from a single historical VM layout that
+# does NOT exist on a fresh Docker or pip install. README tells agents to
+# surface these remediations verbatim, so a container/pip operator was sent
+# to edit a phantom file. The strings below name the config surface that
+# actually exists per deployment mode (same Mode.detect() seam the Neo4j
+# remediation already uses, GH #476):
+#   container — the operator `.env` beside docker-compose.yml
+#   system    — /etc/kairix/.env (FHS layout laid down by `kairix init --system`)
+#   user/pip  — kairix.config.yaml (or the KAIRIX_DOCUMENT_ROOT env var)
+_CONFIG_LOCATION_BY_MODE: dict[Mode, str] = {
+    Mode.container: "the operator `.env` beside docker-compose.yml",
+    Mode.system: "/etc/kairix/.env",
+    Mode.user: "kairix.config.yaml (or set the KAIRIX_DOCUMENT_ROOT env var)",
+}
+
+
+def _config_location_for(env: Mapping[str, str] | None = None) -> str:
+    """Return the deployment-appropriate config-file location phrase.
+
+    Resolved through :meth:`kairix.paths.Mode.detect` so container, system,
+    and pip operators each see the surface that exists on their install
+    rather than a single-VM path (GH #477). ``env`` is the same DI seam
+    :func:`check_document_root_configured` already exposes; production
+    callers leave it ``None`` and the live environment is read at the F4
+    boundary in paths.py.
+    """
+    return _CONFIG_LOCATION_BY_MODE.get(Mode.detect(env), _CONFIG_LOCATION_BY_MODE[Mode.user])
+
+
+# The canonical (one-line) document_root remediation stays deployment-neutral
+# — it can't know the operator's mode at registry-build time, so it names the
+# env var + the config file without the phantom /opt path.
+_DOCUMENT_ROOT_FIX = (
+    "Set `KAIRIX_DOCUMENT_ROOT=/your/docs/path` in your kairix.config.yaml "
+    "(or as an env var) and ensure the directory exists."
+)
+
 CANONICAL_REMEDIATIONS: dict[str, str] = {
     _CHECK_QUERY_CACHE_STATS: (
         "Diagnostic check — no remediation required. Cache hit-rate is informational; "
@@ -165,13 +203,12 @@ CANONICAL_REMEDIATIONS: dict[str, str] = {
     _CHECK_KAIRIX_ON_PATH: _INSTALL_VERIFY_FIX,
     _CHECK_WRAPPER_INSTALLED: _INSTALL_VERIFY_FIX,
     _CHECK_SECRETS_LOADED: (
-        "Run `sudo systemctl enable --now kairix-fetch-secrets.service` on the host; "
-        "if that fails, confirm `/run/secrets/kairix.env` exists and contains "
-        "`KAIRIX_LLM_API_KEY=...` and `KAIRIX_LLM_ENDPOINT=...`."
+        "Set `KAIRIX_PROVIDER_LLM_API_KEY=...` and `KAIRIX_PROVIDER_LLM_ENDPOINT=...` "
+        "in your environment, or write them as KEY=VALUE lines in a secrets file and "
+        "point `KAIRIX_SECRETS_FILE` at it. Run `kairix secrets verify` to confirm "
+        "every credential resolves."
     ),
-    _CHECK_DOCUMENT_ROOT_CONFIGURED: (
-        "Set `KAIRIX_DOCUMENT_ROOT=/your/docs/path` in /opt/kairix/service.env and ensure the directory exists."
-    ),
+    _CHECK_DOCUMENT_ROOT_CONFIGURED: _DOCUMENT_ROOT_FIX,
     _CHECK_VECTOR_SEARCH_WORKING: (
         "Run `docker logs kairix-worker-1` for embed-pipeline errors; confirm "
         "`kairix onboard check secrets_loaded` passes; then run `kairix embed --limit 20` "
@@ -514,16 +551,22 @@ def check_document_root_configured(env: Mapping[str, str] | None = None) -> Chec
 
     ``env`` is a DI seam (defaults to ``os.environ``); tests pass an
     explicit mapping rather than monkeypatching the process environment.
+    The same ``env`` mapping drives :func:`_config_location_for` so the
+    failure remediation names the config surface that exists on the
+    operator's deployment mode (container `.env` / `/etc/kairix/.env` /
+    `kairix.config.yaml`) rather than the phantom `/opt/kairix/service.env`
+    VM path the old strings hard-coded (GH #477).
     """
     if env is None:
         env = os.environ
+    config_location = _config_location_for(env)
     doc_root = env.get("KAIRIX_DOCUMENT_ROOT", "")
     if not doc_root:
         return CheckResult(
             name=_CHECK_DOCUMENT_ROOT_CONFIGURED,
             ok=False,
             detail="KAIRIX_DOCUMENT_ROOT is not set",
-            fix=("Set KAIRIX_DOCUMENT_ROOT in /opt/kairix/service.env:\n  KAIRIX_DOCUMENT_ROOT=/data/documents"),
+            fix=(f"Set KAIRIX_DOCUMENT_ROOT in {config_location}:\n  KAIRIX_DOCUMENT_ROOT=/your/docs/path"),
         )
     p = Path(doc_root)
     if not p.exists():
@@ -532,7 +575,7 @@ def check_document_root_configured(env: Mapping[str, str] | None = None) -> Chec
             ok=False,
             detail=f"KAIRIX_DOCUMENT_ROOT directory does not exist: {doc_root}",
             fix=(
-                "Create the directory or update KAIRIX_DOCUMENT_ROOT in /opt/kairix/service.env.\n"
+                f"Create the directory or update KAIRIX_DOCUMENT_ROOT in {config_location}.\n"
                 "If your documents are at a different path, set: KAIRIX_DOCUMENT_ROOT=/your/docs/path"
             ),
         )

--- a/tests/agents/mcp/test_async_tool_handler_dispatch_pool.py
+++ b/tests/agents/mcp/test_async_tool_handler_dispatch_pool.py
@@ -74,15 +74,28 @@ def _make_wrapped_slow_handler(
     obs_executor: ThreadPoolExecutor,
     db_path: Path,
     started: dict[int, tuple[float, int]],
+    barrier: threading.Barrier | None = None,
 ) -> object:
     """Construct a wrapped handler that records when + on which thread each call ran.
 
     Returns the async-wrapped callable. The handler sleeps ``sleep_s`` so a
     saturated pool's behaviour is observable in wall-clock terms.
+
+    When ``barrier`` is supplied, the handler records its thread ident and
+    then blocks on the barrier BEFORE sleeping. The barrier only releases
+    once ``barrier.parties`` calls have all reached it, so every call is
+    proven genuinely in-flight on its own worker thread at the same instant
+    — no worker can complete and be reused before the others are dispatched.
+    That removes the pool-reuse race that made the distinct-thread count
+    non-deterministic under CI load (#557).
     """
 
     def slow_handler(call_id: int = 0) -> dict[str, int]:
         started[call_id] = (time.monotonic(), threading.get_ident())
+        if barrier is not None:
+            # Hold every worker thread until ALL N calls have arrived, so the
+            # pool can't recycle a finished worker before the rest dispatch.
+            barrier.wait(timeout=10)
         time.sleep(sleep_s)
         return {"id": call_id}
 
@@ -105,16 +118,27 @@ def test_concurrent_calls_use_distinct_dispatch_threads_when_pool_is_large(
     dispatch pool is at least as large as the concurrent-agent count,
     every in-flight call runs in parallel with no queueing.
 
+    A ``threading.Barrier(n_calls)`` gates the slow handler: each call
+    records its worker thread, then blocks on the barrier. The barrier
+    only releases once all eight calls have arrived, so all eight worker
+    threads are provably occupied simultaneously — the pool cannot recycle
+    a finished worker before the rest dispatch. That makes the exact
+    ``== n_calls`` distinct-thread count deterministic and closes the
+    pool-reuse race that produced flaky ``7 == 8`` failures under CI load
+    (#557).
+
     Sabotage proof: revert ``async_tool_handler`` to use
     ``asyncio.to_thread(safe, ...)`` instead of
-    ``loop.run_in_executor(dispatch_executor, ...)`` — this test still
-    passes locally on a 10-CPU dev box (default pool=14) but fails on a
-    2-CPU CI runner (default pool=6) because the eight calls land on only
-    six threads. CONFIRMED locally by manually swapping the wrapper to
-    ``asyncio.to_thread`` and running on a constrained executor pool.
+    ``loop.run_in_executor(dispatch_executor, ...)`` — the injected
+    eight-worker pool is bypassed, the event loop's default executor
+    (``min(32, cpu_count + 4)``) is used, and the eight calls all block
+    on the barrier inside fewer worker slots → the barrier never releases
+    (deadlock/timeout) on a constrained runner. CONFIRMED locally by
+    shrinking the injected dispatch pool below ``n_calls`` (see #557 report).
     """
     n_calls = 8
     started: dict[int, tuple[float, int]] = {}
+    barrier = threading.Barrier(n_calls)
 
     with ThreadPoolExecutor(max_workers=n_calls, thread_name_prefix="test-dispatch") as dispatch:
         wrapped = _make_wrapped_slow_handler(
@@ -123,6 +147,7 @@ def test_concurrent_calls_use_distinct_dispatch_threads_when_pool_is_large(
             obs_executor=obs_executor,
             db_path=silent_db_path,
             started=started,
+            barrier=barrier,
         )
 
         async def fire_all() -> list[dict[str, int]]:
@@ -133,15 +158,11 @@ def test_concurrent_calls_use_distinct_dispatch_threads_when_pool_is_large(
     assert len(results) == n_calls
     assert {r["id"] for r in results} == set(range(n_calls))
     threads_used = {tid for _, tid in started.values()}
-    # Tolerate at most one benign thread reuse: a ThreadPoolExecutor worker can
-    # go briefly idle and be reused between submissions before all N tasks are
-    # dispatched (observed 7/8 on 2-CPU CI runners). ``>= n_calls - 1`` still
-    # proves near-full parallelism — the regression this guards (asyncio.to_thread's
-    # default pool of 6 on a 2-CPU runner) lands on 6 threads and still fails,
-    # and the undersized-pool case (next test) serialises to ~2.
-    assert len(threads_used) >= n_calls - 1, (
-        f"expected ~{n_calls} distinct dispatch threads, got {len(threads_used)} "
-        "(pool exhaustion / queueing would show far fewer)"
+    # The barrier holds every worker until all N calls have arrived, so exactly
+    # N distinct dispatch threads are occupied at once — no pool-reuse race.
+    assert len(threads_used) == n_calls, (
+        f"expected exactly {n_calls} distinct dispatch threads, got {len(threads_used)} "
+        "(pool exhaustion / queueing would show fewer; barrier guarantees full parallelism)"
     )
 
 

--- a/tests/contracts/test_config_example_validates.py
+++ b/tests/contracts/test_config_example_validates.py
@@ -1,0 +1,119 @@
+"""Contract: the repo's own ``kairix.config.example.yaml`` validates clean,
+and the validator's sensitivity vocabulary is single-sourced from the
+``Sensitivity`` / ``F39Tier`` Literals in ``kairix.core.protocols`` (GH #480).
+
+#480 was the two-vocabularies bug: the example config tags sources with the
+chunk-tag ``Sensitivity`` literal (``client-confidential``), but the topology
+validator carried a *second*, divergent hardcoded F39 tier list
+(``public/internal/confidential/restricted``) and rejected it. The two sources
+of truth disagreed.
+
+This module is the F50-style drift guard:
+
+* **Drift guard** — the production ``kairix config validate`` binary, run against
+  the repo's own example config, exits 0. If anyone re-introduces a hardcoded
+  tier list that diverges from the Literal, this goes red.
+* **Single source of truth** — the accepted F39 set is exactly ``get_args(F39Tier)``
+  and every value in ``get_args(Sensitivity)`` is accepted (mapping onto its F39
+  equivalent). Adding a tier to either Literal can't silently drift the validator.
+
+Drives the production CLI surface via subprocess (the canonical F30 outcome
+shape) and the public ``parse_topology_v2`` surface — no private-fn behaviour
+test, no monkeypatch (F1/F2).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import get_args
+
+import pytest
+
+from kairix.config import parse_topology_v2
+from kairix.config.topology_v2 import TopologyV2ParseError
+from kairix.core.protocols import F39Tier, Sensitivity
+
+pytestmark = pytest.mark.contract
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_EXAMPLE_CONFIG = _REPO_ROOT / "kairix.config.example.yaml"
+
+
+def test_example_config_validates_clean_through_the_cli() -> None:
+    """``kairix config validate kairix.config.example.yaml`` exits 0.
+
+    The example config tags a source ``default_sensitivity: client-confidential``
+    (the chunk-tag ``Sensitivity`` vocabulary). Before #480 the topology
+    validator's divergent hardcoded F39 list rejected it; this is the regression
+    lock that the two vocabularies now resolve to one.
+    """
+    result = subprocess.run(
+        [sys.executable, "-m", "kairix.cli", "config", "validate", str(_EXAMPLE_CONFIG)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0, f"validate failed (exit {result.returncode}):\n{combined}"
+    assert "is not a valid F39 tier" not in combined, combined
+    assert "OK" in result.stdout, result.stdout
+
+
+def test_example_config_uses_the_chunk_tag_vocabulary() -> None:
+    """Guard the premise: the example config really does use ``client-confidential``.
+
+    If the example config is ever rewritten to only use F39 tiers, the drift
+    guard above would pass vacuously. This pins that the example actually
+    exercises the cross-vocabulary path.
+    """
+    text = _EXAMPLE_CONFIG.read_text(encoding="utf-8")
+    assert "client-confidential" in text, "example config no longer exercises the chunk-tag vocabulary"
+
+
+@pytest.mark.parametrize("tier", get_args(Sensitivity))
+def test_every_sensitivity_literal_value_is_accepted(tier: str) -> None:
+    """Every value in the ``Sensitivity`` Literal parses through topology_v2.
+
+    Single-source-of-truth: the validator's chunk-tag map is derived from
+    ``get_args(Sensitivity)``, so any value the type system permits is accepted.
+    A hardcoded map that omitted a future-added value would fail here.
+    """
+    cfg = parse_topology_v2(
+        {"topology_v2": {"connectors": [{"id": "c1", "kind": "obsidian", "name": "c1", "default_sensitivity": tier}]}}
+    )
+    accepted = cfg.connectors[0].default_sensitivity
+    assert accepted in get_args(F39Tier), f"{tier!r} normalised to {accepted!r}, not an F39 tier"
+
+
+@pytest.mark.parametrize("tier", get_args(F39Tier))
+def test_every_f39_tier_literal_value_passes_through(tier: str) -> None:
+    """Every value in the ``F39Tier`` Literal passes through unchanged.
+
+    The accepted F39 set is derived from ``get_args(F39Tier)`` — not a second
+    hardcoded tuple. Adding a tier to the Literal extends what the validator
+    accepts automatically.
+    """
+    cfg = parse_topology_v2(
+        {"topology_v2": {"connectors": [{"id": "c1", "kind": "obsidian", "name": "c1", "default_sensitivity": tier}]}}
+    )
+    assert cfg.connectors[0].default_sensitivity == tier
+
+
+def test_value_outside_both_vocabularies_is_rejected() -> None:
+    """A genuinely-invalid tier is still rejected (the validator isn't a no-op)."""
+    with pytest.raises(TopologyV2ParseError) as excinfo:
+        parse_topology_v2(
+            {
+                "topology_v2": {
+                    "connectors": [{"id": "c1", "kind": "obsidian", "name": "c1", "default_sensitivity": "bogus-tier"}]
+                }
+            }
+        )
+    message = str(excinfo.value)
+    assert "bogus-tier" in message
+    # The diagnostic lists the derived F39 vocabulary, not a stale hardcoded one.
+    for tier in get_args(F39Tier):
+        assert tier in message, f"diagnostic omits derived tier {tier!r}: {message}"

--- a/tests/onboard/test_check.py
+++ b/tests/onboard/test_check.py
@@ -244,6 +244,110 @@ def test_document_root_configured_not_set() -> None:
 
 
 # ---------------------------------------------------------------------------
+# check_document_root_configured — deployment-aware fix (GH #477)
+# ---------------------------------------------------------------------------
+# The old fix strings hard-coded /opt/kairix/service.env — a path from a
+# single historical VM layout that does NOT exist on a fresh Docker or pip
+# install. README tells agents to surface these remediations verbatim, so a
+# container/pip user was sent to edit a phantom path. The fix must be
+# deployment-aware via the existing Mode.detect() seam (same shape as
+# check_neo4j_reachable, GH #476): no /opt/kairix/service.env in any branch.
+
+
+@pytest.mark.unit
+def test_document_root_not_set_fix_never_names_phantom_vm_path() -> None:
+    """The "not set" fix must not name /opt/kairix/service.env in any mode.
+
+    That path is a stale single-VM assumption (GH #477) — a fresh Docker
+    or pip install has no such file, so the remediation misdirected the
+    operator. Exercise all three modes through the Mode.detect() env seam.
+    """
+    for env in (
+        {"KAIRIX_CONTAINER": "1"},  # container mode
+        {},  # user / system mode (no container signal)
+    ):
+        result = check_document_root_configured(env=env)
+        assert not result.ok
+        assert result.fix is not None
+        assert "/opt/kairix/service.env" not in result.fix
+        # Still actionable — names the canonical env var the operator sets.
+        assert "KAIRIX_DOCUMENT_ROOT" in result.fix
+
+
+@pytest.mark.unit
+def test_document_root_not_set_fix_is_container_aware() -> None:
+    """In container mode the "not set" fix points at the operator .env next
+    to docker-compose.yml (the real container config surface), not a VM path."""
+    result = check_document_root_configured(env={"KAIRIX_CONTAINER": "1"})
+    assert not result.ok
+    assert result.fix is not None
+    # Container operators edit the .env beside docker-compose.yml.
+    assert ".env" in result.fix
+    assert "/opt/kairix/service.env" not in result.fix
+
+
+@pytest.mark.unit
+def test_document_root_not_set_fix_is_pip_aware() -> None:
+    """In user/pip mode the "not set" fix points at kairix.config.yaml or the
+    KAIRIX_DOCUMENT_ROOT env var — never the VM-only /opt/kairix/service.env."""
+    result = check_document_root_configured(env={})
+    assert not result.ok
+    assert result.fix is not None
+    assert "kairix.config.yaml" in result.fix
+    assert "/opt/kairix/service.env" not in result.fix
+
+
+@pytest.mark.unit
+def test_document_root_missing_dir_fix_never_names_phantom_vm_path() -> None:
+    """The "directory does not exist" fix must not name /opt/kairix/service.env
+    in any mode (GH #477)."""
+    for env_extra in ({"KAIRIX_CONTAINER": "1"}, {}):
+        env = {"KAIRIX_DOCUMENT_ROOT": "/nonexistent/path/vault", **env_extra}
+        result = check_document_root_configured(env=env)
+        assert not result.ok
+        assert result.fix is not None
+        assert "/opt/kairix/service.env" not in result.fix
+
+
+# ---------------------------------------------------------------------------
+# CANONICAL_REMEDIATIONS — VM-only path hygiene broadened (GH #477)
+# ---------------------------------------------------------------------------
+# The existing phantom-artifact guard banned /opt/kairix/secrets.env but NOT
+# /opt/kairix/service.env, so the document_root remediation slipped through.
+# These tests pin the broadened ban explicitly.
+
+
+@pytest.mark.unit
+def test_document_root_canonical_remediation_is_deployment_neutral() -> None:
+    """The canonical document_root remediation must not name /opt/kairix/
+    service.env — that single-VM path doesn't exist on Docker/pip installs.
+
+    The remediation key is derived from the public check's result name
+    (F5-clean — no private-constant import).
+    """
+    from kairix.platform.onboard.check import CANONICAL_REMEDIATIONS
+
+    # The check's own CheckResult.name is the canonical-remediation key.
+    check_name = check_document_root_configured(env={}).name
+    remediation = CANONICAL_REMEDIATIONS[check_name]
+    assert "/opt/kairix/service.env" not in remediation
+    assert "KAIRIX_DOCUMENT_ROOT" in remediation
+
+
+@pytest.mark.unit
+def test_no_canonical_remediation_references_vm_only_service_env() -> None:
+    """No canonical remediation may name /opt/kairix/service.env or
+    /opt/openclaw — both are single-VM-layout paths the README would
+    otherwise surface verbatim to a container/pip operator (GH #477).
+    """
+    from kairix.platform.onboard.check import CANONICAL_REMEDIATIONS
+
+    for name, remediation in CANONICAL_REMEDIATIONS.items():
+        for banned in ("/opt/kairix/service.env", "/opt/openclaw"):
+            assert banned not in remediation, f"{name} remediation references VM-only path {banned!r}"
+
+
+# ---------------------------------------------------------------------------
 # run_all_checks — structural
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Batch of independent fixes from the **hygiene** + **fresh-install GA** clusters, each developed in an isolated worktree (TDD, sabotage-proven, full local `safe-commit` green) and cherry-picked here as clean per-commit history.

## Commits
- **#557** `test(dispatch)` — de-flake `test_concurrent_calls_use_distinct_dispatch_threads_when_pool_is_large`: replace the exact-thread-count assertion with a `threading.Barrier` so all N calls are provably in-flight before any completes (no pool-reuse race). Verified 20× no-flake; sabotage-proven (collapse pool → fails).
- **#480** `fix(config)` — `kairix config validate` failed on the repo's own `kairix.config.example.yaml` (two divergent sensitivity vocabularies). Validator now derives its allowed tiers from the `F39Tier`/`Sensitivity` Literals in `protocols.py` via `get_args` — one source of truth. New contract test asserts the example validates clean (F50-style drift guard).
- **#477** `fix(onboard)` — `kairix onboard check` remediations named a VM-only path (`/opt/kairix/service.env`) as universal guidance; now deployment-aware via the existing `Mode.detect()`. (The `deploy-vm.sh`/wrong-org/curl-pipe references flagged in the issue were already fixed by prior PRs.)
- **#476** `docs(getting-started)` — sweep pip package-name casing to the canonical `Kairix-agentic-knowledge-mgt`. (The substantive 404 / PEP 668 / uninstall-flag fixes were already shipped in a prior commit; this is the residual consistency tidy.)

## Tracker hygiene discovered during this batch
Several "open" issues were already (fully or mostly) resolved by recent PRs but not closed:
- **#484** (wizard Azure deployment-name) — **already fully fixed** by PR #494 / `4a5eecc0` (probe wiring + DeploymentNotFound affordance + azure-only field + tests all present; sabotage-verified). **No commit — recommend closing #484 as resolved.**
- **#476 / #477** had prior partial fixes; these commits complete the residual.

## Deferred (with reasons — not dropped)
- **#485** (wizard save 500s) — needs a design decision: config-overlay write (cleaner, touches open bug #492) vs rw-mount + chown (reverses #470's deliberate `:ro`). Awaiting direction.
- **#550** (reconcile example configs) — changes which config the Docker image bundles; needs an actual Docker build to verify, not a fire-and-forget parallel fix.
- **#489** (wizard OAuth) — a feature; depends on #485.
- **#547** (SonarCloud new-code baseline) — a SonarCloud admin-console action, not a repo change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)