### PR TITLE
feat(linear): Linear source connector (MVP — incremental poll, default OFF)

### DIFF
--- a/docs/architecture/connector-scope-topology/connector-design-specs/linear.md
+++ b/docs/architecture/connector-scope-topology/connector-design-specs/linear.md
@@ -115,20 +115,31 @@ reasonable later generalisation — noted, not built here.)
 
 `list_changes(cursor: Cursor | None) -> Iterator[ChangeEvent]`:
 
-- **Cursor** = an ISO-8601 `updatedAt` high-water-mark (the max `updatedAt` across all entity types
-  seen on the last clean drain). `Cursor = str` (opaque token; §1 protocols).
-- Each tick queries the five entity types for `updatedAt > cursor`, paginated, yielding
+- **Cursor** = an opaque `str` token (`Cursor = str`; §1 protocols) that **JSON-encodes a
+  per-entity-type `updatedAt` watermark map** — `{ "issue": "<iso>", "project": "<iso>",
+  "document": "<iso>", "initiative": "<iso>", "projectUpdate": "<iso>" }`. A single shared
+  high-water-mark would **starve / skip** types under per-tick-budget pressure: with one watermark,
+  a tick that fills the budget on issues advances the shared mark past un-drained project/doc items
+  in the window, permanently skipping them (and can livelock issues vs. the rest). Per-type
+  watermarks make each type's progress independent.
+- Each tick queries the five types for `updatedAt > <that type's watermark>`, paginated, yielding
   `ChangeEvent(op, item_id, modified_at, parent_id?, metadata)`. `op` is `modified` for
   create/update; `SlimConnector` enumeration detects `archived`/`deleted` (id present last tick,
   absent now).
 - **`item_id` is type-prefixed** — `issue:<identifier>`, `project:<uuid>`, `document:<uuid>`,
   `initiative:<uuid>`, `projectUpdate:<uuid>` — so `fetch` / `metadata_for` / `source_link`
   dispatch by type without a second lookup.
-- `cursor is None` → full enumeration (initial sync).
-- `next_cursor()` returns the new high-water-mark; it **advances only on a clean drain** (at-least-once
-  delivery + idempotent chunk upsert means a re-fetched item is harmless).
-- Honours `per_tick_max_items` (default 500) and `disk_watermark_min_free_bytes` (F66) — the tick
-  stops early and resumes next tick rather than blowing the budget.
+- `cursor is None` → full enumeration (initial sync). A **malformed / legacy single-string** token
+  decodes to "no watermark for any type" → full enumeration, so existing operator state degrades
+  safely (re-syncs) rather than skipping data.
+- `next_cursor()` returns the JSON-encoded updated map. **Each type advances its OWN watermark to
+  the max `updatedAt` it EMITTED this tick** (forward progress even on a budget-limited partial
+  drain — *not* "advance only on a fully-clean drain", which livelocks). At-least-once delivery +
+  idempotent chunk upsert makes re-fetching a boundary item harmless.
+- Honours ONE shared `per_tick_max_items` (default 500) and `disk_watermark_min_free_bytes` (F66)
+  across the types this tick — a budget-hit on an earlier type just gives later types fewer/none
+  this tick, but no type's watermark is ever moved past its own unprocessed items, so nothing is
+  skipped and every type makes progress across ticks.
 
 ---
 
@@ -215,10 +226,12 @@ both-branch coverage required (OFF = no Linear polling; ON = the cc_pair drains)
 
 - **Rate limit** — Linear's GraphQL limit is complexity-based; on `429` / `Retry-After` the client
   backs off and retries with a bounded budget (F64 test required).
-- **Per-item isolation** — one malformed issue/doc fails just that item (logged), never the tick.
-- **Cursor safety** — the high-water-mark advances only after a clean drain; a mid-tick crash
-  re-fetches from the last good cursor (idempotent upsert).
-- **Budget** — `per_tick_max_items` + disk watermark stop the tick early and resume (F66).
+- **Per-item isolation** — one malformed issue/doc fails just that item (logged WARNING, conversion
+  wrapped in `try/except`), never the tick.
+- **Cursor safety** — each type's `updatedAt` watermark advances to the max it EMITTED (§4 forward
+  progress), never past an un-emitted item; a mid-tick crash re-fetches from the last persisted
+  per-type watermark (idempotent upsert). No type is starved or skipped under budget pressure.
+- **Budget** — one shared `per_tick_max_items` + disk watermark stop the tick early and resume (F66).
 
 ---
 

--- a/docs/architecture/connector-scope-topology/connector-design-specs/linear.md
+++ b/docs/architecture/connector-scope-topology/connector-design-specs/linear.md
@@ -1,0 +1,299 @@
+# Linear connector — design spec (MVP / Approach A)
+
+> Per-connector design spec for ingesting a Linear workspace's **roadmap + documentation**
+> (Initiatives → Projects → Issues, plus standalone Documents and project/status updates) into
+> the kairix knowledge store. Capability model from `../ADR.md`; failure patterns from
+> `../proactive-failure-modes.md`. Mirrors the `notion.md` shape — Linear is a near-exact analogue
+> (single GraphQL API, content renders to Markdown, incremental poll by `updatedAt`).
+>
+> **Scope of this spec = Approach A (incremental poll, API-key auth).** Webhooks, OAuth, guided
+> config, and per-team scoping are explicitly deferred (see §13 Decision record + §14 Phasing).
+
+## 0. Greenfield → target
+
+**No current implementation.** Not in `kairix/connectors/`, not registered. Sanctioned API surface
+(**F37**): Linear's official **GraphQL API** over plain HTTPS — no third-party SDK dependency, so
+`DEPENDENCIES.md` stays empty and the connector uses the existing HTTP client library. No
+cross-connector / extractor imports (F34/F35).
+
+```mermaid
+flowchart LR
+    subgraph poll["PollConnector (incremental, updatedAt cursor)"]
+        Q["GraphQL query per entity type<br/>filter: updatedAt > cursor, paginated"] --> CE[ChangeEvent]
+    end
+    subgraph fetch["fetch (dispatch by item_id type prefix)"]
+        ISS["issue:&lt;identifier&gt;"] --> MD["entity → Markdown"]
+        PRJ["project:&lt;uuid&gt;"] --> MD
+        DOC["document:&lt;uuid&gt;"] --> MD
+        INI["initiative:&lt;uuid&gt;"] --> MD
+        UPD["projectUpdate:&lt;uuid&gt;"] --> MD
+    end
+    CE --> fetch
+    MD --> BR["bronze → silver → chunk → FTS5 + vec"]
+    WH["webhooks (EventConnector)"]:::deferred -.deferred.-> CE
+    classDef deferred stroke-dasharray: 4 4,color:#888;
+```
+
+---
+
+## 1. Identity, capabilities, containers
+
+**`kind`**: `linear`. **Credential boundary**: one workspace = one API key (Linear personal /
+workspace key). No single credential spans workspaces. `cc_pair` = (connector, one workspace key,
+one workspace). Firm-scope (workspace-wide) for the MVP.
+
+**Container model.** The MVP treats the **workspace as a single container** — `list_changes` polls
+all five entity types globally by `updatedAt`. (Per-team containers are a Phase-2 lever; see §14.)
+
+**Hierarchy (conceptual).** `workspace → initiative → project → issue`, with `document` and
+`projectUpdate` attached to a project/initiative. The MVP does **not** implement
+`HierarchyConnector` — hierarchy is captured as Markdown context + `properties` on each chunk
+(parent project/initiative), not as a graph the framework walks. (`HierarchyConnector` is Phase 2.)
+
+**Capability declaration (MVP target).**
+
+| Capability | Implements? | Why |
+|---|---|---|
+| `SourceConnector` (base) | ✅ | enumerate / fetch / link / sensitivity / metadata / cursor |
+| `PollConnector` | ✅ | per-entity GraphQL queries filtered + ordered by `updatedAt` |
+| `CredentialsConnector` | ✅ | validate + carry the API key from the kairix secret store |
+| `SlimConnector` | ✅ | ids-only enumeration for prune (detect deletes/archives) |
+| `CheckpointedConnector` | ⏳ Phase 2 | per-container checkpoint once multi-team containers land |
+| `EventConnector` | ⏳ Phase 2 | webhooks — deferred (see §13) |
+| `OAuthConnector` | ⏳ Phase 2 | for distributing to other users' workspaces |
+| `HierarchyConnector` | ⏳ Phase 2 | initiative → project → issue tree |
+
+`CAPABILITIES` frozenset (F56) for the MVP: `{SourceConnector, PollConnector, CredentialsConnector, SlimConnector}`.
+
+---
+
+## 2. Functions / actions (GraphQL)
+
+Single endpoint, **HTTPS only** (see §3). One `LinearApiClient` wraps GraphQL POSTs with retry +
+rate-limit handling; tests inject a `FakeLinearApiClient` (no live network — test discipline).
+
+Per-entity queries follow the same shape (connection + `updatedAt` filter + pagination):
+
+```graphql
+query Issues($after: String, $since: DateTimeOrDuration!) {
+  issues(first: 100, after: $after, filter: { updatedAt: { gt: $since } }, orderBy: updatedAt) {
+    pageInfo { hasNextPage endCursor }
+    nodes {
+      id identifier title description url createdAt updatedAt
+      state { name type } assignee { displayName email }
+      team { key name } project { id name } labels { nodes { name } }
+    }
+  }
+}
+```
+
+Analogous queries: `projects`, `documents`, `initiatives`, `projectUpdates` — each selecting the
+fields §5 renders + §6 needs for provenance. Pagination drains `pageInfo.endCursor` until
+`hasNextPage = false`.
+
+---
+
+## 3. Transport security — HTTPS only (invariant)
+
+All Linear API traffic is **TLS / HTTPS, never plaintext**. This is enforced, not incidental:
+
+- The endpoint is a hard-coded constant `https://api.linear.app/graphql` in `api_client.py`.
+- `LinearApiClient` **rejects any non-`https` scheme**: if a base-URL override is ever supplied
+  (e.g. a test recording proxy), the client asserts `urlsplit(url).scheme == "https"` and raises a
+  typed error otherwise — there is no code path that issues an `http://` request.
+- A unit test pins this: constructing/calling the client against an `http://` URL raises; the
+  default endpoint is `https://`. (No live network in the test — the guard is checked before any
+  request is built.)
+
+Rationale: roadmap/doc content is company-internal; the API key is a bearer credential. Plaintext
+transport would leak both. (A repo-wide "connectors call `https://` only" fitness rule is a
+reasonable later generalisation — noted, not built here.)
+
+---
+
+## 4. Sync model / cursor
+
+`list_changes(cursor: Cursor | None) -> Iterator[ChangeEvent]`:
+
+- **Cursor** = an ISO-8601 `updatedAt` high-water-mark (the max `updatedAt` across all entity types
+  seen on the last clean drain). `Cursor = str` (opaque token; §1 protocols).
+- Each tick queries the five entity types for `updatedAt > cursor`, paginated, yielding
+  `ChangeEvent(op, item_id, modified_at, parent_id?, metadata)`. `op` is `modified` for
+  create/update; `SlimConnector` enumeration detects `archived`/`deleted` (id present last tick,
+  absent now).
+- **`item_id` is type-prefixed** — `issue:<identifier>`, `project:<uuid>`, `document:<uuid>`,
+  `initiative:<uuid>`, `projectUpdate:<uuid>` — so `fetch` / `metadata_for` / `source_link`
+  dispatch by type without a second lookup.
+- `cursor is None` → full enumeration (initial sync).
+- `next_cursor()` returns the new high-water-mark; it **advances only on a clean drain** (at-least-once
+  delivery + idempotent chunk upsert means a re-fetched item is harmless).
+- Honours `per_tick_max_items` (default 500) and `disk_watermark_min_free_bytes` (F66) — the tick
+  stops early and resumes next tick rather than blowing the budget.
+
+---
+
+## 5. Rendering (`fetch` → Markdown)
+
+`fetch(item_id) -> RawArtefact(raw=<markdown bytes>, mime="text/markdown", fetched_at, sensitivity_hint)`.
+Dispatch by the `item_id` type prefix; the envelope fetched in `list_changes` is cached so `fetch`
++ `metadata_for` don't re-query. Per-type Markdown:
+
+- **Issue** — `# <identifier> <title>`, then a field block (state, assignee, team, project, labels,
+  url) + the description body (already Markdown in Linear).
+- **Project** — `# <name>`, status/lead/target-date block, description + the project's content doc
+  if present, milestone names.
+- **Document** — `# <title>` + content body (Linear Documents are Markdown).
+- **Initiative** — `# <name>`, overview/description, the list of member projects.
+- **Project / status update** — the update narrative + health (on-track / at-risk / off-track) +
+  date, attributed to its project.
+
+Chunking happens downstream in `kairix/core/connectors/silver.py` (F38) — the connector only emits
+raw Markdown bytes.
+
+---
+
+## 6. Provenance / metadata (F39 + F65)
+
+- `metadata_for(item_id) -> SourceMetadata(modified_at, created_at, author, author_email, tags, properties)`:
+  - `author` / `author_email` from the item's creator (issue/doc/update author; project lead).
+  - `tags` from Linear labels.
+  - `properties`: `{ state, team, identifier, project, initiative, url, health }` (whichever apply).
+- `source_link(item_id)` → the canonical `https://linear.app/<workspace>/...` URL.
+- `sensitivity_for(item_id)` → the configured `default_sensitivity` (per-team/project override is
+  Phase 2).
+- Resulting chunks carry `source_uri` (the Linear URL), `source_modified_at` (`updatedAt`),
+  `sensitivity` (F39), and `author` + `chunk_date` (from `updatedAt`/`createdAt`) (F65).
+
+---
+
+## 7. Config / topology / scope
+
+`topology_v2` block (manual for the MVP; guided config is Phase 2):
+
+```yaml
+topology_v2:
+  connectors:
+    - id: linear-prod
+      kind: linear
+      name: "Linear workspace"
+      default_sensitivity: internal        # roadmap/docs are company-internal; override per-deploy
+  credentials:
+    - id: linear-cred
+      kind: linear
+      credential_ref: connector-linear-api-key   # kairix secret store (KV / KAIRIX_SECRETS_FILE)
+  cc_pairs:
+    - id: cc-linear
+      connector: linear-prod
+      credential: linear-cred
+      access_type: SYNC
+      refresh_freq_override_seconds: 900    # 15-min poll (see latency discussion); tune as needed
+  collections:
+    - id: linear
+      name: "Linear roadmap & docs"
+      default_sensitivity: internal
+      sources: [{ cc_pair_id: cc-linear }]
+```
+
+One `linear` collection (operator tiers it via `source_tier_boost` — roadmap/docs are
+authoritative-ish but not canon; `vault_active` ×1.0 is a sensible default). Firm-scope. The
+credential lives in the writable secret store, never a system path (least-privilege; see
+`feedback`/ADR-017).
+
+---
+
+## 8. Feature flag (cutover)
+
+New `connector_linear` `FeatureFlag` in `kairix/core/features/registry.py`:
+`default=False`, `stage="introduce"`, `owner="connector-framework"`,
+`related_spec="docs/architecture/connector-scope-topology/connector-design-specs/linear.md"`,
+`target_retire_in` = a ~12-month window (matches the slower-adoption connector cohort). F54
+both-branch coverage required (OFF = no Linear polling; ON = the cc_pair drains).
+
+---
+
+## 9. Failure modes / resilience (F64 + F66)
+
+- **Rate limit** — Linear's GraphQL limit is complexity-based; on `429` / `Retry-After` the client
+  backs off and retries with a bounded budget (F64 test required).
+- **Per-item isolation** — one malformed issue/doc fails just that item (logged), never the tick.
+- **Cursor safety** — the high-water-mark advances only after a clean drain; a mid-tick crash
+  re-fetches from the last good cursor (idempotent upsert).
+- **Budget** — `per_tick_max_items` + disk watermark stop the tick early and resume (F66).
+
+---
+
+## 10. Retrieval-quality contract
+
+Seed ≥1 eval-suite question (F75-aligned) exercising the connector — e.g. "what is our roadmap for
+&lt;capability&gt;?" should surface the matching Linear project/initiative; "what does the
+&lt;X&gt; design doc say?" should surface the Linear Document. Fixtures use synthetic
+Linear-shaped data (no real workspace content in committed tests — F32).
+
+---
+
+## 11. Test plan / F-rule deltas
+
+Shipped in the same commit(s) as the connector:
+
+- **F36** — `tests/bdd/features/connector_linear.feature` (happy-path) + Examples-table row in the
+  connectors E2E feature + steps.
+- **F54** — `feature_flag_connector_linear.feature` (OFF + ON) + both-branch integration test.
+- **F64** — 429/`Retry-After` backoff-retry test on `LinearApiClient`.
+- **F65** — `metadata_for` propagation test (author + `chunk_date` land on the chunk).
+- **F43** — contract test parametrized over the real `LinearConnector` + a `FakeLinearConnector`.
+- **F68** — per-`SourceConnector`-method failure-injection contract test.
+- **F56 / F41** — `CAPABILITIES` frozenset; `py.typed`; mypy-strict clean.
+- **§3** — HTTPS-only guard test.
+- Per-entity-type render unit tests; E2E composed path (`config → factory → connector tick →
+  search finds a Linear item`).
+- All network behind `FakeLinearApiClient` — no live calls in tests.
+
+---
+
+## 12. Implementation sequence (lowest-novelty-risk first)
+
+1. `api_client.py` — `LinearApiClient` (GraphQL POST, HTTPS-only guard, pagination, 429 backoff) +
+   `FakeLinearApiClient`.
+2. `connector.py` — `LinearConnector` (`list_changes` cursor, `fetch` dispatch, `metadata_for`,
+   `source_link`, `sensitivity_for`, `next_cursor`) + `make_connector` factory + `__init__.py`
+   (`version`, `CAPABILITIES`) + `py.typed`.
+3. Per-entity Markdown rendering.
+4. Config/topology wiring + `connector_linear` feature flag.
+5. Full test set (contract / BDD / feature-flag / integration / E2E) + the eval question.
+6. `README.md` + `DEPENDENCIES.md`; this spec referenced as `related_spec`.
+
+---
+
+## 13. Decision record — incremental poll, not webhooks (Approach A over B)
+
+**Decision:** the MVP detects changes by **incremental polling** (`PollConnector`, `updatedAt`
+cursor), **not** webhooks (`EventConnector`).
+
+**Context:** webhooks give near-real-time freshness (~seconds) vs polling's freshness-bounded-by-cadence
+(~poll interval; ≤15 min at the proposed 900 s cadence).
+
+**Why poll for the MVP:**
+1. **The content doesn't need it.** Roadmap + docs change on a human cadence; an agent answering
+   "what's our roadmap / what does this doc say" is not sensitive to a sub-15-minute edit lag.
+2. **Webhooks require a public HTTPS callback** Linear can reach — exactly the inbound-exposure
+   friction that conflicts with hardened / closed deployments (the least-privilege posture F94 /
+   ADR-017 just hardened). Polling needs only outbound HTTPS.
+3. **Lower novelty risk** — mirrors the proven Notion poll connector; no subscription lifecycle,
+   HMAC verification, or renewal to get right.
+
+**Consequence:** freshness is the poll cadence (operator-tunable via
+`refresh_freq_override_seconds`). Webhooks remain a clean Phase-2 capability for anyone who needs
+sub-minute freshness AND can expose a callback.
+
+> This decision is also echoed as a docstring on `LinearConnector` / `make_connector`, pointing back
+> to this section.
+
+---
+
+## 14. Phasing / out of scope (MVP)
+
+**Deferred to later waves:** webhooks (`EventConnector`); OAuth (`OAuthConnector`) for other users'
+workspaces; guided config (`kairix linear discover / configure / status`, KFEAT-022); per-team
+containers + `CheckpointedConnector` + `HierarchyConnector`; per-team/project sensitivity overrides;
+comments, cycles, milestones, labels-as-entities. Each is additive and does not change the MVP's
+data model.

--- a/kairix/connectors/linear/DEPENDENCIES.md
+++ b/kairix/connectors/linear/DEPENDENCIES.md
@@ -1,0 +1,30 @@
+# Dependency rationale
+
+This connector introduces **no new third-party dependency**.
+
+Linear ships a single official GraphQL API over plain HTTPS, so the
+connector talks to it directly using `httpx` — the HTTP client kairix
+already depends on. We deliberately avoid the Linear SDK: it adds a
+heavy transitive set for what is a small POST-a-query surface, and a
+raw GraphQL client keeps the import boundary tight (F35) and the
+HTTPS-only guard (spec §3) under our own control.
+
+## Current dependencies
+
+_None beyond the existing kairix dependency set._ The connector imports
+only:
+
+- `httpx` — already a core kairix dependency (the GraphQL POST + 429
+  backoff path).
+- the Python standard library (`logging`, `time`, `urllib.parse`,
+  `datetime`, `dataclasses`).
+- `kairix.core.*` / `kairix.secrets.*` — the Protocol + secret-resolution
+  surfaces.
+
+## Adding a new dependency
+
+1. Justify against "could `httpx` + stdlib do this?" first — for a
+   single GraphQL endpoint the answer is almost always yes.
+2. If a dependency is genuinely needed, add a one-line rationale here
+   (`package — reason`) and confirm it does not break F35 (no
+   cross-connector / extractor imports).

--- a/kairix/connectors/linear/README.md
+++ b/kairix/connectors/linear/README.md
@@ -1,0 +1,125 @@
+# Linear connector
+
+First-party connector that brings your Linear workspace's roadmap and
+docs into the knowledge store — initiatives, projects, issues, plus
+standalone documents and project status updates. One connector instance
+covers one Linear workspace.
+
+## What it does
+
+Each sync tick:
+
+1. Polls five Linear entity types — issues, projects, documents,
+   initiatives, and project updates — over the Linear GraphQL API,
+   filtered and ordered by `updatedAt` so only items changed since the
+   last run come back.
+2. Emits one change event per item, each with a type-prefixed id
+   (`issue:ENG-42`, `project:<uuid>`, `document:<uuid>`,
+   `initiative:<uuid>`, `projectUpdate:<uuid>`) so the rest of the
+   pipeline can tell entity types apart without a second lookup.
+3. Renders each item to Markdown — a title heading, a short field block
+   (state, assignee, team, project, labels, link), and the body (Linear
+   content is already Markdown).
+4. Surfaces envelope metadata (author, created/updated dates, labels,
+   state, team, project, link) so the search layer can boost recency,
+   surface labels as tags, and attribute items to their author.
+
+All traffic is HTTPS-only. The endpoint is hard-coded to
+`https://api.linear.app/graphql` and the client refuses any non-HTTPS
+address.
+
+## What it requires
+
+- A Linear workspace.
+- A **Linear API key** (a personal or workspace key). Create one in
+  Linear under Settings → Account → Security & access → Personal API
+  keys, or Settings → API for a workspace key. The key is a bearer
+  credential — keep it in your secret store, never in a file the app
+  can't write.
+- No extra Python packages. The connector talks to Linear over plain
+  HTTPS using the HTTP client kairix already ships — there is no
+  third-party Linear SDK dependency (see `DEPENDENCIES.md`).
+
+## How operators enable it
+
+Put the API key in your secret store under the canonical name the
+connector resolves: scope `connector`, area `linear`, leaf `api_key`.
+For env-var deployments that means
+`KAIRIX_CONNECTOR_LINEAR_API_KEY`; for a Key Vault mount it is the
+matching `connector-linear-api-key` secret.
+
+Then flip the feature flag and add the connector to your
+`kairix.config.yaml`:
+
+```yaml
+features:
+  connector_linear: true
+
+topology_v2:
+  connectors:
+    - id: linear-prod
+      kind: linear
+      name: "Linear workspace"
+      default_sensitivity: internal        # roadmap/docs are company-internal; override per-deploy
+  credentials:
+    - id: linear-cred
+      kind: linear
+      credential_ref: connector-linear-api-key   # your secret store (KV / secrets file)
+  cc_pairs:
+    - id: cc-linear
+      connector: linear-prod
+      credential: linear-cred
+      access_type: SYNC
+      refresh_freq_override_seconds: 900    # 15-min poll; tune as needed
+  collections:
+    - id: linear
+      name: "Linear roadmap & docs"
+      default_sensitivity: internal
+      sources: [{ cc_pair_id: cc-linear }]
+```
+
+The feature flag defaults OFF, so adding this connector is a no-op until
+you deliberately turn it on.
+
+## How fresh is it
+
+The connector finds changes by polling, not by webhooks. That means new
+edits show up on the next poll — within your poll interval (15 minutes
+at the `refresh_freq_override_seconds: 900` shown above). Roadmap and
+docs change on a human cadence, so this is plenty fresh for questions
+like "what's our roadmap?" or "what does this design doc say?". Polling
+also needs only outbound HTTPS, which keeps it friendly to locked-down
+deployments — no public callback for Linear to reach. Sub-minute
+freshness via webhooks is a planned future option for teams that need it
+and can expose a callback. See the design spec §13 for the full
+reasoning.
+
+## What it does NOT do (yet)
+
+- It does **not** use webhooks for real-time updates (poll-only for now).
+- It does **not** support per-team or per-project sensitivity overrides
+  — every item gets the connector's `default_sensitivity`.
+- It does **not** ingest comments, cycles, or milestones as their own
+  items. Milestone and member-project names are folded into the parent
+  project/initiative Markdown.
+- It does **not** span more than one workspace per API key — one key,
+  one workspace.
+
+## Failure modes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Rate-limit pauses | Linear returned HTTP 429 | The client reads `Retry-After`, backs off, and retries automatically (bounded). No operator action needed. |
+| HTTP 401 on every call | API key revoked or wrong | Generate a fresh Linear API key and update the `connector-linear-api-key` secret. |
+| One item missing, sync continues | A single malformed item | Logged and skipped; the rest of the tick still lands (per-item isolation). |
+| Endpoint error at startup | A non-HTTPS endpoint override | Remove the override; the connector only talks to `https://api.linear.app/graphql`. |
+
+## References
+
+- `kairix/connectors/linear/connector.py` — the source-of-truth for this
+  connector's behaviour.
+- `tests/bdd/features/connector_linear.feature` — the behavioural
+  contract under test.
+- `docs/architecture/connector-scope-topology/connector-design-specs/linear.md`
+  — the full design spec (capabilities, queries, cursor model,
+  poll-over-webhooks decision).

--- a/kairix/connectors/linear/__init__.py
+++ b/kairix/connectors/linear/__init__.py
@@ -1,0 +1,99 @@
+"""Linear connector plugin — workspace roadmap + docs via the Linear GraphQL API.
+
+First-party :class:`kairix.core.protocols.SourceConnector` implementation
+for one Linear workspace. Polls five entity types (issue / project /
+document / initiative / projectUpdate) filtered + ordered by
+``updatedAt``, renders each to Markdown, and emits one
+:class:`~kairix.core.protocols.ChangeEvent` per node with a type-prefixed
+``item_id``.
+
+Auth is a single Linear workspace / personal API key. The connector
+resolves the key via the injected :class:`~kairix.secrets.SecretsResolver`
+(canonical leaf ``("connector", "linear", None, "api_key")``) and threads
+it through every API call via
+:class:`kairix.connectors.linear.api_client.LinearApiClient`. One API
+key = one workspace (no single credential spans workspaces, per spec §1).
+
+All Linear traffic is HTTPS-only (spec §3): the endpoint is a hard-coded
+``https://api.linear.app/graphql`` constant and the client rejects any
+non-``https`` scheme.
+
+Registered via ``[project.entry-points."kairix.connectors"]`` in kairix's
+``pyproject.toml`` — operators select it by listing ``linear`` in their
+``connectors[]`` config, behind the ``connector_linear`` feature flag
+(introduce stage, default off; see
+``docs/architecture/feature-flag-architecture.md`` §3).
+
+Decision record (spec §13): change detection is incremental polling
+(``PollConnector``, ``updatedAt`` cursor), NOT webhooks — roadmap + docs
+change on a human cadence and polling needs only outbound HTTPS, fitting
+hardened deployments. Webhooks remain a clean Phase-2 capability. See
+:class:`kairix.connectors.linear.connector.LinearConnector` and
+``docs/architecture/connector-scope-topology/connector-design-specs/linear.md``
+§13.
+
+Default sensitivity tier is ``internal`` per spec §1 (roadmap/docs are
+company-internal). Operators routing client-confidential workspaces
+override via the connector config's ``default_sensitivity`` key.
+
+The plugin is mypy-strict-clean and carries ``py.typed`` per F41. The
+``SourceConnector`` Protocol surface is narrow by design (F35 / F38);
+chunking happens downstream in ``kairix/core/connectors/silver.py``.
+
+See ``tests/bdd/features/connector_linear.feature`` for the behaviour
+spec this plugin pins.
+"""
+
+from __future__ import annotations
+
+from kairix.connectors.linear.api_client import (
+    LINEAR_DEFAULT_RETRY_AFTER_S,
+    LINEAR_GRAPHQL_ENDPOINT,
+    LinearApiClient,
+)
+from kairix.connectors.linear.connector import (
+    CONNECTOR_LINEAR_FLAG,
+    CONNECTOR_NAME,
+    DEFAULT_PER_TICK_MAX_ITEMS,
+    DEFAULT_SENSITIVITY,
+    LINEAR_MARKDOWN_MIME,
+    LinearConnector,
+    LinearCredentials,
+    make_connector,
+)
+from kairix.connectors.linear.render import ENTITY_KINDS, render
+
+# F56 capability declaration. Linear satisfies the base SourceConnector
+# plus PollConnector (per-entity GraphQL queries filtered by updatedAt),
+# CredentialsConnector (validate + carry the workspace API key), and
+# SlimConnector (id-only enumeration for the prune cycle). EventConnector
+# (webhooks), CheckpointedConnector, OAuthConnector, and HierarchyConnector
+# are Phase-2 capabilities (spec §1 / §14).
+CAPABILITIES: frozenset[str] = frozenset(
+    {
+        "SourceConnector",
+        "PollConnector",
+        "CredentialsConnector",
+        "SlimConnector",
+    }
+)
+
+__all__ = [
+    "CAPABILITIES",
+    "CONNECTOR_LINEAR_FLAG",
+    "CONNECTOR_NAME",
+    "DEFAULT_PER_TICK_MAX_ITEMS",
+    "DEFAULT_SENSITIVITY",
+    "ENTITY_KINDS",
+    "LINEAR_DEFAULT_RETRY_AFTER_S",
+    "LINEAR_GRAPHQL_ENDPOINT",
+    "LINEAR_MARKDOWN_MIME",
+    "LinearApiClient",
+    "LinearConnector",
+    "LinearCredentials",
+    "make_connector",
+    "render",
+]
+
+# Plugin version (mirrors the per-plugin version convention). MVP / Approach A.
+version = "1.0"

--- a/kairix/connectors/linear/api_client.py
+++ b/kairix/connectors/linear/api_client.py
@@ -1,0 +1,290 @@
+"""Thin Linear GraphQL API client for the kairix Linear connector.
+
+A focused wrapper around ``httpx.Client`` for the Linear GraphQL surface
+the connector exercises — arbitrary GraphQL queries and cursor-paginated
+connection traversal. Three commitments:
+
+  1. **HTTPS-only (spec §3).** The endpoint constant is always
+     ``https://api.linear.app/graphql``; the constructor REJECTS any
+     endpoint whose scheme is not ``https`` so no code path can
+     inadvertently issue an ``http://`` request.
+
+  2. **API-key auth.** Every request adds an ``Authorization: <api_key>``
+     header per the Linear API contract. The key is captured into private
+     state and never logged (F15 boundary discipline).
+
+  3. **429 backoff via injected sleeper.** On HTTP 429, the client reads
+     the ``Retry-After`` response header (defaulting to 60 s) and sleeps
+     via the INJECTED sleeper seam — a plain ``Callable[[float], None]``,
+     never ``time.sleep`` directly — then retries up to ``_MAX_RETRIES``
+     times. Tests pass a recording callable; production passes the default
+     which wraps ``time.sleep``.
+
+The sleeper is a plain callable (not a Protocol) on purpose: a Protocol
+with a public method would create an F68 failure-injection obligation
+for a test-only seam. A ``Callable[[float], None]`` carries no F68
+surface while keeping the DI seam clean.
+
+Per F35, this module only imports from ``kairix.connectors.linear.*``,
+the standard library, and third-party packages already in the dependency
+set (``httpx``). No new third-party dependency is introduced.
+
+Per F41, this module is mypy-strict-clean and the package carries
+``py.typed``.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import urllib.parse
+from collections.abc import Callable, Iterator, Mapping
+from typing import Any, Final
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Public constant — downstream connector code imports this.
+LINEAR_GRAPHQL_ENDPOINT: Final[str] = "https://api.linear.app/graphql"
+
+# Per-request timeout. Linear's GraphQL endpoint typically replies in <2s;
+# 60 s covers a cold connection or a paginated reply over a large dataset.
+_LINEAR_REQUEST_TIMEOUT_S: Final[float] = 60.0
+
+# Maximum number of retry attempts on HTTP 429 before giving up.
+_MAX_RETRIES: Final[int] = 3
+
+# Default Retry-After delay when the header is absent or non-numeric.
+# Exported as a public constant so downstream tests can assert the exact
+# fallback without importing a private name (F5).
+LINEAR_DEFAULT_RETRY_AFTER_S: Final[float] = 60.0
+
+# GraphQL response keys — extracted to module-level constants to satisfy
+# the F17 dup-literal gate as the client grows.
+_KEY_DATA: Final[str] = "data"
+_KEY_ERRORS: Final[str] = "errors"
+_KEY_NODES: Final[str] = "nodes"
+_KEY_PAGE_INFO: Final[str] = "pageInfo"
+_KEY_HAS_NEXT_PAGE: Final[str] = "hasNextPage"
+_KEY_END_CURSOR: Final[str] = "endCursor"
+_KEY_AFTER: Final[str] = "after"
+
+# Sleeper seam type. A plain callable taking a float (seconds) — NOT a
+# Protocol, so no F68 failure-injection obligation attaches.
+Sleeper = Callable[[float], None]
+
+
+def _default_sleep(seconds: float) -> None:
+    """Production sleeper — delegates to ``time.sleep``.
+
+    Isolated in a module-level function so the F86 DI-default coverage
+    floor sees the seam body. Tests always supply their own callable via
+    ``sleeper=``; this path runs only in production when a real 429 is hit.
+    """
+    time.sleep(seconds)
+
+
+class LinearApiClient:
+    """Thin Linear GraphQL wrapper for the kairix connector.
+
+    Args:
+        api_key: The Linear personal API key or OAuth token. Required.
+            Never logged — F15 boundary discipline.
+        endpoint: The GraphQL endpoint URL. Must be ``https://``. Defaults
+            to :data:`LINEAR_GRAPHQL_ENDPOINT`.
+        http: Optional ``httpx.Client`` for the request path. Tests pass
+            an :class:`httpx.MockTransport`-backed client so no real Linear
+            call leaks from the test suite. When ``None`` a short-lived
+            owned client is created per request.
+        sleeper: Optional sleep seam — a ``Callable[[float], None]``.
+            Defaults to :func:`_default_sleep`. Tests inject a recording
+            callable so 429-retry tests run at full speed without
+            wall-clock waits.
+
+    Raises:
+        ValueError: If ``endpoint`` is not an ``https://`` URL.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        endpoint: str = LINEAR_GRAPHQL_ENDPOINT,
+        http: httpx.Client | None = None,
+        sleeper: Sleeper | None = None,
+    ) -> None:
+        parsed = urllib.parse.urlsplit(endpoint)
+        if parsed.scheme != "https":
+            raise ValueError(
+                f"linear api client: endpoint scheme must be 'https', got {parsed.scheme!r}. "
+                f"fix: use an https:// endpoint (default: {LINEAR_GRAPHQL_ENDPOINT!r}). "
+                f"next: check connector config for a mis-typed endpoint override."
+            )
+        # F15: api_key captured into private state; never logged.
+        self._api_key = api_key
+        self._endpoint = endpoint
+        self._http = http
+        self._sleeper: Sleeper = sleeper if sleeper is not None else _default_sleep
+
+    # ------------------------------------------------------------------
+    # Public GraphQL surface
+    # ------------------------------------------------------------------
+
+    def query(self, document: str, variables: Mapping[str, Any]) -> dict[str, Any]:
+        """Execute one GraphQL POST and return the ``data`` dict.
+
+        Args:
+            document: The GraphQL query/mutation string.
+            variables: Variable bindings for the document.
+
+        Returns:
+            The ``data`` value from the GraphQL response envelope.
+
+        Raises:
+            httpx.HTTPStatusError: On unrecoverable HTTP errors (non-429)
+                OR when all 429 retries are exhausted.
+            RuntimeError: If the GraphQL response carries ``errors`` or is
+                missing its ``data`` key.
+        """
+        return self._post_with_retry(document, dict(variables))
+
+    def paginate(
+        self,
+        document: str,
+        variables: Mapping[str, Any],
+        *,
+        connection: str,
+    ) -> Iterator[dict[str, Any]]:
+        """Paginate a GraphQL connection field, yielding each node.
+
+        Drives the ``after`` / ``pageInfo.endCursor`` cursor pattern used
+        by every Linear list endpoint. Stops when ``pageInfo.hasNextPage``
+        is ``false`` or the cursor is absent.
+
+        Args:
+            document: The GraphQL query string. Must include
+                ``pageInfo { hasNextPage endCursor }`` in the named
+                connection field.
+            variables: Base variable bindings; ``after`` is injected by
+                this method on successive pages.
+            connection: The top-level connection key in ``data`` (e.g.
+                ``"issues"``).
+
+        Yields:
+            One ``dict`` per node across all pages.
+        """
+        vars_: dict[str, Any] = dict(variables)
+        while True:
+            data = self._post_with_retry(document, vars_)
+            conn = data.get(connection, {})
+            if not isinstance(conn, dict):
+                return
+            yield from conn.get(_KEY_NODES, [])
+            page_info = conn.get(_KEY_PAGE_INFO, {})
+            if not isinstance(page_info, dict):
+                return
+            if not page_info.get(_KEY_HAS_NEXT_PAGE):
+                return
+            cursor = page_info.get(_KEY_END_CURSOR)
+            if not isinstance(cursor, str) or not cursor:
+                return
+            vars_[_KEY_AFTER] = cursor
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _post_with_retry(self, document: str, variables: dict[str, Any]) -> dict[str, Any]:
+        """POST the GraphQL payload with bounded 429 backoff.
+
+        On HTTP 429 the client reads ``Retry-After`` (defaulting to
+        ``LINEAR_DEFAULT_RETRY_AFTER_S``) and sleeps via the injected sleeper.
+        Retries up to ``_MAX_RETRIES`` times. Any other HTTP error is
+        re-raised immediately.
+        """
+        body = {"query": document, "variables": variables}
+        for attempt in range(_MAX_RETRIES + 1):
+            response = self._authorised_post(body)
+            if response.status_code == 429:
+                if attempt == _MAX_RETRIES:
+                    response.raise_for_status()
+                wait = _parse_retry_after(response)
+                logger.debug(
+                    "linear api: 429 rate-limit on attempt %d/%d; sleeping %.1fs",
+                    attempt + 1,
+                    _MAX_RETRIES,
+                    wait,
+                )
+                self._sleeper(wait)
+                continue
+            response.raise_for_status()
+            payload: dict[str, Any] = response.json()
+            if _KEY_ERRORS in payload:
+                raise RuntimeError(
+                    f"linear graphql errors: {payload[_KEY_ERRORS]!r}. "
+                    f"fix: check the query document and variables for schema errors. "
+                    f"run: kairix linear status to verify connectivity."
+                )
+            data = payload.get(_KEY_DATA)
+            if not isinstance(data, dict):
+                raise RuntimeError(
+                    f"linear api client: response missing 'data' key. "
+                    f"fix: check {self._endpoint!r} is a valid Linear GraphQL endpoint."
+                )
+            return data
+        # Unreachable — loop always returns or raises inside.
+        raise RuntimeError(  # pragma: no cover — F3: defensive; loop above always returns or raises
+            "linear api client: retry loop exhausted without returning"
+        )
+
+    def _authorised_post(self, body: dict[str, Any]) -> httpx.Response:
+        """Issue a POST with the Linear API-key auth header.
+
+        F15-clean: the key is composed into the Authorization header here
+        only; never logged, never returned.
+        """
+        headers = self._headers()
+        client = self._http
+        if client is not None:
+            return client.post(
+                self._endpoint,
+                headers=headers,
+                json=body,
+                timeout=_LINEAR_REQUEST_TIMEOUT_S,
+            )
+        with httpx.Client(timeout=_LINEAR_REQUEST_TIMEOUT_S) as owned:
+            return owned.post(self._endpoint, headers=headers, json=body)
+
+    def _headers(self) -> dict[str, str]:
+        """Build per-request headers including the Linear API-key auth.
+
+        F15: the key is composed here only; the helper is private and
+        never returns the key via any other path.
+        """
+        return {
+            "Authorization": self._api_key,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+
+# ---------------------------------------------------------------------------
+# Free-function helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_retry_after(response: httpx.Response) -> float:
+    """Parse the ``Retry-After`` header, falling back to the default.
+
+    Linear may return an integer number of seconds or omit the header
+    entirely. We guard against non-numeric values and negatives.
+    """
+    raw = response.headers.get("Retry-After", "")
+    try:
+        value = float(raw)
+        if value > 0:
+            return value
+    except (ValueError, TypeError):
+        pass
+    return LINEAR_DEFAULT_RETRY_AFTER_S

--- a/kairix/connectors/linear/connector.py
+++ b/kairix/connectors/linear/connector.py
@@ -1,0 +1,604 @@
+"""``LinearConnector`` — SourceConnector for the Linear GraphQL API.
+
+Implements :class:`kairix.core.protocols.SourceConnector` plus the
+:class:`PollConnector`, :class:`CredentialsConnector`, and
+:class:`SlimConnector` capability mix-ins (spec §1) for one Linear
+workspace (one workspace API key = one workspace, per spec §1).
+
+Change detection rides incremental polling: each tick queries the five
+entity types (issue / project / document / initiative / projectUpdate)
+filtered + ordered by ``updatedAt > cursor`` and emits one
+:class:`ChangeEvent` per node. The cursor is an ISO-8601 high-water-mark
+across all entity types, advancing only on a clean drain (spec §4).
+
+Decision record — incremental poll, NOT webhooks (spec §13)
+-----------------------------------------------------------
+The MVP detects changes by **incremental polling** (``PollConnector``,
+``updatedAt`` cursor), not webhooks (``EventConnector``). Three reasons:
+(1) roadmap + docs change on a human cadence — an agent answering
+"what's our roadmap / what does this doc say" is not sensitive to a
+sub-15-minute edit lag; (2) webhooks require a public HTTPS callback
+Linear can reach — exactly the inbound-exposure friction that conflicts
+with hardened / closed deployments, whereas polling needs only outbound
+HTTPS; (3) lower novelty risk — mirrors the proven Notion poll connector.
+Freshness is the operator-tunable poll cadence; webhooks remain a clean
+Phase-2 capability. See
+``docs/architecture/connector-scope-topology/connector-design-specs/linear.md``
+§13 for the full decision context.
+
+Per F35, this module only imports from ``kairix.connectors.linear.*``
+(same plugin) and ``kairix.core.*`` / ``kairix.secrets.*`` (the Protocol
++ secret-resolution surfaces). No reach into other connectors, no reach
+into the extractor layer.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterator, Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, cast
+
+from kairix.connectors.linear.api_client import LinearApiClient
+from kairix.connectors.linear.render import render
+from kairix.core.protocols import (
+    ChangeEvent,
+    Container,
+    Cursor,
+    RawArtefact,
+    Sensitivity,
+    SourceMetadata,
+)
+from kairix.secrets.loader import SecretsLoader, SecretsResolver
+
+logger = logging.getLogger(__name__)
+
+CONNECTOR_NAME = "linear"
+
+# Default sensitivity tier. Spec §1 / §7: roadmap + docs are
+# company-internal; the connector ships with ``internal`` as the safer
+# default. Operators routing client-confidential workspaces override via
+# the connector config's ``default_sensitivity`` key.
+DEFAULT_SENSITIVITY: Sensitivity = "internal"
+
+# Mime hint for the rendered Markdown (spec §5). Bronze persists the raw
+# markdown bytes; Silver routes through the passthrough / markitdown
+# extractor chain.
+LINEAR_MARKDOWN_MIME = "text/markdown"
+
+# Topology v2 flag name — same convention as the other connector pilots.
+# Module-level constant so the F52 call-site scan picks up exactly one
+# verbatim reference per call site.
+CONNECTOR_LINEAR_FLAG = "connector_linear"
+
+# Default per-tick item ceiling (F66, spec §4). The tick stops early and
+# resumes next tick rather than blowing the budget.
+DEFAULT_PER_TICK_MAX_ITEMS = 500
+
+# item_id type prefixes (spec §4). ``fetch`` / ``metadata_for`` /
+# ``source_link`` dispatch on these without a second lookup.
+_PREFIX_SEP = ":"
+
+# Node field names referenced ≥3 times — extracted so the F17 dup-literal
+# gate stays green.
+_FIELD_IDENTIFIER = "identifier"
+
+# GraphQL field constants — extracted so the F17 dup-literal gate stays
+# green across the five per-entity queries.
+_F_PAGE_INFO = "pageInfo { hasNextPage endCursor }"
+_F_UPDATED_FILTER = "filter: { updatedAt: { gt: $since } }, orderBy: updatedAt"
+_F_PAGE_ARGS = "first: 100, after: $after"
+_F_HEADER = "query($after: String, $since: DateTimeOrDuration!)"
+
+# Per-entity query specs: (item_id prefix, GraphQL connection name,
+# node selection set). The selection sets pull the fields §5 renders +
+# §6 needs for provenance. Each is paginated by the api client.
+_ISSUE_NODES = (
+    "id identifier title description url createdAt updatedAt "
+    "state { name type } assignee { displayName email } creator { displayName email } "
+    "team { key name } project { id name } labels { nodes { name } }"
+)
+_PROJECT_NODES = (
+    "id name description url createdAt updatedAt state targetDate "
+    "status { name } lead { displayName email } "
+    "projectMilestones { nodes { name } }"
+)
+_DOCUMENT_NODES = "id title content url createdAt updatedAt creator { displayName email } project { id name }"
+_INITIATIVE_NODES = (
+    "id name description url createdAt updatedAt status creator { displayName email } projects { nodes { name } }"
+)
+_UPDATE_NODES = "id body health url createdAt updatedAt user { displayName email } project { id name }"
+
+
+@dataclass(frozen=True)
+class _EntitySpec:
+    """One entity type's polling spec.
+
+    Frozen per F42 — the spec table is data, not behaviour.
+    ``prefix`` is the item_id type prefix; ``connection`` is the GraphQL
+    connection field name; ``nodes`` is the node selection set.
+    """
+
+    prefix: str
+    connection: str
+    nodes: str
+
+
+# Spec table — drives list_changes + retrieve_all_slim_docs. The
+# ``projectUpdate`` prefix matches the spec §4 item_id shape exactly.
+_ENTITY_SPECS: tuple[_EntitySpec, ...] = (
+    _EntitySpec("issue", "issues", _ISSUE_NODES),
+    _EntitySpec("project", "projects", _PROJECT_NODES),
+    _EntitySpec("document", "documents", _DOCUMENT_NODES),
+    _EntitySpec("initiative", "initiatives", _INITIATIVE_NODES),
+    _EntitySpec("projectUpdate", "projectUpdates", _UPDATE_NODES),
+)
+
+# Linear's beginning-of-time sentinel for the initial (cursor=None) sync.
+# A fixed early ISO timestamp so ``updatedAt > $since`` matches everything.
+_EPOCH_ISO = "1970-01-01T00:00:00.000Z"
+
+# Valid F39 sensitivity tiers — single source for the make_connector
+# validation (mirrors the Sensitivity literal in protocols.py).
+_VALID_SENSITIVITIES: frozenset[str] = frozenset({"public", "internal", "client-confidential", "personal"})
+
+
+def _now_iso() -> str:
+    """Return a current ISO-8601 UTC timestamp (``...Z`` suffix)."""
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _build_query(spec: _EntitySpec) -> str:
+    """Build the paginated GraphQL query string for one entity spec."""
+    return (
+        f"{_F_HEADER} {{ "
+        f"{spec.connection}({_F_PAGE_ARGS}, {_F_UPDATED_FILTER}) {{ "
+        f"{_F_PAGE_INFO} nodes {{ {spec.nodes} }} }} }}"
+    )
+
+
+@dataclass(frozen=True)
+class LinearCredentials:
+    """Resolved API-key credential for one Linear workspace sync.
+
+    Frozen per F42 — the typed shape that crosses the boundary between
+    secret resolution and the connector constructor. Tests construct a
+    literal and pass it via the ``credentials`` kwarg; production resolves
+    via the injected :class:`SecretsResolver`.
+    """
+
+    api_key: str
+
+
+def _resolve_credentials_from_secrets(secrets: SecretsResolver) -> LinearCredentials:
+    """Resolve the Linear workspace API key via :class:`SecretsResolver`.
+
+    Canonical leaf ``("connector", "linear", None, "api_key")`` resolves
+    through canonical env → KV mount. When no source resolves,
+    :meth:`SecretsResolver.require` raises with an actionable message —
+    module import never crashes, only first-use of list_changes / fetch.
+
+    F15-clean: the resolved key is captured into the frozen dataclass and
+    never logged through any code path in this module.
+    """
+    api_key = secrets.require(scope="connector", area="linear", instance=None, leaf="api_key")
+    return LinearCredentials(api_key=api_key)
+
+
+class LinearConnector:
+    """SourceConnector for one Linear workspace (incremental poll).
+
+    Construction is cheap (no I/O, no Linear API call). The first
+    :meth:`list_changes` call drains the five entity-type queries and
+    caches each node so :meth:`fetch` / :meth:`metadata_for` /
+    :meth:`source_link` resolve without a second round-trip.
+
+    Decision record (spec §13): change detection is incremental polling,
+    NOT webhooks — see the module docstring for the full rationale. The
+    poll cadence is the freshness bound; webhooks are a Phase-2 capability.
+
+    DI seams:
+
+      * ``credentials`` — resolved :class:`LinearCredentials`. Tests pass
+        a literal; production callers omit and the connector resolves via
+        the injected :class:`SecretsResolver`.
+      * ``client_builder`` — builds the :class:`LinearApiClient`. Tests
+        pass a builder returning a client backed by an
+        ``httpx.MockTransport`` (or a fake client) so no real Linear call
+        leaks.
+      * ``default_sensitivity`` — connector-wide F39 tier; defaults to
+        ``internal``. Operators set the matching key in
+        ``connector_specific_config`` to override.
+      * ``secrets`` — :class:`SecretsResolver`. Tests pass
+        :class:`tests.fakes.FakeSecretsLoader`; production defaults to
+        :class:`SecretsLoader`.
+
+    Flag gating happens at the worker-dispatch boundary
+    (:func:`kairix.worker.dispatch_linear_sync`) — when the
+    ``connector_linear`` flag is OFF the connector slot is a no-op and
+    this constructor is never called.
+    """
+
+    name: str = CONNECTOR_NAME
+    per_tick_max_items: int = DEFAULT_PER_TICK_MAX_ITEMS
+    # F66-watermark-exempt: Linear nodes stream as small markdown
+    # envelopes; no large disk writes per item.
+    disk_watermark_min_free_bytes: int | None = None
+
+    def __init__(
+        self,
+        *,
+        credentials: LinearCredentials | None = None,
+        client_builder: Callable[[LinearCredentials], LinearApiClient] | None = None,
+        default_sensitivity: Sensitivity = DEFAULT_SENSITIVITY,
+        per_tick_max_items: int = DEFAULT_PER_TICK_MAX_ITEMS,
+        secrets: SecretsResolver | None = None,
+    ) -> None:
+        self._default_sensitivity: Sensitivity = default_sensitivity
+        self.per_tick_max_items = per_tick_max_items
+        # Canonical-naming seam. Tests inject FakeSecretsLoader; production
+        # constructs a real SecretsLoader lazily so the connector imports
+        # cleanly without a provisioned secrets backend.
+        self._secrets: SecretsResolver = secrets if secrets is not None else SecretsLoader()
+
+        resolved = credentials if credentials is not None else _resolve_credentials_from_secrets(self._secrets)
+        self._credentials = resolved
+
+        if client_builder is not None:
+            self._api = client_builder(resolved)
+        else:
+            self._api = LinearApiClient(resolved.api_key)
+
+        # Per-item node cache populated by :meth:`list_changes` so
+        # ``fetch`` / ``metadata_for`` / ``source_link`` resolve without a
+        # second API call. Keyed by the full type-prefixed item_id.
+        self._node_cache: dict[str, Mapping[str, Any]] = {}
+        # High-water-mark cursor advanced on a clean drain (spec §4).
+        self._next_cursor: str | None = None
+
+    # ------------------------------------------------------------------
+    # SourceConnector Protocol surface (base)
+    # ------------------------------------------------------------------
+
+    def list_changes(self, cursor: Cursor | None) -> Iterator[ChangeEvent]:
+        """Stream changes across all five entity types since ``cursor``.
+
+        ``cursor`` is the ISO-8601 ``updatedAt`` high-water-mark; ``None``
+        triggers a full enumeration (initial sync). Each tick queries the
+        five entity types filtered by ``updatedAt > cursor``, yielding one
+        ``modified`` :class:`ChangeEvent` per node with a type-prefixed
+        ``item_id``. Honours :attr:`per_tick_max_items` (F66) — the tick
+        stops early and the cursor advances only on a clean drain.
+        """
+        since = cursor if cursor is not None else _EPOCH_ISO
+        events: list[ChangeEvent] = []
+        budget_hit = any(self._drain_spec(spec, since, events) for spec in _ENTITY_SPECS)
+        # Cursor advances ONLY on a clean drain (spec §4 / §9). A
+        # budget-stopped tick leaves the persisted cursor untouched so the
+        # next tick re-drains from the last good high-water-mark.
+        if not budget_hit:
+            self._next_cursor = self._high_water(events, cursor)
+        return iter(events)
+
+    def _drain_spec(self, spec: _EntitySpec, since: str, events: list[ChangeEvent]) -> bool:
+        """Drain one entity-type query into ``events``; return ``budget_hit``.
+
+        Appends ChangeEvents (and caches nodes) until the page is exhausted
+        OR :attr:`per_tick_max_items` is reached. Returns ``True`` when the
+        budget stopped the drain mid-page (the caller must NOT advance the
+        cursor past this point, spec §4); ``False`` when the page drained
+        clean.
+        """
+        for node in self._api.paginate(
+            _build_query(spec),
+            {"since": since},
+            connection=spec.connection,
+        ):
+            if len(events) >= self.per_tick_max_items:
+                return True
+            event = self._node_to_event(spec, node)
+            if event is None:
+                continue
+            self._node_cache[event.item_id] = node
+            events.append(event)
+        return False
+
+    @staticmethod
+    def _high_water(events: list[ChangeEvent], cursor: str | None) -> str | None:
+        """Return the max ISO timestamp across ``events`` and the prior ``cursor``.
+
+        The high-water-mark is the latest ``updatedAt`` observed in this
+        clean drain, never moving backwards: when the drain produced no
+        events the prior ``cursor`` is preserved, and a prior cursor newer
+        than every event (a defensive case) wins via ``max``.
+        """
+        candidates = [ev.modified_at for ev in events]
+        if cursor is not None:
+            candidates.append(cursor)
+        if not candidates:
+            return None
+        return max(candidates)
+
+    def fetch(self, item_id: str) -> RawArtefact:
+        """Render one cached Linear entity as Markdown.
+
+        Dispatches by the ``item_id`` type prefix to the matching
+        per-entity renderer (spec §5). The node must have been cached by a
+        previous :meth:`list_changes` call.
+        """
+        kind, node = self._cached(item_id)
+        markdown = render(kind, node)
+        return RawArtefact(
+            raw=markdown.encode("utf-8"),
+            mime=LINEAR_MARKDOWN_MIME,
+            fetched_at=_now_iso(),
+            sensitivity_hint=self._default_sensitivity,
+        )
+
+    def source_link(self, item_id: str) -> str:
+        """Return the linear.app URL for the cached node.
+
+        Falls back to a ``linear://`` shape when the node didn't carry a
+        URL (rare partial fetch).
+        """
+        node = self._node_cache.get(item_id)
+        if node is not None:
+            url = node.get("url")
+            if isinstance(url, str) and url:
+                return url
+        return f"linear://{item_id}"
+
+    def sensitivity_for(self, _item_id: str) -> Sensitivity:
+        """Return the connector-configured default sensitivity tier.
+
+        Spec §6: per-team / per-project overrides are Phase 2; v1 returns
+        the configured default for every item.
+        """
+        return self._default_sensitivity
+
+    def next_cursor(self) -> str | None:
+        """Return the high-water-mark cursor after the last clean drain.
+
+        Spec §4: ``None`` before the first call, or when the last tick
+        stopped early on the budget (so the orchestrator does NOT clobber
+        the previously-persisted cursor).
+        """
+        return self._next_cursor
+
+    def metadata_for(self, item_id: str) -> SourceMetadata:
+        """Return cached Linear envelope metadata for ``item_id`` (F65).
+
+        Spec §6: ``author`` / ``author_email`` from the item's creator
+        (issue/doc/update author; project lead); ``tags`` from Linear
+        labels; ``properties`` carry state / team / identifier / project /
+        url / health (whichever apply). Cache miss collapses to an empty
+        :class:`SourceMetadata`.
+        """
+        node = self._node_cache.get(item_id)
+        if node is None:
+            return SourceMetadata()
+        author, author_email = self._author_of(node)
+        return SourceMetadata(
+            modified_at=_opt_str(node.get("updatedAt")),
+            created_at=_opt_str(node.get("createdAt")),
+            author=author,
+            author_email=author_email,
+            tags=self._labels_of(node),
+            properties=self._properties_of(item_id, node),
+        )
+
+    # ------------------------------------------------------------------
+    # PollConnector capability
+    # ------------------------------------------------------------------
+
+    def list_changes_for_container(self, container: Container) -> Iterator[ChangeEvent]:
+        """Yield ChangeEvents since the container's cursor token.
+
+        Spec §1: the MVP treats the workspace as a single container, so
+        the container-scoped poll delegates to :meth:`list_changes` with
+        the container's cursor token as the high-water-mark.
+        """
+        return self.list_changes(container.cursor_token)
+
+    # ------------------------------------------------------------------
+    # SlimConnector capability
+    # ------------------------------------------------------------------
+
+    def retrieve_all_slim_docs(self, _container: Container) -> Iterator[str]:
+        """Enumerate every current item_id for the prune cycle (spec §4).
+
+        Yields the type-prefixed item_id for every node across all five
+        entity types from the EPOCH cursor (full enumeration). The
+        framework diffs the returned set against ``documents.item_id`` to
+        detect archives / deletes (id present last tick, absent now).
+        """
+        for spec in _ENTITY_SPECS:
+            for node in self._api.paginate(
+                _build_query(spec),
+                {"since": _EPOCH_ISO},
+                connection=spec.connection,
+            ):
+                item_id = self._item_id(spec, node)
+                if item_id is not None:
+                    yield item_id
+
+    # ------------------------------------------------------------------
+    # CredentialsConnector capability
+    # ------------------------------------------------------------------
+
+    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
+        """Validate + normalise the raw credential mapping (spec §1).
+
+        Accepts a mapping carrying an ``api_key`` (or legacy ``token``)
+        entry; returns the normalised ``{"api_key": <key>}`` mapping, or
+        ``None`` when no usable key is present (signalling the credential
+        is invalid for the Linear source kind).
+        """
+        raw = credentials.get("api_key") or credentials.get("token")
+        if not isinstance(raw, str) or not raw.strip():
+            return None
+        return {"api_key": raw.strip()}
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _node_to_event(self, spec: _EntitySpec, node: Mapping[str, Any]) -> ChangeEvent | None:
+        """Translate one entity node into a typed ``modified`` ChangeEvent."""
+        item_id = self._item_id(spec, node)
+        if item_id is None:
+            return None
+        modified_at = _opt_str(node.get("updatedAt")) or _now_iso()
+        parent_id = self._parent_id(node)
+        return ChangeEvent(
+            op="modified",
+            item_id=item_id,
+            modified_at=modified_at,
+            parent_id=parent_id,
+            metadata={
+                "sensitivity": self._default_sensitivity,
+                "kind": spec.prefix,
+                "mime": LINEAR_MARKDOWN_MIME,
+            },
+        )
+
+    def _item_id(self, spec: _EntitySpec, node: Mapping[str, Any]) -> str | None:
+        """Compute the type-prefixed item_id for a node.
+
+        Issues key on their human ``identifier`` (e.g. ``ENG-42``); every
+        other entity keys on its UUID ``id`` (spec §4). Returns ``None``
+        when the node carries no usable key.
+        """
+        if spec.prefix == "issue":
+            key = _opt_str(node.get(_FIELD_IDENTIFIER)) or _opt_str(node.get("id"))
+        else:
+            key = _opt_str(node.get("id"))
+        if not key:
+            return None
+        return f"{spec.prefix}{_PREFIX_SEP}{key}"
+
+    def _cached(self, item_id: str) -> tuple[str, Mapping[str, Any]]:
+        """Return ``(kind, node)`` for a cached item_id, or raise KeyError."""
+        node = self._node_cache.get(item_id)
+        if node is None:
+            raise KeyError(
+                f"linear: item_id {item_id!r} not in the per-tick node cache. "
+                "fix: call list_changes() before fetch()/metadata_for() so the "
+                "poll drain populates the node cache before the orchestrator asks for the body. "
+                "next: see kairix/core/connectors/pipeline.py for the list_changes -> fetch contract."
+            )
+        kind = item_id.split(_PREFIX_SEP, 1)[0]
+        return kind, node
+
+    @staticmethod
+    def _author_of(node: Mapping[str, Any]) -> tuple[str | None, str | None]:
+        """Resolve (author, author_email) from the node's creator/lead/user."""
+        for key in ("creator", "lead", "user", "assignee"):
+            person = node.get(key)
+            if isinstance(person, Mapping):
+                name = _opt_str(person.get("displayName"))
+                email = _opt_str(person.get("email"))
+                if name or email:
+                    return name, email
+        return None, None
+
+    @staticmethod
+    def _labels_of(node: Mapping[str, Any]) -> tuple[str, ...]:
+        """Pull Linear label names into a tuple (spec §6 tags)."""
+        labels = node.get("labels")
+        if not isinstance(labels, Mapping):
+            return ()
+        nodes = labels.get("nodes")
+        if not isinstance(nodes, list):
+            return ()
+        out: list[str] = []
+        for entry in nodes:
+            if isinstance(entry, Mapping):
+                name = _opt_str(entry.get("name"))
+                if name:
+                    out.append(name)
+        return tuple(out)
+
+    def _properties_of(self, item_id: str, node: Mapping[str, Any]) -> dict[str, str]:
+        """Build the spec §6 properties block (only the keys that apply)."""
+        props: dict[str, str] = {"kind": item_id.split(_PREFIX_SEP, 1)[0]}
+        _put(props, _FIELD_IDENTIFIER, node.get(_FIELD_IDENTIFIER))
+        _put(props, "state", _nested_name(node.get("state")))
+        _put(props, "team", _nested_name(node.get("team")))
+        _put(props, "project", _nested_name(node.get("project")))
+        _put(props, "url", node.get("url"))
+        _put(props, "health", node.get("health"))
+        return props
+
+    @staticmethod
+    def _parent_id(node: Mapping[str, Any]) -> str | None:
+        """Return the parent project id (issues / updates), prefixed, or None."""
+        project = node.get("project")
+        if isinstance(project, Mapping):
+            pid = _opt_str(project.get("id"))
+            if pid:
+                return f"project{_PREFIX_SEP}{pid}"
+        return None
+
+
+def _opt_str(value: Any) -> str | None:
+    """Return ``value`` as a non-empty stripped string, else ``None``."""
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _nested_name(value: Any) -> str | None:
+    """Pull ``.name`` from a nested object, or None."""
+    if isinstance(value, Mapping):
+        return _opt_str(value.get("name"))
+    return None
+
+
+def _put(props: dict[str, str], key: str, value: Any) -> None:
+    """Insert ``key`` into ``props`` when ``value`` resolves to a string."""
+    resolved = _opt_str(value)
+    if resolved is not None:
+        props[key] = resolved
+
+
+def make_connector(config: Mapping[str, Any]) -> LinearConnector:
+    """Construct a :class:`LinearConnector` from a config mapping.
+
+    Decision record (spec §13): the connector detects changes by
+    incremental polling (``PollConnector``, ``updatedAt`` cursor), NOT
+    webhooks — see :class:`LinearConnector` / spec §13 for the rationale.
+
+    Expected keys:
+
+      * ``default_sensitivity`` (optional) — one of the F39 sensitivity
+        literals; defaults to ``"internal"``.
+      * ``per_tick_max_items`` (optional) — F66 per-tick budget; defaults
+        to :data:`DEFAULT_PER_TICK_MAX_ITEMS`.
+
+    Credentials resolve via the connector's injected
+    :class:`SecretsResolver` — the canonical leaf is
+    ``("connector", "linear", None, "api_key")``.
+
+    Registered via ``[project.entry-points."kairix.connectors"]`` in
+    kairix's ``pyproject.toml`` so the orchestration layer can resolve
+    ``linear`` to this factory by name.
+    """
+    declared = config.get("default_sensitivity", DEFAULT_SENSITIVITY)
+    if declared not in _VALID_SENSITIVITIES:
+        raise ValueError(
+            f"linear: default_sensitivity {declared!r} is not a valid F39 tier. "
+            "fix: set default_sensitivity to one of "
+            "public / internal / client-confidential / personal. "
+            "next: see kairix/core/protocols.py Sensitivity for the literal set."
+        )
+    sensitivity = cast(Sensitivity, declared)
+    raw_budget = config.get("per_tick_max_items", DEFAULT_PER_TICK_MAX_ITEMS)
+    if not isinstance(raw_budget, int) or raw_budget < 1:
+        raise ValueError(
+            f"linear: per_tick_max_items {raw_budget!r} must be a positive integer. "
+            "fix: set per_tick_max_items to an integer >= 1 (default 500). "
+            "next: see kairix/connectors/linear/connector.py DEFAULT_PER_TICK_MAX_ITEMS."
+        )
+    return LinearConnector(default_sensitivity=sensitivity, per_tick_max_items=raw_budget)

--- a/kairix/connectors/linear/connector.py
+++ b/kairix/connectors/linear/connector.py
@@ -8,8 +8,11 @@ workspace (one workspace API key = one workspace, per spec §1).
 Change detection rides incremental polling: each tick queries the five
 entity types (issue / project / document / initiative / projectUpdate)
 filtered + ordered by ``updatedAt > cursor`` and emits one
-:class:`ChangeEvent` per node. The cursor is an ISO-8601 high-water-mark
-across all entity types, advancing only on a clean drain (spec §4).
+:class:`ChangeEvent` per node. The cursor is an opaque ``str`` token that
+JSON-encodes a **per-entity-type** ``updatedAt`` watermark map; each type
+advances its OWN watermark to the max ``updatedAt`` it emitted this tick
+(forward progress), so no type is starved or skipped under per-tick-budget
+pressure (spec §4).
 
 Decision record — incremental poll, NOT webhooks (spec §13)
 -----------------------------------------------------------
@@ -34,6 +37,7 @@ into the extractor layer.
 
 from __future__ import annotations
 
+import json
 import logging
 from collections.abc import Callable, Iterator, Mapping
 from dataclasses import dataclass
@@ -254,7 +258,9 @@ class LinearConnector:
         # ``fetch`` / ``metadata_for`` / ``source_link`` resolve without a
         # second API call. Keyed by the full type-prefixed item_id.
         self._node_cache: dict[str, Mapping[str, Any]] = {}
-        # High-water-mark cursor advanced on a clean drain (spec §4).
+        # Per-entity-type ``updatedAt`` watermark map, JSON-encoded into the
+        # opaque cursor token by :meth:`next_cursor` (spec §4). ``None``
+        # before the first :meth:`list_changes` call.
         self._next_cursor: str | None = None
 
     # ------------------------------------------------------------------
@@ -264,61 +270,75 @@ class LinearConnector:
     def list_changes(self, cursor: Cursor | None) -> Iterator[ChangeEvent]:
         """Stream changes across all five entity types since ``cursor``.
 
-        ``cursor`` is the ISO-8601 ``updatedAt`` high-water-mark; ``None``
-        triggers a full enumeration (initial sync). Each tick queries the
-        five entity types filtered by ``updatedAt > cursor``, yielding one
-        ``modified`` :class:`ChangeEvent` per node with a type-prefixed
-        ``item_id``. Honours :attr:`per_tick_max_items` (F66) — the tick
-        stops early and the cursor advances only on a clean drain.
+        ``cursor`` is an opaque token JSON-encoding a per-entity-type
+        ``updatedAt`` watermark map; ``None`` (or a malformed/legacy
+        single-string token) triggers a full enumeration (initial sync) for
+        every type. Each tick queries the five types filtered by
+        ``updatedAt > <that type's watermark>``, yielding one ``modified``
+        :class:`ChangeEvent` per node with a type-prefixed ``item_id``.
+
+        ONE global :attr:`per_tick_max_items` budget (F66) is shared across
+        the types this tick — a budget-hit on an earlier type just means
+        later types get fewer/none THIS tick. Each type advances its OWN
+        watermark to the max ``updatedAt`` it EMITTED (forward progress even
+        on a budget-limited partial drain), so no type is ever skipped past
+        its unprocessed items and every type makes progress across ticks.
+        Idempotent upsert makes re-fetching a boundary item harmless.
         """
-        since = cursor if cursor is not None else _EPOCH_ISO
+        watermarks = _decode_cursor(cursor)
         events: list[ChangeEvent] = []
-        budget_hit = any(self._drain_spec(spec, since, events) for spec in _ENTITY_SPECS)
-        # Cursor advances ONLY on a clean drain (spec §4 / §9). A
-        # budget-stopped tick leaves the persisted cursor untouched so the
-        # next tick re-drains from the last good high-water-mark.
-        if not budget_hit:
-            self._next_cursor = self._high_water(events, cursor)
+        for spec in _ENTITY_SPECS:
+            self._drain_spec(spec, watermarks, events)
+        # Each type's watermark moved forward to its own last-emitted
+        # updatedAt (spec §4). A type that drained nothing this tick keeps
+        # its prior watermark — never moves backwards, never skips.
+        self._next_cursor = _encode_cursor(watermarks)
         return iter(events)
 
-    def _drain_spec(self, spec: _EntitySpec, since: str, events: list[ChangeEvent]) -> bool:
-        """Drain one entity-type query into ``events``; return ``budget_hit``.
+    def _drain_spec(self, spec: _EntitySpec, watermarks: dict[str, str], events: list[ChangeEvent]) -> None:
+        """Drain one entity-type query into ``events``, advancing its watermark.
 
+        Reads + advances ONLY this type's watermark in ``watermarks``.
         Appends ChangeEvents (and caches nodes) until the page is exhausted
-        OR :attr:`per_tick_max_items` is reached. Returns ``True`` when the
-        budget stopped the drain mid-page (the caller must NOT advance the
-        cursor past this point, spec §4); ``False`` when the page drained
-        clean.
+        OR the shared :attr:`per_tick_max_items` budget is reached. The
+        type's watermark advances to the max ``updatedAt`` of the items it
+        EMITTED this tick — forward progress even on a budget-limited
+        partial drain (spec §4), so the next tick never re-skips an
+        un-emitted item nor re-fetches an already-emitted prefix endlessly.
+
+        Per-item isolation (spec §9): a node that raises on conversion is
+        logged at WARNING and skipped — never failing the whole tick.
         """
+        since = watermarks.get(spec.prefix, _EPOCH_ISO)
         for node in self._api.paginate(
             _build_query(spec),
             {"since": since},
             connection=spec.connection,
         ):
             if len(events) >= self.per_tick_max_items:
-                return True
-            event = self._node_to_event(spec, node)
+                return
+            try:
+                event = self._node_to_event(spec, node)
+            # spec §9 per-item isolation: one malformed node fails just that
+            # item (logged), never the whole tick — the broad catch IS the
+            # intended isolation boundary, hence the rationale-tagged catch.
+            except Exception:  # NOSONAR S112 — F3: spec §9 per-item isolation boundary.
+                logger.warning(
+                    "linear: skipping a malformed %s node — conversion raised; the tick continues.",
+                    spec.prefix,
+                    exc_info=True,
+                )
+                continue
             if event is None:
                 continue
             self._node_cache[event.item_id] = node
             events.append(event)
-        return False
-
-    @staticmethod
-    def _high_water(events: list[ChangeEvent], cursor: str | None) -> str | None:
-        """Return the max ISO timestamp across ``events`` and the prior ``cursor``.
-
-        The high-water-mark is the latest ``updatedAt`` observed in this
-        clean drain, never moving backwards: when the drain produced no
-        events the prior ``cursor`` is preserved, and a prior cursor newer
-        than every event (a defensive case) wins via ``max``.
-        """
-        candidates = [ev.modified_at for ev in events]
-        if cursor is not None:
-            candidates.append(cursor)
-        if not candidates:
-            return None
-        return max(candidates)
+            # Forward progress: advance THIS type's watermark to the latest
+            # updatedAt it has emitted, never moving it backwards. ``max``
+            # over the prior watermark keeps the mark monotonic even if the
+            # source returns a type's nodes out of updatedAt order.
+            prior = watermarks.get(spec.prefix)
+            watermarks[spec.prefix] = event.modified_at if prior is None else max(prior, event.modified_at)
 
     def fetch(self, item_id: str) -> RawArtefact:
         """Render one cached Linear entity as Markdown.
@@ -358,11 +378,14 @@ class LinearConnector:
         return self._default_sensitivity
 
     def next_cursor(self) -> str | None:
-        """Return the high-water-mark cursor after the last clean drain.
+        """Return the JSON-encoded per-entity-type watermark cursor.
 
-        Spec §4: ``None`` before the first call, or when the last tick
-        stopped early on the budget (so the orchestrator does NOT clobber
-        the previously-persisted cursor).
+        Spec §4: ``None`` before the first :meth:`list_changes` call.
+        After a tick it is the opaque token encoding each type's own
+        ``updatedAt`` watermark — every type advanced to its last-emitted
+        ``updatedAt`` (forward progress), so a budget-limited tick still
+        persists progress for the types it drained without skipping any
+        type's un-emitted items.
         """
         return self._next_cursor
 
@@ -561,6 +584,39 @@ def _put(props: dict[str, str], key: str, value: Any) -> None:
     resolved = _opt_str(value)
     if resolved is not None:
         props[key] = resolved
+
+
+def _decode_cursor(cursor: Cursor | None) -> dict[str, str]:
+    """Decode the opaque cursor token into a per-entity-type watermark map.
+
+    Spec §4: the cursor JSON-encodes ``{prefix: <iso-updatedAt>, ...}``.
+    Degrades safely so existing state never skips data:
+
+      * ``None`` → ``{}`` (no watermark for any type → full enumeration).
+      * a malformed / non-JSON / legacy single-ISO-string token → ``{}``
+        (treated as "no watermark for any type" → full enumeration, so a
+        pre-upgrade single-watermark cursor re-syncs rather than skipping).
+      * a JSON object → only its ``str: str`` entries are kept; any
+        non-string value is dropped (that type falls back to full enum).
+    """
+    if cursor is None:
+        return {}
+    try:
+        decoded = json.loads(cursor)
+    except (ValueError, TypeError):
+        return {}
+    if not isinstance(decoded, dict):
+        return {}
+    return {key: value for key, value in decoded.items() if isinstance(key, str) and isinstance(value, str) and value}
+
+
+def _encode_cursor(watermarks: Mapping[str, str]) -> str:
+    """JSON-encode the per-entity-type watermark map into the opaque token.
+
+    Keys are sorted so the token is deterministic (stable round-trip +
+    stable persisted state across ticks with the same watermarks).
+    """
+    return json.dumps(dict(watermarks), sort_keys=True)
 
 
 def make_connector(config: Mapping[str, Any]) -> LinearConnector:

--- a/kairix/connectors/linear/connector.py
+++ b/kairix/connectors/linear/connector.py
@@ -309,6 +309,8 @@ class LinearConnector:
         Per-item isolation (spec §9): a node that raises on conversion is
         logged at WARNING and skipped — never failing the whole tick.
         """
+        if len(events) >= self.per_tick_max_items:
+            return  # budget already full this tick — skip the GraphQL query entirely
         since = watermarks.get(spec.prefix, _EPOCH_ISO)
         for node in self._api.paginate(
             _build_query(spec),

--- a/kairix/connectors/linear/render.py
+++ b/kairix/connectors/linear/render.py
@@ -1,0 +1,229 @@
+"""Per-entity Markdown rendering for the Linear connector (spec §5).
+
+:func:`render` dispatches by entity ``kind`` to one of five per-entity
+renderers. Linear content (issue descriptions, document bodies, project
+overviews) is already Markdown at the source, so rendering is mostly a
+matter of emitting an H1 title, a field block, and the body — no block
+tree walk (unlike Notion). Each renderer tolerates absent / null fields
+because the GraphQL response leaves most fields optional.
+
+Chunking happens downstream in ``kairix/core/connectors/silver.py``
+(F38) — these functions only produce raw Markdown text; the connector
+encodes it to bytes for the :class:`RawArtefact`.
+
+Dispatch by the ``item_id`` type prefix (issue / project / document /
+initiative / projectUpdate) is the connector's job (see
+``connector.py``); this module renders one already-resolved node.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import Any
+
+# Entity kinds the connector recognises. The connector's ``item_id``
+# type prefix maps 1:1 onto these. Extracted as a frozenset so the
+# connector + tests share one source of truth for the valid kinds.
+ENTITY_KINDS: frozenset[str] = frozenset({"issue", "project", "document", "initiative", "projectUpdate"})
+
+# Field-label constants — extracted so the F17 duplicate-literal gate
+# stays green across the five renderers (several reuse the same labels).
+_LABEL_STATE = "State"
+_LABEL_ASSIGNEE = "Assignee"
+_LABEL_TEAM = "Team"
+_LABEL_PROJECT = "Project"
+_LABEL_LABELS = "Labels"
+_LABEL_URL = "URL"
+_LABEL_LEAD = "Lead"
+_LABEL_STATUS = "Status"
+_LABEL_TARGET_DATE = "Target date"
+_LABEL_HEALTH = "Health"
+_LABEL_DATE = "Date"
+
+# Node field name referenced ≥3 times — extracted for the F17 gate.
+_FIELD_DESCRIPTION = "description"
+
+
+def render(kind: str, node: Mapping[str, Any]) -> str:
+    """Render one Linear entity ``node`` to Markdown for the given ``kind``.
+
+    Args:
+        kind: One of :data:`ENTITY_KINDS`.
+        node: The GraphQL node dict for the entity.
+
+    Returns:
+        Markdown text (trailing single newline).
+
+    Raises:
+        ValueError: If ``kind`` is not a recognised entity kind — a
+            mis-typed item_id prefix is a bug in the dispatch table, not
+            a recoverable runtime condition.
+    """
+    renderer = _RENDERERS.get(kind)
+    if renderer is None:
+        raise ValueError(
+            f"linear render: unknown entity kind {kind!r}. "
+            f"fix: dispatch only the prefixes in ENTITY_KINDS "
+            f"(issue / project / document / initiative / projectUpdate). "
+            f"next: see kairix/connectors/linear/connector.py for the item_id prefix map."
+        )
+    return renderer(node)
+
+
+# ---------------------------------------------------------------------------
+# Per-entity renderers
+# ---------------------------------------------------------------------------
+
+
+def _render_issue(node: Mapping[str, Any]) -> str:
+    """Issue — ``# <identifier> <title>`` + field block + description body."""
+    identifier = _str(node.get("identifier"))
+    title = _str(node.get("title"))
+    heading = f"{identifier} {title}".strip() or "(untitled issue)"
+    fields: list[tuple[str, str]] = [
+        (_LABEL_STATE, _nested_name(node.get("state"))),
+        (_LABEL_ASSIGNEE, _nested_display(node.get("assignee"))),
+        (_LABEL_TEAM, _nested_name(node.get("team"))),
+        (_LABEL_PROJECT, _nested_name(node.get("project"))),
+        (_LABEL_LABELS, _join_labels(node.get("labels"))),
+        (_LABEL_URL, _str(node.get("url"))),
+    ]
+    return _assemble(heading, fields, _str(node.get(_FIELD_DESCRIPTION)))
+
+
+def _render_project(node: Mapping[str, Any]) -> str:
+    """Project — ``# <name>`` + status/lead/target-date block + description + milestones."""
+    heading = _str(node.get("name")) or "(untitled project)"
+    fields: list[tuple[str, str]] = [
+        (_LABEL_STATUS, _nested_name(node.get("status")) or _str(node.get("state"))),
+        (_LABEL_LEAD, _nested_display(node.get("lead"))),
+        (_LABEL_TARGET_DATE, _str(node.get("targetDate"))),
+        (_LABEL_URL, _str(node.get("url"))),
+    ]
+    milestones = _join_node_names(node.get("projectMilestones"))
+    body_parts: list[str] = []
+    description = _str(node.get(_FIELD_DESCRIPTION))
+    if description:
+        body_parts.append(description)
+    if milestones:
+        body_parts.append(f"## Milestones\n\n{milestones}")
+    return _assemble(heading, fields, "\n\n".join(body_parts))
+
+
+def _render_document(node: Mapping[str, Any]) -> str:
+    """Document — ``# <title>`` + content body (Linear Documents are Markdown)."""
+    heading = _str(node.get("title")) or "(untitled document)"
+    fields: list[tuple[str, str]] = [
+        (_LABEL_PROJECT, _nested_name(node.get("project"))),
+        (_LABEL_URL, _str(node.get("url"))),
+    ]
+    return _assemble(heading, fields, _str(node.get("content")))
+
+
+def _render_initiative(node: Mapping[str, Any]) -> str:
+    """Initiative — ``# <name>`` + overview/description + member projects."""
+    heading = _str(node.get("name")) or "(untitled initiative)"
+    fields: list[tuple[str, str]] = [
+        (_LABEL_STATUS, _nested_name(node.get("status")) or _str(node.get("status"))),
+        (_LABEL_URL, _str(node.get("url"))),
+    ]
+    member_projects = _join_node_names(node.get("projects"))
+    body_parts: list[str] = []
+    description = _str(node.get(_FIELD_DESCRIPTION))
+    if description:
+        body_parts.append(description)
+    if member_projects:
+        body_parts.append(f"## Projects\n\n{member_projects}")
+    return _assemble(heading, fields, "\n\n".join(body_parts))
+
+
+def _render_project_update(node: Mapping[str, Any]) -> str:
+    """Project / status update — narrative + health + date, attributed to its project."""
+    project_name = _nested_name(node.get("project"))
+    heading = f"Update — {project_name}".strip(" —") or "Project update"
+    fields: list[tuple[str, str]] = [
+        (_LABEL_PROJECT, project_name),
+        (_LABEL_HEALTH, _str(node.get("health"))),
+        (_LABEL_DATE, _str(node.get("createdAt"))),
+        (_LABEL_URL, _str(node.get("url"))),
+    ]
+    return _assemble(heading, fields, _str(node.get("body")))
+
+
+# ---------------------------------------------------------------------------
+# Shared shaping helpers
+# ---------------------------------------------------------------------------
+
+
+def _assemble(heading: str, fields: list[tuple[str, str]], body: str) -> str:
+    """Assemble the H1 heading, the non-empty field block, and the body."""
+    lines: list[str] = [f"# {heading}", ""]
+    field_lines = [f"- **{label}**: {value}" for label, value in fields if value]
+    if field_lines:
+        lines.extend(field_lines)
+        lines.append("")
+    body = body.strip()
+    if body:
+        lines.append(body)
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _str(value: Any) -> str:
+    """Return ``value`` as a stripped string, or empty for None / non-str."""
+    if isinstance(value, str):
+        return value.strip()
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _nested_name(value: Any) -> str:
+    """Pull ``.name`` from a nested object (state / team / project / status)."""
+    if isinstance(value, Mapping):
+        return _str(value.get("name"))
+    return ""
+
+
+def _nested_display(value: Any) -> str:
+    """Pull ``.displayName`` (falling back to ``.name``) from a user object."""
+    if isinstance(value, Mapping):
+        return _str(value.get("displayName")) or _str(value.get("name"))
+    return ""
+
+
+def _join_labels(value: Any) -> str:
+    """Join a Linear ``labels { nodes { name } }`` connection into a string."""
+    return _join_node_names(value)
+
+
+def _join_node_names(value: Any) -> str:
+    """Join a GraphQL ``{ nodes: [{ name } ...] }`` connection's names.
+
+    Tolerates the bare-list shape (already-unwrapped ``nodes``) too so a
+    fixture can pass either ``{"nodes": [...]}`` or ``[...]`` directly.
+    """
+    nodes: Any
+    if isinstance(value, Mapping):
+        nodes = value.get("nodes", [])
+    elif isinstance(value, list):
+        nodes = value
+    else:
+        return ""
+    names: list[str] = []
+    for entry in nodes:
+        name = _nested_name(entry) if isinstance(entry, Mapping) else _str(entry)
+        if name:
+            names.append(name)
+    return ", ".join(names)
+
+
+# Dispatch table — built after the renderers so the references resolve.
+# Keys mirror :data:`ENTITY_KINDS` exactly (a kind missing here would
+# raise in :func:`render`, which the unit tests pin).
+_RENDERERS: dict[str, Callable[[Mapping[str, Any]], str]] = {
+    "issue": _render_issue,
+    "project": _render_project,
+    "document": _render_document,
+    "initiative": _render_initiative,
+    "projectUpdate": _render_project_update,
+}

--- a/kairix/core/features/registry.py
+++ b/kairix/core/features/registry.py
@@ -208,6 +208,30 @@ REGISTRY: dict[str, FeatureFlag] = {
         owner=_CONNECTOR_FRAMEWORK_OWNER,
         related_spec="docs/architecture/connector-scope-topology/connector-design-specs/slack.md",
     ),
+    "connector_linear": FeatureFlag(
+        name="connector_linear",
+        default=False,
+        description=(
+            "Enable the Linear connector — polls workspace roadmap + docs "
+            "(issues / projects / documents / initiatives / project updates) "
+            "via the Linear GraphQL API filtered by updatedAt, renders each "
+            "entity to Markdown, and dispatches the markdown bytes through "
+            "the kairix extractor registry. HTTPS-only; incremental poll, "
+            "NOT webhooks (linear.md §13). When OFF the connector slot is a "
+            "no-op; when ON the cc_pair drains every 5 entity types on the "
+            "updatedAt high-water-mark cursor."
+        ),
+        stage="introduce",
+        # Linear cutover plan (per docs/architecture/feature-flag-architecture.md §7 and
+        # docs/architecture/connector-scope-topology/connector-design-specs/linear.md §8):
+        # Greenfield (no legacy slice). Twelve-month retire window matches the
+        # slower-adoption connector cohort (per-workspace API-key provisioning
+        # cadence); shares the Wave-E window constant with the slack/github pilots.
+        introduced_in=_FLAG_INTRODUCED_WAVE_E_LATER,
+        target_retire_in=_LONG_RETIRE_WINDOW_WAVE_E,
+        owner=_CONNECTOR_FRAMEWORK_OWNER,
+        related_spec="docs/architecture/connector-scope-topology/connector-design-specs/linear.md",
+    ),
     # bronze_ttl_gc removed in Phase 7 of streaming-bronze (#27) — streaming
     # bronze writes no on-disk blobs so there's nothing for a TTL-based GC
     # to bound. The maintenance stage that backed this flag is a no-op now.

--- a/kairix/worker.py
+++ b/kairix/worker.py
@@ -1375,6 +1375,58 @@ def dispatch_notion_sync(
     return off_branch()
 
 
+def linear_off_branch_noop() -> ConnectorSyncResult:
+    """OFF-branch default for :func:`dispatch_linear_sync` —
+    return zero counters and emit the operator-visible signal that the
+    Linear connector is gated off.
+
+    F6-clean: a real callable default, no ``None``. Public so the
+    feature-flag BDD steps can reach it without an internal-name
+    import (F5).
+    """
+    logger.info("worker: linear connector gated off (flag OFF)")
+    return ConnectorSyncResult(synced=0, failed=0, dead_letter_added=0)
+
+
+def run_via_linear_connector() -> ConnectorSyncResult:
+    """ON-branch default for :func:`dispatch_linear_sync` — delegate
+    to the canonical :func:`run_connector_sync_pipeline` which resolves
+    the ``linear`` plugin via its entry-point factory and drives the
+    standard ConnectorPipeline.
+
+    The branch log distinguishes the Linear path from the sibling
+    notion / m365 / sharepoint paths so operators can tell which
+    connector ran by grep-ing INFO logs.
+    """
+    logger.info("worker: linear connector running (flag ON)")
+    return run_connector_sync_pipeline()
+
+
+def dispatch_linear_sync(
+    read_flag: Callable[[str], bool] = _default_flag_value,
+    on_branch: Callable[[], ConnectorSyncResult] = run_via_linear_connector,
+    off_branch: Callable[[], ConnectorSyncResult] = linear_off_branch_noop,
+) -> ConnectorSyncResult:
+    """Compose the flag-branching dispatcher for the Linear connector slot.
+
+    Reads the ``connector_linear`` flag and routes to the ON branch
+    (the standard connector pipeline, which resolves the ``linear``
+    plugin) or the OFF branch (a no-op that skips the connector
+    entirely). Mirrors :func:`dispatch_notion_sync` shape — the BDD +
+    integration tests pin the flag through
+    :class:`FakeFeatureFlagResolver` and observe the branch via the
+    per-helper INFO log.
+
+    Gating happens at the connector-selection boundary — when OFF, the
+    linear plugin never runs even if listed in ``kairix.config.yaml``.
+    When ON, the connector is selected via the standard config +
+    entry-point shape.
+    """
+    if read_flag("connector_linear"):
+        return on_branch()
+    return off_branch()
+
+
 def gmail_off_branch_noop() -> ConnectorSyncResult:
     """OFF-branch default for :func:`dispatch_gmail_sync` —
     return zero counters and emit the operator-visible signal that the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,6 +245,7 @@ gmail              = "kairix.connectors.gmail:make_connector"
 google_drive       = "kairix.connectors.google_drive:make_connector"
 apple_caldav       = "kairix.connectors.apple_caldav:make_connector"
 google_calendar    = "kairix.connectors.google_calendar:make_connector"
+linear             = "kairix.connectors.linear:make_connector"
 
 # Extractor plugin discovery — same shape as kairix.providers above.
 # Per-format-family plugins live under kairix/extractors/<name>/ and

--- a/tests/bdd/features/connector_linear.feature
+++ b/tests/bdd/features/connector_linear.feature
@@ -1,0 +1,36 @@
+@connector @linear @wave-5
+Feature: Linear connector pulls workspace roadmap and docs via the Linear GraphQL API
+  As an operator running kairix against a Linear workspace
+  I want every changed roadmap and doc item to surface as a typed change event
+  So that issues, projects, documents, initiatives and updates land in the index
+  with the right source link and sensitivity without me writing per-entity glue.
+
+  The connector polls five entity types filtered and ordered by updatedAt,
+  renders each to Markdown, and emits one type-prefixed change event per
+  item. All traffic is HTTPS-only. The default sensitivity tier is
+  internal per spec section 1. See
+  docs/architecture/connector-scope-topology/connector-design-specs/linear.md.
+
+  @happy_path
+  Scenario: A changed Linear issue surfaces as a modified change event
+    Given a stubbed Linear workspace that returns one changed issue
+    When the operator runs the linear connector list_changes with no cursor
+    Then one linear modified change event is emitted
+    And the linear change event item id is prefixed with the issue type
+    And the linear change event carries an ISO-8601 modified_at timestamp
+    And the linear change event's sensitivity tier is internal
+
+  @cursor_advance
+  Scenario: The connector advances its high-water-mark cursor after a clean drain
+    Given a stubbed Linear workspace that returns one changed issue
+    When the operator runs the linear connector list_changes with no cursor
+    Then the linear connector exposes a non-empty next cursor
+    And the linear next cursor matches the highest updatedAt seen
+
+  @render
+  Scenario: A fetched Linear issue renders to Markdown
+    Given a stubbed Linear workspace that returns one changed issue
+    When the operator runs the linear connector list_changes with no cursor
+    And the operator fetches the changed linear issue
+    Then the fetched linear artefact is Markdown
+    And the fetched linear artefact contains the issue identifier

--- a/tests/bdd/features/e2e_connector_sync.feature
+++ b/tests/bdd/features/e2e_connector_sync.feature
@@ -44,3 +44,5 @@ Feature: End-to-end connector sync journey
       | google_drive        | passthrough  |
       | apple_caldav        | passthrough  |
       | google_calendar     | passthrough  |
+      | linear              | passthrough  |
+      | linear              | markitdown   |

--- a/tests/bdd/features/feature_flag_connector_linear.feature
+++ b/tests/bdd/features/feature_flag_connector_linear.feature
@@ -1,0 +1,24 @@
+@feature_flag @connector_linear
+Feature: Operator toggles the Linear connector feature flag
+  As an operator running a kairix deployment
+  I want to choose whether the Linear connector is enabled
+  So that I can validate the new ingest path before cutting over and roll back safely if needed
+
+  The flag gates the connector at the dispatch boundary. When OFF the
+  connector slot is a no-op (zero counters); when ON the standard
+  connector pipeline resolves the linear plugin via its entry-point and
+  runs one sync tick. See docs/architecture/feature-flag-architecture.md §7.
+
+  @happy_path @off
+  Scenario: Flag OFF — the Linear connector slot is a no-op
+    Given the operator has the linear connector flag set to false
+    When the worker linear connector sync tick runs
+    Then the linear connector OFF branch log appears
+    And the linear connector ON branch does not run
+
+  @happy_path @on
+  Scenario: Flag ON — the Linear connector pipeline runs
+    Given the operator has the linear connector flag set to true
+    When the worker linear connector sync tick runs
+    Then the linear connector ON branch log appears
+    And the linear connector OFF branch does not run

--- a/tests/bdd/steps/connector_linear_steps.py
+++ b/tests/bdd/steps/connector_linear_steps.py
@@ -1,0 +1,166 @@
+"""Step definitions for connector_linear.feature.
+
+Drives the real :class:`kairix.connectors.linear.LinearConnector`
+against a scripted :class:`tests.fakes.FakeLinearApiClient`. No real
+network call — the fake returns one issue node so the behaviour
+assertions can pin the typed ChangeEvent shape, the type-prefixed
+item_id, the high-water-mark cursor, and the Markdown rendering.
+
+Per F46, this step file reaches the connector through the real
+constructor + the ``client_builder`` DI seam (depth <= 2). Direct
+construction is permitted in BDD step files when the target is a
+Protocol-compliant leaf such as ``LinearConnector``.
+
+F1-clean: no @patch / kairix module-attribute substitution.
+F2-clean: no KAIRIX_* env-var manipulation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+from pytest_bdd import given, parsers, then, when
+
+from kairix.connectors.linear import (
+    LinearConnector,
+    LinearCredentials,
+)
+from kairix.core.protocols import ChangeEvent, RawArtefact
+from tests.fakes import FakeLinearApiClient
+
+pytestmark = pytest.mark.bdd
+
+_ISSUE_IDENTIFIER = "ENG-101"
+_ISSUE_TITLE = "Ship the roadmap recall path"
+_ISSUE_URL = "https://linear.app/your-team/issue/ENG-101"
+_UPDATED_AT = "2026-05-22T10:00:00.000Z"
+
+
+def _one_issue_node() -> dict[str, Any]:
+    """One Linear issue node as the GraphQL surface returns it."""
+    return {
+        "id": "uuid-issue-0001",
+        "identifier": _ISSUE_IDENTIFIER,
+        "title": _ISSUE_TITLE,
+        "description": "We need recall over the roadmap.",
+        "url": _ISSUE_URL,
+        "createdAt": "2026-05-20T09:00:00.000Z",
+        "updatedAt": _UPDATED_AT,
+        "state": {"name": "In Progress", "type": "started"},
+        "assignee": {"displayName": "agent-alpha", "email": "agent-alpha@example.com"},
+        "creator": {"displayName": "agent-beta", "email": "agent-beta@example.com"},
+        "team": {"key": "ENG", "name": "Engineering"},
+        "project": {"id": "uuid-project-0001", "name": "Roadmap recall"},
+        "labels": {"nodes": [{"name": "roadmap"}]},
+    }
+
+
+@dataclass
+class _Ctx:
+    """Per-scenario context — no module-level mutable state."""
+
+    connector: LinearConnector | None = None
+    events: list[ChangeEvent] = field(default_factory=list)
+    artefact: RawArtefact | None = None
+
+
+@pytest.fixture
+def linear_ctx() -> _Ctx:
+    return _Ctx()
+
+
+def _build_connector() -> LinearConnector:
+    """Construct the real connector wired to a scripted Linear API."""
+    api = FakeLinearApiClient(pages={"issues": [[_one_issue_node()]]})
+    return LinearConnector(
+        credentials=LinearCredentials(api_key="lin_api_fixture_key"),  # pragma: allowlist secret — test fixture
+        client_builder=lambda _creds: api,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Givens
+# ---------------------------------------------------------------------------
+
+
+@given(parsers.parse("a stubbed Linear workspace that returns one changed issue"))
+def _given_one_issue(linear_ctx: _Ctx) -> None:
+    linear_ctx.connector = _build_connector()
+
+
+# ---------------------------------------------------------------------------
+# Whens
+# ---------------------------------------------------------------------------
+
+
+@when(parsers.parse("the operator runs the linear connector list_changes with no cursor"))
+def _when_list_changes(linear_ctx: _Ctx) -> None:
+    assert linear_ctx.connector is not None, "Given step must run before When"
+    linear_ctx.events = list(linear_ctx.connector.list_changes(cursor=None))
+
+
+@when("the operator fetches the changed linear issue")
+def _when_fetch(linear_ctx: _Ctx) -> None:
+    assert linear_ctx.connector is not None
+    assert linear_ctx.events, "list_changes must run (and emit) before fetch"
+    linear_ctx.artefact = linear_ctx.connector.fetch(linear_ctx.events[0].item_id)
+
+
+# ---------------------------------------------------------------------------
+# Thens
+# ---------------------------------------------------------------------------
+
+
+@then("one linear modified change event is emitted")
+def _one_modified_event(linear_ctx: _Ctx) -> None:
+    events = linear_ctx.events
+    assert len(events) == 1, f"expected 1 event, got {len(events)}: {events!r}"
+    assert events[0].op == "modified", f"expected modified op, got {events[0]!r}"
+
+
+@then("the linear change event item id is prefixed with the issue type")
+def _event_prefixed(linear_ctx: _Ctx) -> None:
+    item_id = linear_ctx.events[0].item_id
+    assert item_id == f"issue:{_ISSUE_IDENTIFIER}", f"unexpected item_id: {item_id!r}"
+
+
+@then("the linear change event carries an ISO-8601 modified_at timestamp")
+def _event_has_iso(linear_ctx: _Ctx) -> None:
+    event = linear_ctx.events[0]
+    assert event.modified_at == _UPDATED_AT, f"event {event!r} modified_at mismatch"
+    assert event.modified_at.endswith("Z"), f"modified_at not ISO-8601: {event.modified_at!r}"
+
+
+@then("the linear change event's sensitivity tier is internal")
+def _event_internal_tier(linear_ctx: _Ctx) -> None:
+    tier = linear_ctx.events[0].metadata.get("sensitivity")
+    assert tier == "internal", f"event sensitivity is not internal: {tier!r}"
+
+
+@then("the linear connector exposes a non-empty next cursor")
+def _connector_has_cursor(linear_ctx: _Ctx) -> None:
+    assert linear_ctx.connector is not None
+    cursor = linear_ctx.connector.next_cursor()
+    assert cursor, f"expected non-empty next cursor, got {cursor!r}"
+
+
+@then("the linear next cursor matches the highest updatedAt seen")
+def _cursor_matches_high_water(linear_ctx: _Ctx) -> None:
+    assert linear_ctx.connector is not None
+    cursor = linear_ctx.connector.next_cursor()
+    assert cursor == _UPDATED_AT, f"cursor must equal the issue's updatedAt; got {cursor!r}"
+
+
+@then("the fetched linear artefact is Markdown")
+def _artefact_is_markdown(linear_ctx: _Ctx) -> None:
+    assert linear_ctx.artefact is not None, "fetch step must run first"
+    assert linear_ctx.artefact.mime == "text/markdown", f"unexpected mime: {linear_ctx.artefact.mime!r}"
+
+
+@then("the fetched linear artefact contains the issue identifier")
+def _artefact_contains_identifier(linear_ctx: _Ctx) -> None:
+    assert linear_ctx.artefact is not None
+    body = linear_ctx.artefact.raw.decode("utf-8")
+    assert _ISSUE_IDENTIFIER in body, f"rendered Markdown missing identifier: {body!r}"

--- a/tests/bdd/steps/connector_linear_steps.py
+++ b/tests/bdd/steps/connector_linear_steps.py
@@ -148,9 +148,15 @@ def _connector_has_cursor(linear_ctx: _Ctx) -> None:
 
 @then("the linear next cursor matches the highest updatedAt seen")
 def _cursor_matches_high_water(linear_ctx: _Ctx) -> None:
+    import json
+
     assert linear_ctx.connector is not None
     cursor = linear_ctx.connector.next_cursor()
-    assert cursor == _UPDATED_AT, f"cursor must equal the issue's updatedAt; got {cursor!r}"
+    assert cursor is not None, "expected a next cursor after a clean drain"
+    # The opaque cursor JSON-encodes a per-entity-type watermark map; the
+    # issue type's watermark must equal the only issue's updatedAt.
+    decoded = json.loads(cursor)
+    assert decoded.get("issue") == _UPDATED_AT, f"issue watermark must equal the issue's updatedAt; got {decoded!r}"
 
 
 @then("the fetched linear artefact is Markdown")

--- a/tests/bdd/steps/feature_flag_connector_linear_steps.py
+++ b/tests/bdd/steps/feature_flag_connector_linear_steps.py
@@ -1,0 +1,149 @@
+"""Step definitions for feature_flag_connector_linear.feature.
+
+Drives the production :func:`kairix.worker.dispatch_linear_sync`
+composition surface with the flag value pinned through the canonical
+:class:`FakeFeatureFlagResolver` from ``tests/fakes.py``. No
+``@patch``, no ``monkeypatch.setattr`` on kairix internals, no
+``KAIRIX_FEATURE_*`` env vars.
+
+Per F46, steps reach a sanctioned entry point in their call graph
+(depth <= 2). ``dispatch_linear_sync`` delegates to either the
+ON-branch default (which wraps :func:`run_connector_sync_pipeline`)
+or the OFF-branch default (a no-op returning zero counters).
+
+Both branches log a distinct INFO message at entry; the assertion
+target is the branch-identifier log line, not the counters. The ON
+branch is wrapped with a never-call stub here so we don't drive a
+real connector-pipeline run during a BDD scenario — the branch
+selection is the property under test.
+
+F1-clean: no @patch / module-attribute substitution on kairix.
+F2-clean: no ``KAIRIX_*`` env-var manipulation.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import pytest
+from pytest_bdd import given, parsers, then, when
+
+from kairix.worker import (
+    ConnectorSyncResult,
+    dispatch_linear_sync,
+    linear_off_branch_noop,
+    run_via_linear_connector,
+)
+from tests.fakes import FakeFeatureFlagResolver
+
+pytestmark = pytest.mark.bdd
+
+_ON_BRANCH_MARKER = "linear connector running (flag ON)"
+_OFF_BRANCH_MARKER = "linear connector gated off (flag OFF)"
+
+
+@dataclass
+class _Ctx:
+    """Per-scenario context — no module-level mutable state."""
+
+    resolver: FakeFeatureFlagResolver | None = None
+    captured_logs: list[str] | None = None
+    branch_result: ConnectorSyncResult | None = None
+    on_branch_calls: int = 0
+    off_branch_calls: int = 0
+
+
+@pytest.fixture
+def linear_flag_ctx() -> _Ctx:
+    return _Ctx()
+
+
+# ---------------------------------------------------------------------------
+# Givens
+# ---------------------------------------------------------------------------
+
+
+@given(parsers.parse("the operator has the linear connector flag set to {value}"))
+def _operator_sets_flag(linear_flag_ctx: _Ctx, value: str) -> None:
+    """Pin the flag's value via :class:`FakeFeatureFlagResolver`."""
+    parsed = value.strip().lower() == "true"
+    linear_flag_ctx.resolver = FakeFeatureFlagResolver().with_flag("connector_linear", parsed)
+
+
+# ---------------------------------------------------------------------------
+# Whens
+# ---------------------------------------------------------------------------
+
+
+@when("the worker linear connector sync tick runs")
+def _worker_tick_runs(linear_flag_ctx: _Ctx, caplog: pytest.LogCaptureFixture) -> None:
+    """Invoke the production :func:`dispatch_linear_sync`.
+
+    The ON / OFF branches are wrapped so we observe selection without
+    driving a real connector-pipeline run in a BDD scenario (the
+    integration test is the home for the composed-pipeline assertions).
+    The branch helpers still log via the production marker text so the
+    distinct INFO markers fire.
+    """
+    resolver = linear_flag_ctx.resolver
+    assert resolver is not None, "Given step must run before When"
+
+    def _wrapped_on() -> ConnectorSyncResult:
+        linear_flag_ctx.on_branch_calls += 1
+        logging.getLogger("kairix.worker").info(_ON_BRANCH_MARKER)
+        return ConnectorSyncResult(synced=0, failed=0, dead_letter_added=0)
+
+    def _wrapped_off() -> ConnectorSyncResult:
+        linear_flag_ctx.off_branch_calls += 1
+        return linear_off_branch_noop()
+
+    # Reference the production default ON helper to keep its symbol
+    # live for F52's call-site scan.
+    _ = run_via_linear_connector
+
+    with caplog.at_level(logging.INFO, logger="kairix.worker"):
+        linear_flag_ctx.branch_result = dispatch_linear_sync(
+            read_flag=resolver.get,
+            on_branch=_wrapped_on,
+            off_branch=_wrapped_off,
+        )
+
+    linear_flag_ctx.captured_logs = [rec.getMessage() for rec in caplog.records]
+
+
+# ---------------------------------------------------------------------------
+# Thens
+# ---------------------------------------------------------------------------
+
+
+def _has_marker(logs: list[str] | None, marker: str) -> bool:
+    return any(marker in line for line in (logs or []))
+
+
+@then("the linear connector OFF branch log appears")
+def _off_branch_log(linear_flag_ctx: _Ctx) -> None:
+    assert _has_marker(linear_flag_ctx.captured_logs, _OFF_BRANCH_MARKER), (
+        f"expected the linear OFF branch log; got {linear_flag_ctx.captured_logs!r}"
+    )
+
+
+@then("the linear connector ON branch log appears")
+def _on_branch_log(linear_flag_ctx: _Ctx) -> None:
+    assert _has_marker(linear_flag_ctx.captured_logs, _ON_BRANCH_MARKER), (
+        f"expected the linear ON branch log; got {linear_flag_ctx.captured_logs!r}"
+    )
+
+
+@then("the linear connector ON branch does not run")
+def _on_branch_skipped(linear_flag_ctx: _Ctx) -> None:
+    assert linear_flag_ctx.on_branch_calls == 0, (
+        f"expected ON branch to NOT run; on_branch_calls={linear_flag_ctx.on_branch_calls}"
+    )
+
+
+@then("the linear connector OFF branch does not run")
+def _off_branch_skipped(linear_flag_ctx: _Ctx) -> None:
+    assert linear_flag_ctx.off_branch_calls == 0, (
+        f"expected OFF branch to NOT run; off_branch_calls={linear_flag_ctx.off_branch_calls}"
+    )

--- a/tests/bdd/test_connector_linear.py
+++ b/tests/bdd/test_connector_linear.py
@@ -1,0 +1,20 @@
+"""pytest-bdd binding for connector_linear.feature (Linear connector).
+
+Steps live in :mod:`tests.bdd.steps.connector_linear_steps`.
+
+The scenarios exercise the real
+:class:`kairix.connectors.linear.LinearConnector` against a scripted
+:class:`tests.fakes.FakeLinearApiClient` (no real network call, no
+monkey-patching, no internal-substitution fakes).
+"""
+
+from pathlib import Path
+
+import pytest
+from pytest_bdd import scenarios
+
+FEATURE = str(Path(__file__).parent / "features" / "connector_linear.feature")
+
+pytestmark = pytest.mark.bdd
+
+scenarios(FEATURE)

--- a/tests/bdd/test_feature_flag_connector_linear.py
+++ b/tests/bdd/test_feature_flag_connector_linear.py
@@ -1,0 +1,20 @@
+"""pytest-bdd binding for feature_flag_connector_linear.feature.
+
+Steps live in :mod:`tests.bdd.steps.feature_flag_connector_linear_steps`.
+
+Both branches drive the production
+:func:`kairix.worker.dispatch_linear_sync` with the flag pinned via
+:class:`tests.fakes.FakeFeatureFlagResolver`. No env-var manipulation,
+no @patch — F1/F2 clean.
+"""
+
+from pathlib import Path
+
+import pytest
+from pytest_bdd import scenarios
+
+FEATURE = str(Path(__file__).parent / "features" / "feature_flag_connector_linear.feature")
+
+pytestmark = pytest.mark.bdd
+
+scenarios(FEATURE)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -241,6 +241,8 @@ pytest_plugins = [
     # docs/architecture/connector-scope-topology/connector-design-specs/slack.md.
     "tests.bdd.steps.connector_slack_steps",
     "tests.bdd.steps.feature_flag_connector_slack_steps",
+    "tests.bdd.steps.connector_linear_steps",
+    "tests.bdd.steps.feature_flag_connector_linear_steps",
     # IM-6 FTS-gap regression pin — connector-ingested chunks must be
     # findable via BM25 (the cutover surfaced 68,814 chunks in the
     # ``obsidian`` collection invisible to BM25 because the chunk-writer

--- a/tests/connectors/linear/test_api_client.py
+++ b/tests/connectors/linear/test_api_client.py
@@ -1,0 +1,386 @@
+"""Unit tests for :class:`kairix.connectors.linear.LinearApiClient`.
+
+Scope:
+  * HTTPS-only guard — ``http://`` endpoint rejected at construction time.
+  * 429 backoff (F64) — client retries and succeeds; injected sleeper
+    callable records sleep durations so the test can assert retry happened
+    without wall-clock waits.
+  * Pagination — ``paginate()`` drains two scripted pages and stops at
+    ``hasNextPage=false``.
+  * Error surfaces — GraphQL ``errors`` key, missing ``data`` key, and
+    429 exhaustion all raise the documented exception.
+
+F1-clean (no monkey-patching or @patch). F8 carries ``@pytest.mark.unit``.
+The sleeper seam is a plain ``Callable[[float], None]`` injected through
+the constructor; the HTTP client is injected via ``httpx.MockTransport``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from kairix.connectors.linear.api_client import (
+    LINEAR_DEFAULT_RETRY_AFTER_S,
+    LINEAR_GRAPHQL_ENDPOINT,
+    LinearApiClient,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+class _RecordingSleeper:
+    """Callable sleeper that records durations instead of sleeping.
+
+    Passed as ``sleeper=`` to ``LinearApiClient`` (the seam is a plain
+    ``Callable[[float], None]``) so tests run at full speed while still
+    asserting retry behaviour — no real ``time.sleep`` in tests.
+    """
+
+    def __init__(self) -> None:
+        self.sleeps: list[float] = []
+
+    def __call__(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+
+
+def _make_gql_response(data: dict[str, Any]) -> httpx.Response:
+    """Build a successful 200 GraphQL response JSON envelope."""
+    return httpx.Response(200, json={"data": data})
+
+
+def _make_gql_page(
+    connection: str,
+    nodes: list[dict[str, Any]],
+    *,
+    has_next: bool,
+    end_cursor: str | None,
+) -> dict[str, Any]:
+    """Build a single GraphQL connection page payload."""
+    return {
+        connection: {
+            "nodes": nodes,
+            "pageInfo": {
+                "hasNextPage": has_next,
+                "endCursor": end_cursor,
+            },
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — HTTPS-only guard
+# ---------------------------------------------------------------------------
+
+
+def test_https_guard_rejects_http_endpoint() -> None:
+    """LinearApiClient raises ValueError on a non-https endpoint.
+
+    Spec §3: the client enforces HTTPS-only; no code path may issue an
+    ``http://`` request. The guard lives in ``__init__`` so a mis-configured
+    endpoint is caught immediately at construction time, not at first use.
+    """
+    with pytest.raises(ValueError, match="https"):
+        LinearApiClient(api_key="k", endpoint="http://evil.example/graphql")
+
+
+def test_https_guard_accepts_default_endpoint() -> None:
+    """The default endpoint constant is ``https://``."""
+    assert LINEAR_GRAPHQL_ENDPOINT.startswith("https://")
+    client = LinearApiClient(api_key="k")
+    assert client is not None
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — 429 backoff (F64 rate-limit test)
+# ---------------------------------------------------------------------------
+
+
+def test_query_retries_on_429_and_succeeds() -> None:
+    """query() retries once after a 429 and returns the data on success.
+
+    The injected sleeper records the sleep call so we can assert the
+    retry happened without any real wall-clock wait.
+    """
+    call_count: list[int] = [0]
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return httpx.Response(
+                429,
+                headers={"Retry-After": "1"},
+                json={"error": "rate limited"},
+            )
+        return _make_gql_response({"viewer": {"id": "u-1"}})
+
+    transport = httpx.MockTransport(_handler)
+    http = httpx.Client(transport=transport)
+    sleeper = _RecordingSleeper()
+
+    client = LinearApiClient(api_key="test-key", http=http, sleeper=sleeper)
+    result = client.query("query { viewer { id } }", {})
+
+    assert result == {"viewer": {"id": "u-1"}}
+    assert call_count[0] == 2, "expected exactly one retry after the 429"
+    assert len(sleeper.sleeps) >= 1, "expected sleeper called at least once"
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — Pagination
+# ---------------------------------------------------------------------------
+
+
+def test_paginate_yields_all_nodes_across_two_pages() -> None:
+    """paginate() drains two pages and stops at hasNextPage=false.
+
+    Each page is served by the scripted handler. The first page carries
+    ``hasNextPage=true`` and an ``endCursor``; the second page carries
+    ``hasNextPage=false``. The iterator must yield all nodes from both
+    pages and then stop.
+    """
+    pages_served: list[int] = [0]
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        variables = body.get("variables", {})
+        after = variables.get("after")
+
+        pages_served[0] += 1
+        if after is None:
+            data = _make_gql_page(
+                "issues",
+                nodes=[{"id": "i-1", "title": "First"}, {"id": "i-2", "title": "Second"}],
+                has_next=True,
+                end_cursor="cursor-abc",
+            )
+        else:
+            data = _make_gql_page(
+                "issues",
+                nodes=[{"id": "i-3", "title": "Third"}],
+                has_next=False,
+                end_cursor=None,
+            )
+        return _make_gql_response(data)
+
+    transport = httpx.MockTransport(_handler)
+    http = httpx.Client(transport=transport)
+    sleeper = _RecordingSleeper()
+
+    client = LinearApiClient(api_key="test-key", http=http, sleeper=sleeper)
+    doc = "query($after: String) { issues { nodes { id title } pageInfo { hasNextPage endCursor } } }"
+    nodes = list(client.paginate(doc, {}, connection="issues"))
+
+    assert [n["id"] for n in nodes] == ["i-1", "i-2", "i-3"]
+    assert pages_served[0] == 2, "expected exactly two pages fetched"
+    assert len(sleeper.sleeps) == 0, "no rate-limit hit; sleeper should not have been called"
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — Empty-cursor guard
+# ---------------------------------------------------------------------------
+
+
+def test_paginate_stops_on_empty_string_cursor() -> None:
+    """paginate() stops when endCursor is an empty string.
+
+    Pins the ``or not cursor`` branch on the cursor validity guard:
+    an empty-string endCursor is logically absent even if ``hasNextPage``
+    is True. Without this test, a mutant that changes ``or`` to ``and``
+    would survive — an empty cursor would be advanced as a real one.
+    """
+    call_count: list[int] = [0]
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        call_count[0] += 1
+        data = _make_gql_page(
+            "issues",
+            nodes=[{"id": "i-1"}],
+            has_next=True,
+            end_cursor="",  # empty — treated as absent
+        )
+        return _make_gql_response(data)
+
+    transport = httpx.MockTransport(_handler)
+    http = httpx.Client(transport=transport)
+    sleeper = _RecordingSleeper()
+
+    client = LinearApiClient(api_key="test-key", http=http, sleeper=sleeper)
+    _doc = "query { issues { nodes { id } pageInfo { hasNextPage endCursor } } }"
+    nodes = list(client.paginate(_doc, {}, connection="issues"))
+
+    assert [n["id"] for n in nodes] == ["i-1"]
+    assert call_count[0] == 1, "empty endCursor should stop pagination after one page"
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — Retry-After: 0 uses the default delay
+# ---------------------------------------------------------------------------
+
+
+def test_query_uses_default_retry_delay_when_retry_after_is_zero() -> None:
+    """query() uses the default delay when the Retry-After header is '0'.
+
+    Pins the ``value > 0`` guard in ``_parse_retry_after``: a zero value
+    is not a valid delay and must fall back to the default. Without this
+    test, a mutant that changes ``>`` to ``>=`` would survive — a Retry-After
+    of 0 would be used directly (meaning no wait) rather than falling back.
+    """
+    call_count: list[int] = [0]
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return httpx.Response(
+                429,
+                headers={"Retry-After": "0"},
+                json={"error": "rate limited"},
+            )
+        return _make_gql_response({"viewer": {"id": "u-1"}})
+
+    transport = httpx.MockTransport(_handler)
+    http = httpx.Client(transport=transport)
+    sleeper = _RecordingSleeper()
+
+    client = LinearApiClient(api_key="test-key", http=http, sleeper=sleeper)
+    result = client.query("query { viewer { id } }", {})
+
+    assert result == {"viewer": {"id": "u-1"}}
+    assert len(sleeper.sleeps) >= 1
+    assert sleeper.sleeps[0] == LINEAR_DEFAULT_RETRY_AFTER_S, (
+        f"expected default retry delay {LINEAR_DEFAULT_RETRY_AFTER_S}s when Retry-After=0, got {sleeper.sleeps[0]}s"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — 429 exhaustion raises HTTPStatusError
+# ---------------------------------------------------------------------------
+
+
+def test_query_raises_after_max_retries_exhausted() -> None:
+    """query() raises HTTPStatusError when all retries are 429.
+
+    Covers the ``attempt == _MAX_RETRIES`` branch that calls
+    ``response.raise_for_status()`` instead of sleeping again.
+    """
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(429, headers={"Retry-After": "1"}, json={"error": "throttled"})
+
+    transport = httpx.MockTransport(_handler)
+    http = httpx.Client(transport=transport)
+    sleeper = _RecordingSleeper()
+
+    client = LinearApiClient(api_key="test-key", http=http, sleeper=sleeper)
+    with pytest.raises(httpx.HTTPStatusError):
+        client.query("query { viewer { id } }", {})
+
+
+# ---------------------------------------------------------------------------
+# Test 7 — GraphQL errors key raises RuntimeError
+# ---------------------------------------------------------------------------
+
+
+def test_query_raises_on_graphql_errors_key() -> None:
+    """query() raises RuntimeError when the response payload has an ``errors`` key."""
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"errors": [{"message": "unknown field"}], "data": None})
+
+    transport = httpx.MockTransport(_handler)
+    http = httpx.Client(transport=transport)
+
+    client = LinearApiClient(api_key="test-key", http=http, sleeper=_RecordingSleeper())
+    with pytest.raises(RuntimeError, match="linear graphql errors"):
+        client.query("query { viewer { id } }", {})
+
+
+# ---------------------------------------------------------------------------
+# Test 8 — Missing ``data`` key raises RuntimeError
+# ---------------------------------------------------------------------------
+
+
+def test_query_raises_when_data_key_missing() -> None:
+    """query() raises RuntimeError when ``data`` is absent from the response."""
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"unexpected": True})
+
+    transport = httpx.MockTransport(_handler)
+    http = httpx.Client(transport=transport)
+
+    client = LinearApiClient(api_key="test-key", http=http, sleeper=_RecordingSleeper())
+    with pytest.raises(RuntimeError, match="response missing 'data' key"):
+        client.query("query { viewer { id } }", {})
+
+
+# ---------------------------------------------------------------------------
+# Test 9 — paginate() skips gracefully when connection value is not a dict
+# ---------------------------------------------------------------------------
+
+
+def test_paginate_stops_when_connection_not_a_dict() -> None:
+    """paginate() returns immediately when the connection value is not a dict."""
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return _make_gql_response({"issues": "unexpected_string"})
+
+    transport = httpx.MockTransport(_handler)
+    http = httpx.Client(transport=transport)
+
+    client = LinearApiClient(api_key="test-key", http=http, sleeper=_RecordingSleeper())
+    nodes = list(client.paginate("query { issues }", {}, connection="issues"))
+    assert nodes == []
+
+
+# ---------------------------------------------------------------------------
+# Test 10 — paginate() stops when pageInfo is not a dict
+# ---------------------------------------------------------------------------
+
+
+def test_paginate_stops_when_page_info_not_a_dict() -> None:
+    """paginate() returns when pageInfo is not a dict."""
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return _make_gql_response({"issues": {"nodes": [{"id": "i-1"}], "pageInfo": "bad"}})
+
+    transport = httpx.MockTransport(_handler)
+    http = httpx.Client(transport=transport)
+
+    client = LinearApiClient(api_key="test-key", http=http, sleeper=_RecordingSleeper())
+    nodes = list(client.paginate("query { issues }", {}, connection="issues"))
+    assert nodes == [{"id": "i-1"}]
+
+
+# ---------------------------------------------------------------------------
+# Test 11 — _parse_retry_after falls back when header is non-numeric
+# ---------------------------------------------------------------------------
+
+
+def test_query_uses_default_retry_delay_when_retry_after_is_non_numeric() -> None:
+    """query() falls back to the default delay when Retry-After is non-numeric."""
+    call_count: list[int] = [0]
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return httpx.Response(429, headers={"Retry-After": "not-a-number"}, json={"error": "throttled"})
+        return _make_gql_response({"viewer": {"id": "u-1"}})
+
+    transport = httpx.MockTransport(_handler)
+    http = httpx.Client(transport=transport)
+    sleeper = _RecordingSleeper()
+
+    client = LinearApiClient(api_key="test-key", http=http, sleeper=sleeper)
+    result = client.query("query { viewer { id } }", {})
+
+    assert result == {"viewer": {"id": "u-1"}}
+    assert sleeper.sleeps[0] == LINEAR_DEFAULT_RETRY_AFTER_S

--- a/tests/connectors/linear/test_connector.py
+++ b/tests/connectors/linear/test_connector.py
@@ -1,0 +1,351 @@
+"""Unit tests for :class:`kairix.connectors.linear.LinearConnector`.
+
+Drives the real connector against a scripted
+:class:`tests.fakes.FakeLinearApiClient` (no network). Covers the cursor
+high-water-mark, type-prefixed dispatch, fetch rendering, metadata
+surfacing, sensitivity, source_link, the per-tick budget, the credential
+loader, and the slim enumeration.
+
+F1/F2-clean: the api client is injected via the ``client_builder`` seam;
+no @patch, no env vars. F8 carries ``@pytest.mark.unit``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+# Import via the module path (``...linear.connector``) — not just the
+# package — so the mutation-parity impacted-test selector (import-graph
+# heuristic) maps this file's strong per-line assertions onto
+# ``kairix/connectors/linear/connector.py`` mutants and kills them.
+from kairix.connectors.linear.connector import (
+    LinearConnector,
+    LinearCredentials,
+    make_connector,
+)
+from kairix.core.protocols import Container, RawArtefact, SourceMetadata
+from tests.fakes import FakeLinearApiClient
+
+pytestmark = pytest.mark.unit
+
+
+def _issue_node(identifier: str, updated_at: str) -> dict[str, Any]:
+    return {
+        "id": f"uuid-{identifier}",
+        "identifier": identifier,
+        "title": f"Issue {identifier}",
+        "description": "body",
+        "url": f"https://linear.app/team/issue/{identifier}",
+        "createdAt": "2026-05-01T00:00:00.000Z",
+        "updatedAt": updated_at,
+        "state": {"name": "Todo"},
+        "creator": {"displayName": "agent-alpha", "email": "agent-alpha@example.com"},
+        "team": {"name": "Engineering"},
+        "project": {"id": "uuid-proj", "name": "Reliability"},
+        "labels": {"nodes": [{"name": "bug"}]},
+    }
+
+
+def _project_node(pid: str, updated_at: str) -> dict[str, Any]:
+    return {
+        "id": pid,
+        "name": f"Project {pid}",
+        "description": "overview",
+        "url": f"https://linear.app/team/project/{pid}",
+        "createdAt": "2026-05-01T00:00:00.000Z",
+        "updatedAt": updated_at,
+        "lead": {"displayName": "agent-beta", "email": "agent-beta@example.com"},
+    }
+
+
+def _build(pages: dict[str, list[list[dict[str, Any]]]], **kwargs: Any) -> LinearConnector:
+    api = FakeLinearApiClient(pages=pages)
+    return LinearConnector(
+        credentials=LinearCredentials(api_key="lin_fixture"),  # pragma: allowlist secret — test fixture
+        client_builder=lambda _c: api,
+        **kwargs,
+    )
+
+
+def test_list_changes_emits_type_prefixed_events() -> None:
+    """Each entity type yields a ``modified`` event with a type-prefixed id."""
+    connector = _build(
+        {
+            "issues": [[_issue_node("ENG-1", "2026-05-10T00:00:00.000Z")]],
+            "projects": [[_project_node("uuid-p1", "2026-05-11T00:00:00.000Z")]],
+        }
+    )
+    events = list(connector.list_changes(cursor=None))
+    ids = {e.item_id for e in events}
+    assert "issue:ENG-1" in ids
+    assert "project:uuid-p1" in ids
+    assert all(e.op == "modified" for e in events)
+
+
+def test_list_changes_event_modified_at_is_the_node_updated_at() -> None:
+    """The emitted event's modified_at equals the node's ``updatedAt``.
+
+    Pins the ``_opt_str(node.get("updatedAt")) or _now_iso()`` branch — a
+    mutant that swaps ``or`` for ``and`` would substitute the wall-clock
+    now() even when updatedAt is present.
+    """
+    connector = _build({"issues": [[_issue_node("ENG-1", "2026-05-10T00:00:00.000Z")]]})
+    events = list(connector.list_changes(cursor=None))
+    assert events[0].modified_at == "2026-05-10T00:00:00.000Z"
+
+
+def test_next_cursor_is_high_water_mark_across_types() -> None:
+    """next_cursor() returns the max updatedAt across all drained entities."""
+    connector = _build(
+        {
+            "issues": [[_issue_node("ENG-1", "2026-05-10T00:00:00.000Z")]],
+            "projects": [[_project_node("uuid-p1", "2026-05-15T00:00:00.000Z")]],
+        }
+    )
+    list(connector.list_changes(cursor=None))
+    assert connector.next_cursor() == "2026-05-15T00:00:00.000Z"
+
+
+def test_next_cursor_keeps_prior_cursor_when_no_events() -> None:
+    """A clean drain that produced no events preserves the prior cursor.
+
+    Pins the ``if not events: return cursor`` branch in _high_water — the
+    high-water-mark must not be clobbered to None when nothing changed.
+    """
+    connector = _build({"issues": [[]]})
+    list(connector.list_changes(cursor="2026-05-01T00:00:00.000Z"))
+    assert connector.next_cursor() == "2026-05-01T00:00:00.000Z"
+
+
+def test_next_cursor_keeps_higher_prior_cursor_over_older_events() -> None:
+    """When the prior cursor is newer than every event, it is preserved.
+
+    Pins the ``cursor > latest`` guard in _high_water — the mark must never
+    move backwards even if a re-fetched older item shows up in the drain.
+    """
+    connector = _build({"issues": [[_issue_node("ENG-1", "2026-05-10T00:00:00.000Z")]]})
+    list(connector.list_changes(cursor="2026-06-01T00:00:00.000Z"))
+    assert connector.next_cursor() == "2026-06-01T00:00:00.000Z"
+
+
+def test_per_tick_budget_stops_early_and_holds_cursor() -> None:
+    """When per_tick_max_items is hit, the drain stops and the cursor stays None.
+
+    Spec §4: a budget-stopped tick must NOT advance the cursor past the
+    point it reached, so the next tick re-drains from the last good cursor.
+    """
+    connector = _build(
+        {
+            "issues": [
+                [
+                    _issue_node("ENG-1", "2026-05-10T00:00:00.000Z"),
+                    _issue_node("ENG-2", "2026-05-11T00:00:00.000Z"),
+                    _issue_node("ENG-3", "2026-05-12T00:00:00.000Z"),
+                ]
+            ]
+        },
+        per_tick_max_items=2,
+    )
+    events = list(connector.list_changes(cursor=None))
+    assert len(events) == 2, "budget should cap the tick at 2 items"
+    assert connector.next_cursor() is None, "budget-stopped tick must not advance the cursor"
+
+
+def test_fetch_dispatches_to_renderer_by_prefix() -> None:
+    """fetch() renders the cached node as Markdown via the prefix dispatch."""
+    connector = _build({"issues": [[_issue_node("ENG-7", "2026-05-10T00:00:00.000Z")]]})
+    list(connector.list_changes(cursor=None))
+    artefact = connector.fetch("issue:ENG-7")
+    assert isinstance(artefact, RawArtefact)
+    assert artefact.mime == "text/markdown"
+    assert b"ENG-7" in artefact.raw
+
+
+def test_fetch_uncached_item_raises_keyerror() -> None:
+    """fetch() on an un-drained item raises a fix-pointer KeyError."""
+    connector = _build({"issues": [[_issue_node("ENG-7", "2026-05-10T00:00:00.000Z")]]})
+    with pytest.raises(KeyError, match="node cache"):
+        connector.fetch("issue:NEVER-SEEN")
+
+
+def test_metadata_for_surfaces_author_dates_and_labels() -> None:
+    """metadata_for() surfaces creator + dates + label tags (F65)."""
+    connector = _build({"issues": [[_issue_node("ENG-9", "2026-05-10T00:00:00.000Z")]]})
+    list(connector.list_changes(cursor=None))
+    meta = connector.metadata_for("issue:ENG-9")
+    assert isinstance(meta, SourceMetadata)
+    assert meta.author == "agent-alpha"
+    assert meta.author_email == "agent-alpha@example.com"
+    assert meta.modified_at == "2026-05-10T00:00:00.000Z"
+    assert meta.created_at == "2026-05-01T00:00:00.000Z"
+    assert "bug" in meta.tags
+    assert meta.properties.get("team") == "Engineering"
+
+
+def test_metadata_for_uncached_returns_empty() -> None:
+    """metadata_for() on an un-drained item collapses to empty SourceMetadata."""
+    connector = _build({"issues": [[]]})
+    meta = connector.metadata_for("issue:UNSEEN")
+    assert meta == SourceMetadata()
+
+
+def test_metadata_for_coerces_non_string_dates_to_none() -> None:
+    """A non-string ``createdAt`` is coerced to None, not crashed or kept.
+
+    Pins the ``isinstance(value, str) and value.strip()`` guard in
+    _opt_str — a mutant swapping ``and`` for ``or`` would call ``.strip()``
+    on the int and raise (or keep the wrong value). The connector must
+    tolerate a malformed envelope field by dropping it to None.
+    """
+    node = _issue_node("ENG-13", "2026-05-10T00:00:00.000Z")
+    node["createdAt"] = 12345  # malformed: an int, not an ISO string
+    connector = _build({"issues": [[node]]})
+    list(connector.list_changes(cursor=None))
+    meta = connector.metadata_for("issue:ENG-13")
+    assert meta.created_at is None
+    # modified_at is still the valid string updatedAt — drop affected only created_at.
+    assert meta.modified_at == "2026-05-10T00:00:00.000Z"
+
+
+def test_source_link_returns_linear_url() -> None:
+    """source_link() returns the node's linear.app URL after a drain."""
+    connector = _build({"issues": [[_issue_node("ENG-5", "2026-05-10T00:00:00.000Z")]]})
+    list(connector.list_changes(cursor=None))
+    assert connector.source_link("issue:ENG-5") == "https://linear.app/team/issue/ENG-5"
+
+
+def test_source_link_fallback_when_uncached() -> None:
+    """source_link() falls back to a ``linear://`` shape for an unknown id."""
+    connector = _build({"issues": [[]]})
+    assert connector.source_link("issue:GONE") == "linear://issue:GONE"
+
+
+def test_source_link_falls_back_when_cached_node_has_empty_url() -> None:
+    """A cached node with an empty url string falls back to ``linear://``.
+
+    Pins the ``isinstance(url, str) and url`` guard — a mutant swapping
+    ``and`` for ``or`` would return the empty string as the link.
+    """
+    node = _issue_node("ENG-3", "2026-05-10T00:00:00.000Z")
+    node["url"] = ""  # present but empty
+    connector = _build({"issues": [[node]]})
+    list(connector.list_changes(cursor=None))
+    assert connector.source_link("issue:ENG-3") == "linear://issue:ENG-3"
+
+
+def test_metadata_for_surfaces_author_with_email_only_creator() -> None:
+    """A creator with an email but no displayName still surfaces author_email.
+
+    Pins the ``if name or email`` selection in _author_of — a mutant
+    swapping ``or`` for ``and`` would skip a person who has only an email.
+    """
+    node = _issue_node("ENG-11", "2026-05-10T00:00:00.000Z")
+    node["creator"] = {"email": "email-only@example.com"}  # no displayName
+    connector = _build({"issues": [[node]]})
+    list(connector.list_changes(cursor=None))
+    meta = connector.metadata_for("issue:ENG-11")
+    assert meta.author_email == "email-only@example.com"
+    assert meta.author is None
+
+
+def test_metadata_for_skips_person_with_no_name_or_email() -> None:
+    """A creator block with neither name nor email is skipped (author None).
+
+    Together with the email-only case, this pins both sides of the
+    ``name or email`` selection so neither operand can be dropped.
+    """
+    node = _issue_node("ENG-12", "2026-05-10T00:00:00.000Z")
+    node["creator"] = {}  # empty person — neither name nor email
+    node.pop("assignee", None)
+    connector = _build({"issues": [[node]]})
+    list(connector.list_changes(cursor=None))
+    meta = connector.metadata_for("issue:ENG-12")
+    assert meta.author is None
+    assert meta.author_email is None
+
+
+def test_sensitivity_for_returns_configured_default() -> None:
+    """sensitivity_for() returns the connector's configured tier."""
+    connector = _build({"issues": [[]]}, default_sensitivity="client-confidential")
+    assert connector.sensitivity_for("issue:any") == "client-confidential"
+
+
+def test_list_changes_for_container_delegates_to_cursor() -> None:
+    """PollConnector path uses the container's cursor token as the high-water-mark."""
+    connector = _build({"issues": [[_issue_node("ENG-2", "2026-05-10T00:00:00.000Z")]]})
+    container = Container(
+        cc_pair_id=1,
+        container_id="workspace",
+        access_state="ACCESSIBLE",
+        cursor_token=None,
+        last_synced_at=None,
+    )
+    events = list(connector.list_changes_for_container(container))
+    assert [e.item_id for e in events] == ["issue:ENG-2"]
+
+
+def test_retrieve_all_slim_docs_enumerates_ids() -> None:
+    """SlimConnector yields the type-prefixed id for every current node."""
+    connector = _build(
+        {
+            "issues": [[_issue_node("ENG-1", "2026-05-10T00:00:00.000Z")]],
+            "projects": [[_project_node("uuid-p1", "2026-05-11T00:00:00.000Z")]],
+        }
+    )
+    container = Container(
+        cc_pair_id=1,
+        container_id="workspace",
+        access_state="ACCESSIBLE",
+        cursor_token=None,
+        last_synced_at=None,
+    )
+    ids = set(connector.retrieve_all_slim_docs(container))
+    assert ids == {"issue:ENG-1", "project:uuid-p1"}
+
+
+def test_load_credentials_normalises_api_key() -> None:
+    """CredentialsConnector normalises ``api_key`` / ``token`` -> {api_key}."""
+    connector = _build({"issues": [[]]})
+    from_api_key = connector.load_credentials({"api_key": " key1 "})  # pragma: allowlist secret — test fixture
+    from_token = connector.load_credentials({"token": "key2"})  # pragma: allowlist secret — test fixture
+    assert from_api_key == {"api_key": "key1"}  # pragma: allowlist secret — test fixture
+    assert from_token == {"api_key": "key2"}  # pragma: allowlist secret — test fixture
+
+
+def test_load_credentials_rejects_empty() -> None:
+    """CredentialsConnector returns None when no usable key is present."""
+    connector = _build({"issues": [[]]})
+    assert connector.load_credentials({}) is None
+    assert connector.load_credentials({"api_key": "   "}) is None
+
+
+def test_make_connector_rejects_bad_sensitivity() -> None:
+    """make_connector validates the F39 sensitivity tier."""
+    with pytest.raises(ValueError, match="not a valid F39 tier"):
+        make_connector({"default_sensitivity": "secret"})
+
+
+def test_make_connector_rejects_bad_budget() -> None:
+    """make_connector validates per_tick_max_items is a positive int."""
+    with pytest.raises(ValueError, match="positive integer"):
+        make_connector({"per_tick_max_items": 0})
+
+
+def test_make_connector_accepts_budget_of_one() -> None:
+    """A per_tick_max_items of exactly 1 is the lowest VALID budget.
+
+    Pins the ``raw_budget < 1`` boundary — a mutant tightening it to
+    ``<= 1`` would reject the legal minimum with the "positive integer"
+    ValueError. ``make_connector`` validates the budget BEFORE it
+    resolves credentials, so a budget of 1 must clear validation and
+    proceed to the credential-resolution step (which raises
+    SecretNotFoundError here because no secret backend is provisioned).
+    We assert that the ONLY way this raises is the secret lookup — never
+    the budget ValueError — which the ``<= 1`` mutant would trigger.
+    """
+    from kairix.secrets.loader import SecretNotFoundError
+
+    with pytest.raises(SecretNotFoundError):
+        make_connector({"per_tick_max_items": 1, "default_sensitivity": "internal"})

--- a/tests/connectors/linear/test_connector.py
+++ b/tests/connectors/linear/test_connector.py
@@ -96,8 +96,16 @@ def test_list_changes_event_modified_at_is_the_node_updated_at() -> None:
     assert events[0].modified_at == "2026-05-10T00:00:00.000Z"
 
 
-def test_next_cursor_is_high_water_mark_across_types() -> None:
-    """next_cursor() returns the max updatedAt across all drained entities."""
+def test_next_cursor_encodes_per_entity_type_watermarks() -> None:
+    """next_cursor() encodes each type's own last-emitted updatedAt (spec §4).
+
+    The cursor is a JSON-encoded per-type watermark map — issues advance
+    to the latest issue updatedAt, projects to the latest project
+    updatedAt, independently. Pins that each type tracks its OWN mark
+    (a mutant collapsing to one shared watermark would lose a key).
+    """
+    import json
+
     connector = _build(
         {
             "issues": [[_issue_node("ENG-1", "2026-05-10T00:00:00.000Z")]],
@@ -105,37 +113,61 @@ def test_next_cursor_is_high_water_mark_across_types() -> None:
         }
     )
     list(connector.list_changes(cursor=None))
-    assert connector.next_cursor() == "2026-05-15T00:00:00.000Z"
+    decoded = json.loads(connector.next_cursor() or "")
+    assert decoded == {
+        "issue": "2026-05-10T00:00:00.000Z",
+        "project": "2026-05-15T00:00:00.000Z",
+    }
 
 
-def test_next_cursor_keeps_prior_cursor_when_no_events() -> None:
-    """A clean drain that produced no events preserves the prior cursor.
+def test_cursor_round_trips_to_resume_per_type() -> None:
+    """next_cursor() → list_changes(cursor) resumes each type past its mark.
 
-    Pins the ``if not events: return cursor`` branch in _high_water — the
-    high-water-mark must not be clobbered to None when nothing changed.
+    A second tick fed the first tick's cursor must NOT re-emit items at or
+    below each type's watermark, but MUST emit a newer item of any type.
     """
-    connector = _build({"issues": [[]]})
-    list(connector.list_changes(cursor="2026-05-01T00:00:00.000Z"))
-    assert connector.next_cursor() == "2026-05-01T00:00:00.000Z"
+    connector = _build(
+        {
+            "issues": [
+                [
+                    _issue_node("ENG-1", "2026-05-10T00:00:00.000Z"),
+                    _issue_node("ENG-2", "2026-05-20T00:00:00.000Z"),
+                ]
+            ],
+        }
+    )
+    list(connector.list_changes(cursor=None))
+    cursor = connector.next_cursor()
+    # Second tick with the same fixture: every issue updatedAt is <= the
+    # watermark, so nothing is re-emitted.
+    again = list(connector.list_changes(cursor=cursor))
+    assert again == [], "items at or below the per-type watermark must not re-emit"
 
 
-def test_next_cursor_keeps_higher_prior_cursor_over_older_events() -> None:
-    """When the prior cursor is newer than every event, it is preserved.
+def test_legacy_single_string_cursor_degrades_to_full_enum() -> None:
+    """A pre-upgrade single-ISO-string cursor re-syncs rather than skipping.
 
-    Pins the ``cursor > latest`` guard in _high_water — the mark must never
-    move backwards even if a re-fetched older item shows up in the drain.
+    Pins the robust-decode contract (spec §4): a malformed/legacy token is
+    treated as "no watermark for any type" → full enumeration, so existing
+    operator state degrades safely instead of silently skipping data.
     """
     connector = _build({"issues": [[_issue_node("ENG-1", "2026-05-10T00:00:00.000Z")]]})
-    list(connector.list_changes(cursor="2026-06-01T00:00:00.000Z"))
-    assert connector.next_cursor() == "2026-06-01T00:00:00.000Z"
+    # Legacy cursor: a bare ISO string newer than the only event. Under the
+    # OLD single-watermark code this would have filtered the event out; the
+    # new decode treats it as "no watermark" and re-enumerates everything.
+    events = list(connector.list_changes(cursor="2026-06-01T00:00:00.000Z"))
+    assert [e.item_id for e in events] == ["issue:ENG-1"]
 
 
-def test_per_tick_budget_stops_early_and_holds_cursor() -> None:
-    """When per_tick_max_items is hit, the drain stops and the cursor stays None.
+def test_per_tick_budget_advances_drained_type_watermark() -> None:
+    """A budget-stopped tick advances each drained type's OWN watermark (spec §4).
 
-    Spec §4: a budget-stopped tick must NOT advance the cursor past the
-    point it reached, so the next tick re-drains from the last good cursor.
+    Forward progress: when per_tick_max_items caps the drain mid-page, the
+    type's watermark moves to the max updatedAt it EMITTED — never None,
+    never past an un-emitted item. The next tick resumes from there.
     """
+    import json
+
     connector = _build(
         {
             "issues": [
@@ -150,7 +182,11 @@ def test_per_tick_budget_stops_early_and_holds_cursor() -> None:
     )
     events = list(connector.list_changes(cursor=None))
     assert len(events) == 2, "budget should cap the tick at 2 items"
-    assert connector.next_cursor() is None, "budget-stopped tick must not advance the cursor"
+    decoded = json.loads(connector.next_cursor() or "")
+    # Watermark advanced to the SECOND emitted item — not past ENG-3.
+    assert decoded == {"issue": "2026-05-11T00:00:00.000Z"}, (
+        "budget-stopped tick must advance the issue watermark to its last emitted item, not skip ENG-3"
+    )
 
 
 def test_fetch_dispatches_to_renderer_by_prefix() -> None:
@@ -349,3 +385,197 @@ def test_make_connector_accepts_budget_of_one() -> None:
 
     with pytest.raises(SecretNotFoundError):
         make_connector({"per_tick_max_items": 1, "default_sensitivity": "internal"})
+
+
+def _document_node(did: str, updated_at: str) -> dict[str, Any]:
+    return {
+        "id": did,
+        "title": f"Doc {did}",
+        "content": "doc body",
+        "url": f"https://linear.app/team/document/{did}",
+        "createdAt": "2026-05-01T00:00:00.000Z",
+        "updatedAt": updated_at,
+        "creator": {"displayName": "agent-gamma", "email": "agent-gamma@example.com"},
+    }
+
+
+def test_multi_type_budget_no_starvation_or_skip_across_ticks() -> None:
+    """Under per-tick-budget pressure, every entity type is eventually
+    emitted across ticks — no starvation, no skip, no livelock (Finding 1).
+
+    With a SINGLE shared watermark + ``any()`` short-circuit drain (the old
+    code), the first spec (issues) fills ``per_tick_max_items`` every tick,
+    the other four types are never queried, and the held single cursor lets
+    the next tick re-drain issues from scratch forever — projects/documents
+    are emitted NEVER. The per-entity-type watermark cursor fixes this: each
+    type advances its OWN watermark to its last-emitted updatedAt, so later
+    ticks resume past the drained issues and reach the other types.
+
+    Asserts: (a) all three issues + the project + the document are emitted
+    across the ticks (no type skipped), (b) every tick before completion
+    makes forward progress (no livelock), (c) no in-range item is lost.
+    """
+    issues = [
+        _issue_node("ENG-1", "2026-05-10T00:00:00.000Z"),
+        _issue_node("ENG-2", "2026-05-11T00:00:00.000Z"),
+        _issue_node("ENG-3", "2026-05-12T00:00:00.000Z"),
+    ]
+    project = _project_node("uuid-p1", "2026-05-13T00:00:00.000Z")
+    document = _document_node("uuid-d1", "2026-05-14T00:00:00.000Z")
+    expected = {
+        "issue:ENG-1",
+        "issue:ENG-2",
+        "issue:ENG-3",
+        "project:uuid-p1",
+        "document:uuid-d1",
+    }
+    connector = _build(
+        {
+            "issues": [issues],
+            "projects": [[project]],
+            "documents": [[document]],
+        },
+        per_tick_max_items=2,
+    )
+
+    seen: set[str] = set()
+    cursor = None
+    # Bound the loop well above the minimum needed (5 items / budget 2 = 3
+    # ticks) so a livelock surfaces as "never converges" rather than hanging.
+    max_ticks = 12
+    for _ in range(max_ticks):
+        before = len(seen)
+        batch = list(connector.list_changes(cursor=cursor))
+        seen.update(e.item_id for e in batch)
+        cursor = connector.next_cursor()
+        if seen == expected:
+            break
+        # Forward progress: a tick that emits nothing new while items remain
+        # is a livelock — the per-type watermark must keep advancing.
+        assert len(seen) > before, "livelock: a tick made no forward progress while items remain undrained"
+
+    assert seen == expected, (
+        f"every entity type must be emitted across ticks under budget pressure — missing: {expected - seen}"
+    )
+
+
+class _ExplodingNode(dict):  # type: ignore[type-arg]  # F3: test-only node that raises on identity access.
+    """Yields a valid ``updatedAt`` (so the fake's since-filter passes it
+    to the connector) but raises on any other key — forcing the
+    connector's per-item conversion to throw, not the fake."""
+
+    def get(self, key: Any, default: Any = None) -> Any:
+        if key == "updatedAt":
+            return "2026-05-09T00:00:00.000Z"
+        raise ValueError("boom: malformed linear node")
+
+
+def test_drain_skips_malformed_node_and_keeps_siblings(caplog: pytest.LogCaptureFixture) -> None:
+    """A node that raises on conversion is skipped; siblings still emit (Finding 2).
+
+    Spec §9 per-item isolation: one malformed item fails just that item,
+    logged at WARNING with the traceback (``exc_info``) — never the whole
+    tick. We force the conversion to raise by handing the drain a node that
+    explodes on ``.get``, and assert the valid sibling issue is still
+    emitted, the tick succeeds, AND the skip is logged WITH the exception
+    traceback (pins ``exc_info=True`` — a mutant flipping it to ``False``
+    drops the traceback the operator needs to diagnose the bad node).
+    """
+    import logging
+
+    good = _issue_node("ENG-OK", "2026-05-10T00:00:00.000Z")
+    connector = _build({"issues": [[_ExplodingNode(), good]]})
+    with caplog.at_level(logging.WARNING, logger="kairix.connectors.linear.connector"):
+        events = list(connector.list_changes(cursor=None))
+    ids = [e.item_id for e in events]
+    assert ids == ["issue:ENG-OK"], "the malformed node is skipped, the valid sibling still emits"
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING and "malformed" in r.getMessage()]
+    assert warnings, "the skipped malformed node must be logged at WARNING"
+    # exc_info=True populates record.exc_info with the (type, value, tb)
+    # tuple; exc_info=False leaves it as the literal False. Assert the tuple
+    # so a True->False mutant (dropping the traceback) is killed.
+    exc = warnings[0].exc_info
+    assert isinstance(exc, tuple) and exc[0] is ValueError, (
+        f"the WARNING must carry the exception traceback (exc_info=True), got {exc!r}"
+    )
+
+
+def test_watermark_is_monotonic_even_with_out_of_order_nodes() -> None:
+    """A type's watermark never moves backward when nodes arrive out of order.
+
+    Pins the ``max(prior, modified_at)`` forward-progress advance (spec §4
+    monotonicity): even if a later-yielded node of the same type has an
+    OLDER updatedAt, the watermark stays at the newest one already emitted.
+    A mutant that drops the ``max`` (taking the last value unconditionally)
+    would regress the watermark to the older timestamp.
+    """
+    import json
+
+    connector = _build(
+        {
+            "issues": [
+                [
+                    _issue_node("ENG-NEW", "2026-05-20T00:00:00.000Z"),  # newest first
+                    _issue_node("ENG-OLD", "2026-05-10T00:00:00.000Z"),  # older, yielded after
+                ]
+            ]
+        }
+    )
+    events = list(connector.list_changes(cursor=None))
+    assert {e.item_id for e in events} == {"issue:ENG-NEW", "issue:ENG-OLD"}
+    decoded = json.loads(connector.next_cursor() or "")
+    assert decoded == {"issue": "2026-05-20T00:00:00.000Z"}, (
+        "watermark must hold the newest emitted updatedAt, never regress to the older out-of-order node"
+    )
+
+
+def test_cursor_decode_drops_non_string_watermark_value() -> None:
+    """A JSON cursor whose watermark value isn't a string is dropped to full enum.
+
+    Pins the ``isinstance(value, str) and value`` filter in _decode_cursor
+    (line 609): a corrupt per-type watermark (e.g. a number) must be
+    discarded so that type re-enumerates from epoch rather than being
+    applied as a bogus filter. A mutant swapping ``and`` for ``or`` would
+    keep the non-string value and feed it to the API as ``since``.
+    """
+    import json
+
+    # issue watermark is a NUMBER (corrupt); project watermark is a valid
+    # future ISO string that filters the project out. The issue must still
+    # emit (its corrupt watermark is dropped → epoch → full enum).
+    corrupt = json.dumps({"issue": 12345, "project": "2026-12-01T00:00:00.000Z"})
+    connector = _build(
+        {
+            "issues": [[_issue_node("ENG-1", "2026-05-10T00:00:00.000Z")]],
+            "projects": [[_project_node("uuid-p1", "2026-05-11T00:00:00.000Z")]],
+        }
+    )
+    events = list(connector.list_changes(cursor=corrupt))
+    ids = {e.item_id for e in events}
+    assert "issue:ENG-1" in ids, "a corrupt (non-string) issue watermark must drop to full enum, not skip the issue"
+    assert "project:uuid-p1" not in ids, "the valid project watermark (future) still filters the project out"
+
+
+def test_encode_cursor_keys_are_sorted_deterministically() -> None:
+    """The encoded cursor token sorts its keys for a deterministic round-trip.
+
+    Pins ``json.dumps(..., sort_keys=True)`` (line 618): the persisted token
+    must be byte-stable regardless of drain order, so the orchestrator's
+    cursor row doesn't churn. The connector drains in spec order
+    (issue, then document), so the INSERTION order is ``issue, document``;
+    SORTED order is ``document, issue`` (alphabetical). We assert the token
+    is in sorted order — a mutant flipping ``sort_keys`` to ``False`` would
+    emit the insertion order (``issue`` before ``document``) and fail.
+    """
+    connector = _build(
+        {
+            "issues": [[_issue_node("ENG-1", "2026-05-10T00:00:00.000Z")]],
+            "documents": [[_document_node("uuid-d1", "2026-05-15T00:00:00.000Z")]],
+        }
+    )
+    list(connector.list_changes(cursor=None))
+    token = connector.next_cursor()
+    assert token is not None
+    assert token.index('"document"') < token.index('"issue"'), (
+        f"encoded cursor keys must be sorted (document before issue), not drain order; got {token!r}"
+    )

--- a/tests/connectors/linear/test_connector.py
+++ b/tests/connectors/linear/test_connector.py
@@ -556,6 +556,48 @@ def test_cursor_decode_drops_non_string_watermark_value() -> None:
     assert "project:uuid-p1" not in ids, "the valid project watermark (future) still filters the project out"
 
 
+def test_budget_full_skips_graphql_query_for_later_specs() -> None:
+    """Once the per-tick budget is full, later entity specs issue ZERO GraphQL calls (review I1).
+
+    The pre-fix code called ``paginate()`` for every spec unconditionally —
+    even when an earlier spec had already filled the budget — wasting up to 4
+    GraphQL POSTs per budget-hit tick. The fix hoists the budget guard to the
+    TOP of ``_drain_spec``, before touching the paginator.
+
+    Sabotage-proof: remove the early-return hoist → ``paginate_calls`` for
+    ``projects`` goes from 0 to 1 → test fails → restore hoist → green.
+    """
+    issues = [
+        _issue_node("ENG-1", "2026-05-10T00:00:00.000Z"),
+        _issue_node("ENG-2", "2026-05-11T00:00:00.000Z"),
+    ]
+    project = _project_node("uuid-p1", "2026-05-13T00:00:00.000Z")
+
+    api = FakeLinearApiClient(
+        pages={
+            "issues": [issues],
+            "projects": [[project]],
+        }
+    )
+    connector = LinearConnector(
+        credentials=LinearCredentials(api_key="lin_fixture"),  # pragma: allowlist secret — test fixture
+        client_builder=lambda _c: api,
+        per_tick_max_items=2,
+    )
+    events = list(connector.list_changes(cursor=None))
+
+    # Issues fill the budget (2 items, budget = 2).
+    assert len(events) == 2
+    assert all(e.item_id.startswith("issue:") for e in events)
+
+    # The ``projects`` paginator must never have been called.
+    projects_calls = [c for c in api.paginate_calls if c[2] == "projects"]
+    assert projects_calls == [], (
+        f"projects paginate() must not be called when the budget is already full, "
+        f"but got {len(projects_calls)} call(s): {projects_calls}"
+    )
+
+
 def test_encode_cursor_keys_are_sorted_deterministically() -> None:
     """The encoded cursor token sorts its keys for a deterministic round-trip.
 

--- a/tests/connectors/linear/test_render.py
+++ b/tests/connectors/linear/test_render.py
@@ -1,0 +1,124 @@
+"""Unit tests for :mod:`kairix.connectors.linear.render`.
+
+Pins the per-entity Markdown renderers (spec §5): one test per entity
+kind plus the dispatch guard. Each test asserts on concrete output
+content so a renderer that drops a field (or the dispatch table losing a
+kind) fails.
+
+F8 carries ``@pytest.mark.unit``. No network, no fakes — pure functions.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kairix.connectors.linear.render import ENTITY_KINDS, render
+
+pytestmark = pytest.mark.unit
+
+
+def test_render_issue_emits_identifier_title_fields_and_body() -> None:
+    """Issue render: H1 ``# <identifier> <title>`` + field block + description."""
+    node = {
+        "identifier": "ENG-42",
+        "title": "Fix the cursor drift",
+        "description": "The cursor advanced on a partial drain.",
+        "url": "https://linear.app/team/issue/ENG-42",
+        "state": {"name": "In Progress"},
+        "assignee": {"displayName": "agent-alpha"},
+        "team": {"name": "Engineering"},
+        "project": {"name": "Reliability"},
+        "labels": {"nodes": [{"name": "bug"}, {"name": "p1"}]},
+    }
+    md = render("issue", node)
+    assert md.startswith("# ENG-42 Fix the cursor drift")
+    assert "**State**: In Progress" in md
+    assert "**Assignee**: agent-alpha" in md
+    assert "**Team**: Engineering" in md
+    assert "**Project**: Reliability" in md
+    assert "**Labels**: bug, p1" in md
+    assert "The cursor advanced on a partial drain." in md
+    assert md.endswith("\n")
+
+
+def test_render_project_emits_name_status_and_milestones() -> None:
+    """Project render: H1 name + status/lead/target block + description + milestones."""
+    node = {
+        "name": "Roadmap recall",
+        "description": "Make the roadmap searchable.",
+        "status": {"name": "Started"},
+        "lead": {"displayName": "agent-beta"},
+        "targetDate": "2026-09-01",
+        "projectMilestones": {"nodes": [{"name": "MVP"}, {"name": "GA"}]},
+    }
+    md = render("project", node)
+    assert md.startswith("# Roadmap recall")
+    assert "**Status**: Started" in md
+    assert "**Lead**: agent-beta" in md
+    assert "**Target date**: 2026-09-01" in md
+    assert "## Milestones" in md
+    assert "MVP, GA" in md
+
+
+def test_render_document_emits_title_and_content() -> None:
+    """Document render: H1 title + content body."""
+    node = {
+        "title": "Design doc — temporal boost",
+        "content": "Temporal boost weights recency.",
+        "url": "https://linear.app/team/document/abc",
+        "project": {"name": "Search"},
+    }
+    md = render("document", node)
+    assert md.startswith("# Design doc — temporal boost")
+    assert "**Project**: Search" in md
+    assert "Temporal boost weights recency." in md
+
+
+def test_render_initiative_emits_name_and_member_projects() -> None:
+    """Initiative render: H1 name + overview + member projects."""
+    node = {
+        "name": "FY26 platform",
+        "description": "The platform initiative.",
+        "status": "Active",
+        "projects": {"nodes": [{"name": "Search"}, {"name": "Ingest"}]},
+    }
+    md = render("initiative", node)
+    assert md.startswith("# FY26 platform")
+    assert "The platform initiative." in md
+    assert "## Projects" in md
+    assert "Search, Ingest" in md
+
+
+def test_render_project_update_emits_narrative_health_and_attribution() -> None:
+    """Project update render: narrative + health + date, attributed to its project."""
+    node = {
+        "body": "On track for the GA milestone.",
+        "health": "onTrack",
+        "createdAt": "2026-06-01T12:00:00.000Z",
+        "project": {"name": "Roadmap recall"},
+    }
+    md = render("projectUpdate", node)
+    assert "Roadmap recall" in md
+    assert "**Health**: onTrack" in md
+    assert "On track for the GA milestone." in md
+
+
+def test_render_tolerates_sparse_node() -> None:
+    """A near-empty node still renders an H1 fallback without raising."""
+    md = render("issue", {})
+    assert md.startswith("# (untitled issue)")
+
+
+def test_render_rejects_unknown_kind() -> None:
+    """Dispatch guard: an unknown entity kind raises ValueError.
+
+    Pins the dispatch table — dropping a kind (or mistyping a prefix)
+    surfaces loudly rather than silently rendering nothing.
+    """
+    with pytest.raises(ValueError, match="unknown entity kind"):
+        render("comment", {"id": "c-1"})
+
+
+def test_entity_kinds_cover_all_five() -> None:
+    """ENTITY_KINDS is exactly the five MVP entity kinds (spec §1 / §5)."""
+    assert ENTITY_KINDS == frozenset({"issue", "project", "document", "initiative", "projectUpdate"})

--- a/tests/contracts/test_linear_connector_contract.py
+++ b/tests/contracts/test_linear_connector_contract.py
@@ -1,0 +1,108 @@
+"""Per-method failure-injection contract for the Linear connector (F68-style).
+
+The F43 behavioural-parity body lives in
+:mod:`tests.contracts.test_linear_protocol` (one parametrized assertion
+over real + fake). This file is the companion failure-behaviour
+coverage: each public ``SourceConnector`` method's failure surface is
+driven explicitly (the api client raising, or an un-drained cache) and
+the observable outcome asserted — not just shape compliance.
+
+``LinearConnector`` is a concrete class, not a Protocol, so F68's
+repo-wide Protocol scan imposes no gate obligation here; this coverage
+ships per spec §11 (the connector's failure modes / resilience contract)
+so a regression that swallows a transport error or silently returns
+empty fails loudly.
+
+Real-impl path is driven against scripted in-memory clients; no real
+network call is made.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from kairix.connectors.linear import LinearConnector, LinearCredentials
+from kairix.core.protocols import Container, SourceMetadata
+from tests.fakes import FakeLinearApiClient
+
+pytestmark = pytest.mark.contract
+
+
+def _connector_with_failing_api() -> LinearConnector:
+    """Real connector whose api client raises on every paginate/query."""
+
+    class _FailingApi:
+        def query(self, document: str, variables: Any) -> dict[str, Any]:
+            raise RuntimeError("linear api: simulated query failure")
+
+        def paginate(self, document: str, variables: Any, *, connection: str) -> Any:
+            raise RuntimeError("linear api: simulated paginate failure")
+            yield  # pragma: no cover — unreachable; marks this a generator
+
+    return LinearConnector(
+        credentials=LinearCredentials(api_key="lin_fail_fixture"),  # pragma: allowlist secret — test fixture
+        client_builder=lambda _c: _FailingApi(),  # type: ignore[arg-type, return-value]  # F3-rationale: failing stub satisfies the query/paginate surface the connector calls.
+    )
+
+
+def _connector_empty() -> LinearConnector:
+    """Real connector with an empty scripted api (no nodes, cache empty)."""
+    api = FakeLinearApiClient(pages={"issues": [[]]})
+    return LinearConnector(
+        credentials=LinearCredentials(api_key="lin_fixture"),  # pragma: allowlist secret — test fixture
+        client_builder=lambda _c: api,
+    )
+
+
+def _workspace_container() -> Container:
+    return Container(
+        cc_pair_id=1,
+        container_id="workspace",
+        access_state="ACCESSIBLE",
+        cursor_token=None,
+        last_synced_at=None,
+    )
+
+
+def test_list_changes_raises_when_api_paginate_fails() -> None:
+    """list_changes propagates the api client's failure (does not swallow it).
+
+    Spec §9: a transport failure surfaces to the orchestrator, which
+    dead-letters the tick — the connector must not silently return empty.
+    """
+    connector = _connector_with_failing_api()
+    with pytest.raises(RuntimeError, match="simulated paginate failure"):
+        list(connector.list_changes(cursor=None))
+
+
+def test_retrieve_all_slim_docs_raises_when_api_paginate_fails() -> None:
+    """retrieve_all_slim_docs propagates the api client's failure."""
+    connector = _connector_with_failing_api()
+    with pytest.raises(RuntimeError, match="simulated paginate failure"):
+        list(connector.retrieve_all_slim_docs(_workspace_container()))
+
+
+def test_fetch_raises_keyerror_for_uncached_item() -> None:
+    """fetch on an un-drained item raises a fix-pointer KeyError.
+
+    The cache is empty because no list_changes drain populated it — the
+    method fails loudly with an actionable message rather than returning
+    a silent empty artefact.
+    """
+    connector = _connector_empty()
+    with pytest.raises(KeyError, match="node cache"):
+        connector.fetch("issue:UNSEEN")
+
+
+def test_metadata_for_returns_empty_when_item_unknown() -> None:
+    """metadata_for returns an empty SourceMetadata for an unknown id."""
+    connector = _connector_empty()
+    assert connector.metadata_for("issue:UNSEEN") == SourceMetadata()
+
+
+def test_source_link_returns_fallback_when_item_unknown() -> None:
+    """source_link returns the ``linear://`` fallback for an unknown id."""
+    connector = _connector_empty()
+    assert connector.source_link("issue:UNSEEN") == "linear://issue:UNSEEN"

--- a/tests/contracts/test_linear_protocol.py
+++ b/tests/contracts/test_linear_protocol.py
@@ -1,0 +1,175 @@
+"""Contract test for the Linear connector plugin (F43 behavioural parity).
+
+Exercises the canonical fake (:class:`tests.fakes.FakeLinearConnector`)
+AND the real implementation
+(:class:`kairix.connectors.linear.LinearConnector`) through the same
+:class:`~kairix.core.protocols.SourceConnector` Protocol assertions in
+ONE parametrized body per behaviour (F43). Without the pairing the fake
+can drift from the real wire (or vice versa) and the production path
+silently diverges from what BDD / unit tests measure.
+
+Every ``test_*`` function here is parametrized over the
+``(name, factory)`` pair so the SAME assertion runs against both the
+real and fake implementation — the F43 LIMB-2 requirement. The
+per-method failure-injection coverage lives in
+:mod:`tests.contracts.test_linear_connector_contract` (F68-style
+behaviour-under-failure; spec §11).
+
+Real-impl path is driven against a scripted
+:class:`tests.fakes.FakeLinearApiClient`; no real network call is made.
+
+Sabotage proofs (spec §5 / §11):
+  * Removing ``list_changes`` from :class:`LinearConnector` flips
+    ``test_connector_satisfies_source_connector_protocol`` (real branch).
+  * Replacing ``fetch``'s return with plain ``bytes`` breaks
+    ``test_connector_fetch_returns_markdown_artefact``.
+  * Mutating :data:`DEFAULT_SENSITIVITY` to ``"public"`` flips
+    ``test_connector_default_sensitivity_is_internal``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from kairix.connectors.linear import (
+    DEFAULT_SENSITIVITY,
+    LinearConnector,
+    LinearCredentials,
+)
+from kairix.core.protocols import ChangeEvent, RawArtefact, SourceConnector
+from tests.fakes import FakeLinearApiClient, FakeLinearConnector
+
+pytestmark = pytest.mark.contract
+
+_ISSUE_ID = "ENG-301"
+_PROJECT_ID = "uuid-project-301"
+
+
+def _issue_node() -> dict[str, Any]:
+    return {
+        "id": "uuid-issue-301",
+        "identifier": _ISSUE_ID,
+        "title": "Contract issue",
+        "description": "Issue body for the contract test.",
+        "url": "https://linear.app/your-team/issue/ENG-301",
+        "createdAt": "2026-05-20T09:00:00.000Z",
+        "updatedAt": "2026-05-22T10:00:00.000Z",
+        "state": {"name": "Backlog"},
+        "creator": {"displayName": "agent-alpha", "email": "agent-alpha@example.com"},
+        "team": {"name": "Engineering"},
+        "project": {"id": _PROJECT_ID, "name": "Contract project"},
+        "labels": {"nodes": [{"name": "roadmap"}]},
+    }
+
+
+def _project_node() -> dict[str, Any]:
+    return {
+        "id": _PROJECT_ID,
+        "name": "Contract project",
+        "description": "Project body for the contract test.",
+        "url": "https://linear.app/your-team/project/uuid-project-301",
+        "createdAt": "2026-05-19T09:00:00.000Z",
+        "updatedAt": "2026-05-21T10:00:00.000Z",
+        "lead": {"displayName": "agent-beta", "email": "agent-beta@example.com"},
+    }
+
+
+def _fake_factory() -> SourceConnector:
+    """Canonical fake factory — seeds one issue + one project node."""
+    return FakeLinearConnector(
+        nodes={
+            "issue": [_issue_node()],
+            "project": [_project_node()],
+        }
+    )
+
+
+def _real_factory() -> SourceConnector:
+    """Real-impl factory — scripted FakeLinearApiClient, cache primed."""
+    api = FakeLinearApiClient(
+        pages={
+            "issues": [[_issue_node()]],
+            "projects": [[_project_node()]],
+        }
+    )
+    connector = LinearConnector(
+        credentials=LinearCredentials(api_key="lin_contract_fixture"),  # pragma: allowlist secret — test fixture
+        client_builder=lambda _c: api,
+    )
+    # Prime the node cache so fetch()/metadata_for()/source_link() work.
+    list(connector.list_changes(cursor=None))
+    return connector
+
+
+_FACTORIES: list[tuple[str, Callable[[], SourceConnector]]] = [
+    ("fake", _fake_factory),
+    ("real", _real_factory),
+]
+
+
+@pytest.mark.parametrize("name,factory", _FACTORIES)
+def test_connector_satisfies_source_connector_protocol(name: str, factory: Callable[[], SourceConnector]) -> None:
+    """F43: both fake and real impl satisfy the runtime-checkable Protocol."""
+    connector = factory()
+    assert isinstance(connector, SourceConnector), f"{name!r} factory output is not a SourceConnector"
+    assert connector.name == "linear"
+
+
+@pytest.mark.parametrize("name,factory", _FACTORIES)
+def test_connector_list_changes_returns_change_events(name: str, factory: Callable[[], SourceConnector]) -> None:
+    """Both implementations stream type-prefixed :class:`ChangeEvent` instances."""
+    connector = factory()
+    events = list(connector.list_changes(cursor=None))
+    assert events, f"{name!r} factory produced no events"
+    for ev in events:
+        assert isinstance(ev, ChangeEvent), f"{name!r} yielded a non-ChangeEvent: {ev!r}"
+        assert ev.op in ("created", "modified", "archived", "deleted", "access_lost")
+        assert ":" in ev.item_id, f"{name!r} item_id not type-prefixed: {ev.item_id!r}"
+
+
+@pytest.mark.parametrize("name,factory", _FACTORIES)
+def test_connector_fetch_returns_markdown_artefact(name: str, factory: Callable[[], SourceConnector]) -> None:
+    """Both implementations satisfy the ``fetch`` -> :class:`RawArtefact` shape."""
+    connector = factory()
+    artefact = connector.fetch(f"issue:{_ISSUE_ID}")
+    assert isinstance(artefact, RawArtefact), f"{name!r} fetch did not return a RawArtefact: {artefact!r}"
+    assert artefact.mime == "text/markdown", f"{name!r} fetch mime is wrong: {artefact.mime!r}"
+    assert artefact.raw, f"{name!r} fetch raw bytes is empty"
+    assert _ISSUE_ID.encode() in artefact.raw, f"{name!r} rendered body missing identifier"
+
+
+@pytest.mark.parametrize("name,factory", _FACTORIES)
+def test_connector_source_link_round_trips_to_linear(name: str, factory: Callable[[], SourceConnector]) -> None:
+    """``source_link`` returns a linear.app URL on both implementations."""
+    connector = factory()
+    link = connector.source_link(f"issue:{_ISSUE_ID}")
+    assert link, f"{name!r} produced empty source_link"
+    assert link.startswith(("https://linear.app/", "linear://")), f"{name!r} unexpected link scheme: {link!r}"
+
+
+@pytest.mark.parametrize("name,factory", _FACTORIES)
+def test_connector_default_sensitivity_is_internal(name: str, factory: Callable[[], SourceConnector]) -> None:
+    """``sensitivity_for`` returns the documented default ``internal`` tier."""
+    connector = factory()
+    tier = connector.sensitivity_for(f"issue:{_ISSUE_ID}")
+    assert tier == DEFAULT_SENSITIVITY == "internal", f"{name!r} returned unexpected sensitivity: {tier!r}"
+
+
+@pytest.mark.parametrize("name,factory", _FACTORIES)
+def test_connector_metadata_for_surfaces_author(name: str, factory: Callable[[], SourceConnector]) -> None:
+    """Both implementations surface the issue author through metadata_for."""
+    connector = factory()
+    meta = connector.metadata_for(f"issue:{_ISSUE_ID}")
+    assert meta.author == "agent-alpha", f"{name!r} author mismatch: {meta.author!r}"
+
+
+@pytest.mark.parametrize("name,factory", _FACTORIES)
+def test_connector_next_cursor_advances_on_clean_drain(name: str, factory: Callable[[], SourceConnector]) -> None:
+    """Both implementations expose a high-water-mark cursor after a clean drain."""
+    connector = factory()
+    list(connector.list_changes(cursor=None))
+    cursor = connector.next_cursor()
+    assert cursor == "2026-05-22T10:00:00.000Z", f"{name!r} cursor not the max updatedAt: {cursor!r}"

--- a/tests/contracts/test_linear_protocol.py
+++ b/tests/contracts/test_linear_protocol.py
@@ -168,8 +168,20 @@ def test_connector_metadata_for_surfaces_author(name: str, factory: Callable[[],
 
 @pytest.mark.parametrize("name,factory", _FACTORIES)
 def test_connector_next_cursor_advances_on_clean_drain(name: str, factory: Callable[[], SourceConnector]) -> None:
-    """Both implementations expose a high-water-mark cursor after a clean drain."""
+    """Both impls expose a per-entity-type watermark cursor after a drain.
+
+    The opaque token JSON-encodes ``{prefix: <max-updatedAt-for-that-type>}``;
+    parity (F43) requires the fake and real impl agree on the decoded map —
+    issue advances to the issue's updatedAt, project to the project's.
+    """
+    import json
+
     connector = factory()
     list(connector.list_changes(cursor=None))
     cursor = connector.next_cursor()
-    assert cursor == "2026-05-22T10:00:00.000Z", f"{name!r} cursor not the max updatedAt: {cursor!r}"
+    assert cursor is not None, f"{name!r} produced no cursor"
+    decoded = json.loads(cursor)
+    assert decoded == {
+        "issue": "2026-05-22T10:00:00.000Z",
+        "project": "2026-05-21T10:00:00.000Z",
+    }, f"{name!r} per-type watermark map mismatch: {decoded!r}"

--- a/tests/e2e/test_composed_connector_linear_path.py
+++ b/tests/e2e/test_composed_connector_linear_path.py
@@ -1,0 +1,147 @@
+"""End-to-end composed path test for the ``connector_linear`` flag.
+
+F48 sibling to ``tests/e2e/test_composed_production_path.py``. Pinned
+by F54 because the flag's ``related_spec`` references
+``docs/architecture/connector-scope-topology/connector-design-specs/linear.md``
+— a top-level capability spec.
+
+Scenario: composes the full production path:
+
+  build_connector_pipeline (factory)
+    → FakeLinearConnector emits a ChangeEvent for an issue node
+      with mime ``text/markdown``
+    → ExtractorRegistry resolves the passthrough extractor (Markdown
+      passes through unchanged)
+    → DefaultSilverProcessor chunks the Markdown
+    → _SqliteChunkWriter persists into documents + FTS5
+    → BM25 query against the linear collection returns the chunk for
+      a token from the issue description body
+
+Flag dispatch path:
+
+  flag-resolver pins connector_linear=True
+    → dispatch_linear_sync routes to the production ON branch helper
+    → branch helper wraps the pipeline run
+
+The OFF path is covered by the integration tests at
+``tests/integration/test_feature_flag_connector_linear.py``. F54's
+E2E requirement is per-flag (one E2E composed-path file).
+
+Sabotage proof (executed by the agent, restored on completion):
+mutating _ISSUE_NODE's ``title`` to "Improve visibility" and
+``description`` to "Unrelated content about something else entirely."
+(removing all occurrences of "roadmap") makes the BM25 assertion fail
+with ``AssertionError: 0 >= 1``. Restored, the "roadmap" token in both
+title and description surfaces via BM25.
+
+No optional extras required — the Linear connector renders issues as
+Markdown, which routes through the passthrough extractor and avoids the
+markitdown/pptx/docx skipif gates that gate the SharePoint E2E.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from kairix.core.connectors import ExtractorRegistry
+from kairix.core.db.schema import create_schema
+from kairix.core.factory import build_connector_pipeline
+from kairix.worker import (
+    ConnectorSyncResult,
+    dispatch_linear_sync,
+)
+from tests.fakes import FakeFeatureFlagResolver, FakeLinearConnector
+
+pytestmark = pytest.mark.e2e
+
+# Issue node seeded into the FakeLinearConnector. Uses synthetic content
+# only (F32 — no real workspace data, no real names from Linear).
+_ISSUE_NODE: dict[str, object] = {
+    "id": "issue-fixture-0001",
+    "identifier": "ENG-42",
+    "title": "Improve roadmap visibility",
+    "description": (
+        "The roadmap needs a clearer breakdown of milestones and owners.\n"
+        "Each initiative should link to its planning document."
+    ),
+    "url": "https://linear.app/your-team/issue/ENG-42",
+    "createdAt": "2026-05-10T09:00:00.000Z",
+    "updatedAt": "2026-05-22T14:00:00.000Z",
+    "state": {"name": "In Progress", "type": "started"},
+    "team": {"key": "ENG", "name": "Engineering"},
+    "labels": {"nodes": []},
+}
+
+# BM25 token that must appear in the rendered Markdown output.
+# ``render._render_issue`` includes the description verbatim after the
+# field block — "roadmap" is a distinctive word not found in any fixture
+# or framework prose, so a false-positive BM25 hit is structurally
+# impossible in this in-memory test DB.
+_QUERY_TOKEN = "roadmap"
+
+
+def _build_db_with_schema(db_path: Path) -> sqlite3.Connection:
+    db = sqlite3.connect(str(db_path), timeout=10.0)
+    db.execute("PRAGMA journal_mode=WAL")
+    db.execute("PRAGMA foreign_keys=ON")
+    create_schema(db, dims=4)
+    return db
+
+
+def test_composed_linear_issue_path(tmp_path: Path) -> None:
+    """Linear: composed path issue → connector → passthrough → silver → BM25.
+
+    Sabotage proof (executed): mutated _ISSUE_NODE title to "Improve
+    visibility" and description to "Unrelated content about something
+    else entirely." (removing all "roadmap" occurrences) → BM25 asserts
+    ``0 >= 1`` (FAILED). Restored both fields → 1 passed.
+    """
+    resolver = FakeFeatureFlagResolver().with_flag("connector_linear", True)
+    db_path = tmp_path / "index.sqlite"
+    db = _build_db_with_schema(db_path)
+
+    fake_connector = FakeLinearConnector(nodes={"issue": [_ISSUE_NODE]})
+    registry = ExtractorRegistry()
+
+    def _on_branch() -> ConnectorSyncResult:
+        # Resolve the passthrough extractor for text/markdown — same mime
+        # the FakeLinearConnector.fetch() emits via render().
+        extractor = registry.resolve("text/markdown", b"# ENG-42")
+        pipeline = build_connector_pipeline(
+            db=db,
+            collection="linear",
+        )
+        result = pipeline.run_batch(fake_connector, extractor)
+        db.commit()
+        return ConnectorSyncResult(
+            synced=result.processed,
+            failed=result.dead_lettered,
+            dead_letter_added=result.dead_lettered,
+        )
+
+    sync_result = dispatch_linear_sync(
+        read_flag=resolver.get,
+        on_branch=_on_branch,
+    )
+    assert sync_result.synced >= 1, (
+        f"composed path must index the fixture issue; got {sync_result}. "
+        "Sabotage hint: check that FakeLinearConnector seeded the issue node "
+        "and the pipeline's chunk_writer received processed chunks."
+    )
+
+    rows = list(
+        db.execute(
+            "SELECT d.path FROM documents d JOIN documents_fts fts ON fts.rowid = d.id "
+            "WHERE documents_fts MATCH ? AND d.collection = 'linear'",
+            (_QUERY_TOKEN,),
+        )
+    )
+    db.close()
+    assert len(rows) >= 1, (
+        "composed Linear path must surface the issue description via BM25; got 0 matches. "
+        f"Sabotage hint: check that the issue description contained {_QUERY_TOKEN!r} and "
+        "the chunk-writer populated documents/content for the 'linear' collection."
+    )

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -11,6 +11,7 @@ These fakes are the canonical test doubles for contract and unit tests.
 
 from __future__ import annotations
 
+from collections.abc import Iterator, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -3162,6 +3163,220 @@ class FakeNotionConnector:
         from kairix.core.protocols import SourceMetadata
 
         return SourceMetadata()
+
+
+class FakeLinearApiClient:
+    """Scripted ``LinearApiClient`` stand-in for tests — no network.
+
+    Implements the same ``query`` / ``paginate`` surface as
+    :class:`kairix.connectors.linear.api_client.LinearApiClient` using
+    in-memory scripted responses. Records every call so tests can assert
+    what the connector sent.
+
+    Args:
+        pages: Mapping from connection name (``issues`` / ``projects`` /
+            ``documents`` / ``initiatives`` / ``projectUpdates``) to a
+            list of pages, where each page is a list of node dicts.
+            ``paginate()`` serves pages in order and stops at the last
+            page. Example::
+
+                FakeLinearApiClient(
+                    pages={
+                        "issues": [
+                            [{"id": "i-1"}, {"id": "i-2"}],   # page 1
+                            [{"id": "i-3"}],                   # page 2 (last)
+                        ]
+                    }
+                )
+
+        raise_429_times: Make ``query()`` raise
+            :class:`httpx.HTTPStatusError` (429) this many times before
+            succeeding. Use to exercise retry logic in callers without
+            a real HTTP client.
+    """
+
+    def __init__(
+        self,
+        *,
+        pages: Mapping[str, list[list[dict[str, Any]]]] | None = None,
+        raise_429_times: int = 0,
+    ) -> None:
+        import copy
+
+        self._pages: dict[str, list[list[dict[str, Any]]]] = {k: copy.deepcopy(v) for k, v in (pages or {}).items()}
+        self._remaining_429s = raise_429_times
+        self.query_calls: list[tuple[str, dict[str, Any]]] = []
+        self.paginate_calls: list[tuple[str, dict[str, Any], str]] = []
+
+    def query(self, document: str, variables: Mapping[str, Any]) -> dict[str, Any]:
+        """Return an empty data dict after consuming any scripted 429s."""
+        self.query_calls.append((document, dict(variables)))
+        if self._remaining_429s > 0:
+            self._remaining_429s -= 1
+            import httpx
+
+            raise httpx.HTTPStatusError(
+                "429 Too Many Requests",
+                request=httpx.Request("POST", "https://api.linear.app/graphql"),
+                response=httpx.Response(429),
+            )
+        return {}
+
+    def paginate(
+        self,
+        document: str,
+        variables: Mapping[str, Any],
+        *,
+        connection: str,
+    ) -> Iterator[dict[str, Any]]:
+        """Yield nodes from the scripted pages for ``connection``."""
+        self.paginate_calls.append((document, dict(variables), connection))
+        for page in self._pages.get(connection, []):
+            yield from page
+
+
+class FakeLinearConnector:
+    """Scripted Linear :class:`kairix.core.protocols.SourceConnector`.
+
+    Constructor takes the per-kind node set the fake should emit; the
+    fake satisfies the full MVP capability surface (base SourceConnector
+    + PollConnector + CredentialsConnector + SlimConnector) without
+    touching the Linear GraphQL network. Canonical fake F43 pairs with
+    the real :class:`kairix.connectors.linear.LinearConnector` inside
+    ``tests/contracts/test_linear_connector_contract.py``.
+
+    Args:
+        nodes: Mapping from entity kind (``issue`` / ``project`` /
+            ``document`` / ``initiative`` / ``projectUpdate``) to a list
+            of GraphQL-shaped node dicts. Issues key their id on
+            ``identifier``; every other kind keys on ``id``.
+        sensitivity: the F39 tier ``sensitivity_for`` returns
+            (default ``internal`` to mirror the shipped connector).
+    """
+
+    name: str = "linear"
+    per_tick_max_items: int = 500
+    disk_watermark_min_free_bytes: int | None = None
+
+    def __init__(
+        self,
+        *,
+        nodes: Mapping[str, list[dict[str, Any]]] | None = None,
+        sensitivity: str = "internal",
+    ) -> None:
+        self._sensitivity = sensitivity
+        self._by_id: dict[str, tuple[str, dict[str, Any]]] = {}
+        self._order: list[str] = []
+        self._next_cursor: str | None = None
+        for kind, kind_nodes in (nodes or {}).items():
+            for node in kind_nodes:
+                key = node.get("identifier") if kind == "issue" else node.get("id")
+                if not key:
+                    continue
+                item_id = f"{kind}:{key}"
+                self._by_id[item_id] = (kind, dict(node))
+                self._order.append(item_id)
+
+    def list_changes(self, cursor: Any | None = None) -> Any:
+        """Yield one ``modified`` ChangeEvent per seeded node."""
+        del cursor
+        from kairix.core.protocols import ChangeEvent
+
+        events: list[ChangeEvent] = []
+        high_water: str | None = None
+        for item_id in self._order:
+            kind, node = self._by_id[item_id]
+            modified_at = str(node.get("updatedAt", "1970-01-01T00:00:00.000Z"))
+            events.append(
+                ChangeEvent(
+                    op="modified",
+                    item_id=item_id,
+                    modified_at=modified_at,
+                    metadata={
+                        "sensitivity": self._sensitivity,
+                        "kind": kind,
+                        "mime": "text/markdown",
+                    },
+                )
+            )
+            if high_water is None or modified_at > high_water:
+                high_water = modified_at
+        self._next_cursor = high_water
+        return iter(events)
+
+    def fetch(self, item_id: str) -> Any:
+        from datetime import datetime, timezone
+
+        from kairix.connectors.linear.render import render
+        from kairix.core.protocols import RawArtefact
+
+        kind, node = self._by_id.get(item_id, ("issue", {}))
+        markdown = render(kind, node)
+        fetched_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        return RawArtefact(
+            raw=markdown.encode("utf-8"),
+            mime="text/markdown",
+            fetched_at=fetched_at,
+            sensitivity_hint=self._sensitivity,  # type: ignore[arg-type]  # F3-rationale: fixture passes a valid Sensitivity literal.
+        )
+
+    def source_link(self, item_id: str) -> str:
+        entry = self._by_id.get(item_id)
+        if entry is not None:
+            url = entry[1].get("url")
+            if isinstance(url, str) and url:
+                return url
+        return f"linear://{item_id}"
+
+    def sensitivity_for(self, _item_id: str) -> Any:
+        return self._sensitivity
+
+    def next_cursor(self) -> str | None:
+        return self._next_cursor
+
+    def metadata_for(self, item_id: str) -> Any:
+        """Surface author + dates + labels from the seeded node (F65)."""
+        from kairix.core.protocols import SourceMetadata
+
+        entry = self._by_id.get(item_id)
+        if entry is None:
+            return SourceMetadata()
+        node = entry[1]
+        author = None
+        author_email = None
+        for key in ("creator", "lead", "user", "assignee"):
+            person = node.get(key)
+            if isinstance(person, dict):
+                author = person.get("displayName")
+                author_email = person.get("email")
+                break
+        labels_block = node.get("labels")
+        tags: tuple[str, ...] = ()
+        if isinstance(labels_block, dict) and isinstance(labels_block.get("nodes"), list):
+            tags = tuple(n["name"] for n in labels_block["nodes"] if isinstance(n, dict) and n.get("name"))
+        return SourceMetadata(
+            modified_at=node.get("updatedAt"),
+            created_at=node.get("createdAt"),
+            author=author,
+            author_email=author_email,
+            tags=tags,
+            properties={"kind": entry[0]},
+        )
+
+    def list_changes_for_container(self, container: Any) -> Any:
+        """PollConnector — delegate to the single-cursor list_changes."""
+        return self.list_changes(getattr(container, "cursor_token", None))
+
+    def retrieve_all_slim_docs(self, _container: Any) -> Any:
+        """SlimConnector — yield every seeded item_id for the prune cycle."""
+        yield from list(self._order)
+
+    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
+        """CredentialsConnector — validate + normalise the raw credential."""
+        raw = credentials.get("api_key") or credentials.get("token")
+        if not isinstance(raw, str) or not raw.strip():
+            return None
+        return {"api_key": raw.strip()}
 
 
 class FakeGitHubConnector:

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -3229,10 +3229,22 @@ class FakeLinearApiClient:
         *,
         connection: str,
     ) -> Iterator[dict[str, Any]]:
-        """Yield nodes from the scripted pages for ``connection``."""
+        """Yield scripted nodes for ``connection`` filtered by ``updatedAt > since``.
+
+        Mirrors the real Linear API contract (``filter: { updatedAt: { gt:
+        $since } }``): nodes whose ``updatedAt`` is at or before the
+        ``since`` variable are not returned, so the connector's per-entity
+        watermark cursor is exercised faithfully across ticks. A node
+        missing ``updatedAt`` is always yielded (the connector handles it).
+        """
         self.paginate_calls.append((document, dict(variables), connection))
+        since = variables.get("since")
         for page in self._pages.get(connection, []):
-            yield from page
+            for node in page:
+                updated_at = node.get("updatedAt")
+                if isinstance(since, str) and isinstance(updated_at, str) and updated_at <= since:
+                    continue
+                yield node
 
 
 class FakeLinearConnector:
@@ -3278,12 +3290,20 @@ class FakeLinearConnector:
                 self._order.append(item_id)
 
     def list_changes(self, cursor: Any | None = None) -> Any:
-        """Yield one ``modified`` ChangeEvent per seeded node."""
+        """Yield one ``modified`` ChangeEvent per seeded node.
+
+        Mirrors the real connector's per-entity-type watermark cursor: each
+        kind advances its OWN ``updatedAt`` watermark, JSON-encoded into the
+        opaque token by :meth:`next_cursor` (F43 behavioural parity with
+        :class:`kairix.connectors.linear.LinearConnector`).
+        """
+        import json
+
         del cursor
         from kairix.core.protocols import ChangeEvent
 
         events: list[ChangeEvent] = []
-        high_water: str | None = None
+        watermarks: dict[str, str] = {}
         for item_id in self._order:
             kind, node = self._by_id[item_id]
             modified_at = str(node.get("updatedAt", "1970-01-01T00:00:00.000Z"))
@@ -3299,9 +3319,10 @@ class FakeLinearConnector:
                     },
                 )
             )
-            if high_water is None or modified_at > high_water:
-                high_water = modified_at
-        self._next_cursor = high_water
+            prior = watermarks.get(kind)
+            if prior is None or modified_at > prior:
+                watermarks[kind] = modified_at
+        self._next_cursor = json.dumps(watermarks, sort_keys=True) if watermarks else None
         return iter(events)
 
     def fetch(self, item_id: str) -> Any:

--- a/tests/integration/test_feature_flag_connector_linear.py
+++ b/tests/integration/test_feature_flag_connector_linear.py
@@ -1,0 +1,105 @@
+"""Integration tests for the ``connector_linear`` flag (F54).
+
+Exercises both branches of :func:`kairix.worker.dispatch_linear_sync`
+through the production composition surface:
+
+  * **Flag OFF** — the connector slot is a no-op; the off-branch helper
+    returns zero counters and emits the OFF-branch INFO log. The ON
+    branch is wrapped with a never-call stub; a misroute increments its
+    counter and the assertion fails loudly.
+  * **Flag ON** — the ON branch fires; the OFF branch is wrapped with a
+    never-call stub. The ON branch's marker INFO log appears.
+
+F47 — both branches are reached via the production
+``dispatch_linear_sync`` entry point; no direct ``*Pipeline(...)``
+construction in this file.
+
+F1-clean: ``FakeFeatureFlagResolver`` from ``tests/fakes.py`` is
+threaded through the production ``dispatch_linear_sync(read_flag=...)``
+DI seam — no @patch / module-attribute substitution on kairix.
+
+Sabotage proof (executed by the agent, restored on completion):
+inverting the if/else in :func:`dispatch_linear_sync` so OFF runs the
+ON branch and ON runs the OFF branch — confirmed that BOTH
+:func:`test_linear_flag_off_branch_runs` AND
+:func:`test_linear_flag_on_branch_runs` fail. Restoring the original
+branch direction returns both tests to green.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from kairix.worker import (
+    ConnectorSyncResult,
+    dispatch_linear_sync,
+)
+from tests.fakes import FakeFeatureFlagResolver
+
+pytestmark = pytest.mark.integration
+
+_ON_MARKER = "linear connector running (flag ON)"
+_OFF_MARKER = "linear connector gated off (flag OFF)"
+
+
+def test_linear_flag_off_branch_runs(caplog: pytest.LogCaptureFixture) -> None:
+    """OFF branch — linear connector slot is a no-op; ON does not fire."""
+    resolver = FakeFeatureFlagResolver().with_flag("connector_linear", False)
+
+    on_calls = {"n": 0}
+
+    def _never_on() -> ConnectorSyncResult:
+        on_calls["n"] += 1
+        return ConnectorSyncResult(synced=99, failed=0, dead_letter_added=0)
+
+    with caplog.at_level(logging.INFO, logger="kairix.worker"):
+        result = dispatch_linear_sync(
+            read_flag=resolver.get,
+            on_branch=_never_on,
+        )
+
+    messages = [rec.getMessage() for rec in caplog.records]
+    assert any(_OFF_MARKER in m for m in messages), f"flag OFF must route through the OFF branch; logs={messages!r}"
+    assert not any(_ON_MARKER in m for m in messages), (
+        f"flag OFF must NOT route through the ON branch; logs={messages!r}"
+    )
+    assert on_calls["n"] == 0, "ON branch must not run when flag is OFF"
+    assert result.synced == 0, f"OFF branch must return zero counters; got {result}"
+
+
+def test_linear_flag_on_branch_runs(caplog: pytest.LogCaptureFixture) -> None:
+    """ON branch — linear connector ON branch helper fires; OFF does not.
+
+    The ON branch is wrapped with a marker-emitting stub here so the
+    integration test doesn't drive a real connector-pipeline run (that's
+    the E2E test's job). The branch selection — gated by the flag — is
+    the property under test.
+    """
+    resolver = FakeFeatureFlagResolver().with_flag("connector_linear", True)
+
+    off_calls = {"n": 0}
+
+    def _never_off() -> ConnectorSyncResult:
+        off_calls["n"] += 1
+        return ConnectorSyncResult(synced=0, failed=0, dead_letter_added=0)
+
+    def _wrapped_on() -> ConnectorSyncResult:
+        logging.getLogger("kairix.worker").info(_ON_MARKER)
+        return ConnectorSyncResult(synced=1, failed=0, dead_letter_added=0)
+
+    with caplog.at_level(logging.INFO, logger="kairix.worker"):
+        result = dispatch_linear_sync(
+            read_flag=resolver.get,
+            on_branch=_wrapped_on,
+            off_branch=_never_off,
+        )
+
+    messages = [rec.getMessage() for rec in caplog.records]
+    assert any(_ON_MARKER in m for m in messages), f"flag ON must route through the ON branch; logs={messages!r}"
+    assert not any(_OFF_MARKER in m for m in messages), (
+        f"flag ON must NOT route through the OFF branch; logs={messages!r}"
+    )
+    assert off_calls["n"] == 0, "OFF branch must not run when flag is ON"
+    assert result.synced == 1, f"ON branch must have run and returned its result; got {result}"

--- a/tests/integration/test_linear_metadata_propagation.py
+++ b/tests/integration/test_linear_metadata_propagation.py
@@ -1,0 +1,85 @@
+"""Linear envelope metadata propagation — ADR-021 / F65.
+
+:class:`kairix.connectors.linear.LinearConnector` lifts the Linear node
+envelope (creator → author, createdAt/updatedAt → dates, labels → tags,
+state/team/project → properties) onto the :class:`SourceMetadata`
+payload; silver threads it through to the indexed
+:class:`~kairix.core.protocols.Chunk`.
+
+Sabotage proof (executed by the agent, restored on completion): mutate
+``LinearConnector.metadata_for`` to return ``SourceMetadata()`` (drop the
+author lift); assert ``chunk.author`` becomes ``None``; the test fails;
+restore.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from kairix.connectors.linear import LinearConnector, LinearCredentials
+from kairix.core import factory
+from kairix.core.db.schema import create_schema
+from tests.fakes import FakeChunkWriter, FakeEntityGraphSink, FakeExtractor, FakeLinearApiClient
+
+pytestmark = pytest.mark.integration
+
+_UPDATED_AT = "2026-05-28T08:30:00.000Z"
+
+
+def _issue_node() -> dict[str, Any]:
+    return {
+        "id": "uuid-issue-metadata-1",
+        "identifier": "ENG-501",
+        "title": "Envelope-bearing issue",
+        "description": "The issue body that becomes chunk content.",
+        "url": "https://linear.app/your-team/issue/ENG-501",
+        "createdAt": "2026-05-26T09:00:00.000Z",
+        "updatedAt": _UPDATED_AT,
+        "state": {"name": "In Progress"},
+        "creator": {"displayName": "agent-alpha", "email": "agent-alpha@example.com"},
+        "team": {"name": "Engineering"},
+        "project": {"id": "uuid-proj-1", "name": "Roadmap recall"},
+        "labels": {"nodes": [{"name": "roadmap"}, {"name": "p1"}]},
+    }
+
+
+def test_linear_envelope_metadata_lands_on_chunk(tmp_path: Path) -> None:
+    """LinearConnector.metadata_for surfaces author + chunk_date onto the chunk."""
+    api = FakeLinearApiClient(pages={"issues": [[_issue_node()]]})
+    connector = LinearConnector(
+        credentials=LinearCredentials(api_key="lin_metadata_fixture"),  # pragma: allowlist secret — test fixture
+        client_builder=lambda _c: api,
+    )
+    db_path = tmp_path / "linear_metadata.sqlite"
+    db = sqlite3.connect(str(db_path))
+    create_schema(db)
+    chunk_writer = FakeChunkWriter()
+    pipeline = factory.build_connector_pipeline(
+        db=db,
+        collection="linear-metadata-propagation",
+        chunk_writer=chunk_writer,
+        entity_graph_sink=FakeEntityGraphSink(),
+    )
+
+    pipeline.run_batch(connector, FakeExtractor())
+
+    chunks = [chunk for batch in chunk_writer.writes for chunk in batch]
+    assert chunks, "LinearConnector did not surface any chunks"
+
+    authors = [chunk.author for chunk in chunks]
+    assert "agent-alpha" in authors, f"expected envelope author 'agent-alpha' on chunk.author; got {authors!r}"
+
+    # chunk_date rides source_modified_at (the issue's updatedAt envelope).
+    chunk_dates = [chunk.source_modified_at for chunk in chunks]
+    assert _UPDATED_AT in chunk_dates, (
+        f"expected envelope updatedAt on chunk.source_modified_at (chunk_date); got {chunk_dates!r}"
+    )
+
+    all_tags: set[str] = set()
+    for chunk in chunks:
+        all_tags.update(chunk.tags)
+    assert "roadmap" in all_tags, f"expected label 'roadmap' in chunk.tags; got {sorted(all_tags)!r}"

--- a/tests/integration/test_linear_rate_limit.py
+++ b/tests/integration/test_linear_rate_limit.py
@@ -1,0 +1,116 @@
+"""F64 — Linear GraphQL client honours HTTP 429 + Retry-After backoff.
+
+:class:`kairix.connectors.linear.LinearApiClient` is the only HTTP-bound
+surface in the Linear connector. Linear's GraphQL endpoint signals
+rate-limiting with HTTP 429 + a ``Retry-After`` header (complexity-based
+limit; spec §9). This test pins:
+
+  (a) on 429 + Retry-After the client sleeps the requested seconds via
+      the INJECTED sleeper (no real wall-clock wait) and then retries,
+  (b) a Retry-After of ``0`` / a missing / non-numeric header falls back
+      to the documented default delay, and
+  (c) after exhausting the bounded retry budget the client RAISES
+      (it does NOT silently swallow the throttle and dead-letter every
+      in-flight item — the ADR-024 Bug-2 class).
+
+Linear does not use HTTP 503 for throttling (unlike the Graph-backed
+SharePoint sibling); its documented rate-limit signal is 429 only, so
+this test exercises the 429 path that the production client actually
+implements. The sleeper seam is a plain ``Callable[[float], None]`` —
+no real ``time.sleep`` (F82-clean), no monkey-patching (F1-clean).
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from kairix.connectors.linear.api_client import (
+    LINEAR_DEFAULT_RETRY_AFTER_S,
+    LinearApiClient,
+)
+
+pytestmark = pytest.mark.integration
+
+
+class _RecordingSleeper:
+    """Callable sleeper that records durations instead of sleeping."""
+
+    def __init__(self) -> None:
+        self.calls: list[float] = []
+
+    def __call__(self, seconds: float) -> None:
+        self.calls.append(seconds)
+
+
+def _ok_response() -> httpx.Response:
+    return httpx.Response(200, json={"data": {"viewer": {"id": "u-1"}}})
+
+
+def test_429_with_retry_after_honoured() -> None:
+    """The client sleeps the Retry-After seconds, then retries and succeeds."""
+    served: list[int] = [0]
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        served[0] += 1
+        if served[0] == 1:
+            return httpx.Response(429, headers={"Retry-After": "2"}, json={"error": "rate limited"})
+        return _ok_response()
+
+    sleeper = _RecordingSleeper()
+    client = LinearApiClient(
+        api_key="test-key",  # pragma: allowlist secret — test fixture
+        http=httpx.Client(transport=httpx.MockTransport(_handler)),
+        sleeper=sleeper,
+    )
+    result = client.query("query { viewer { id } }", {})
+
+    assert result == {"viewer": {"id": "u-1"}}
+    assert sleeper.calls == [2.0], f"expected one 2s backoff, got {sleeper.calls!r}"
+    assert served[0] == 2, "expected exactly one retry after the 429"
+
+
+def test_429_missing_retry_after_uses_default_delay() -> None:
+    """A 429 without a Retry-After header falls back to the default delay."""
+    served: list[int] = [0]
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        served[0] += 1
+        if served[0] == 1:
+            return httpx.Response(429, json={"error": "rate limited"})
+        return _ok_response()
+
+    sleeper = _RecordingSleeper()
+    client = LinearApiClient(
+        api_key="test-key",  # pragma: allowlist secret — test fixture
+        http=httpx.Client(transport=httpx.MockTransport(_handler)),
+        sleeper=sleeper,
+    )
+    client.query("query { viewer { id } }", {})
+
+    assert sleeper.calls == [LINEAR_DEFAULT_RETRY_AFTER_S], (
+        f"expected the default {LINEAR_DEFAULT_RETRY_AFTER_S}s fallback, got {sleeper.calls!r}"
+    )
+
+
+def test_429_exhausted_retries_raise_not_silent() -> None:
+    """After the bounded retry budget is exhausted the client RAISES.
+
+    Pins the ADR-024 Bug-2 class — a perpetually-throttled endpoint must
+    surface an error to the orchestrator (which dead-letters the tick),
+    not silently swallow the 429 and return empty.
+    """
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(429, headers={"Retry-After": "1"}, json={"error": "throttled"})
+
+    sleeper = _RecordingSleeper()
+    client = LinearApiClient(
+        api_key="test-key",  # pragma: allowlist secret — test fixture
+        http=httpx.Client(transport=httpx.MockTransport(_handler)),
+        sleeper=sleeper,
+    )
+    with pytest.raises(httpx.HTTPStatusError):
+        client.query("query { viewer { id } }", {})
+    # The client backed off on each attempt before giving up (bounded).
+    assert sleeper.calls, "client must have backed off at least once before exhausting retries"


### PR DESCRIPTION
## Summary
A Linear source connector that ingests a workspace's **roadmap + documentation** — Initiatives, Projects, Issues, Documents, and project/status updates — into the kairix knowledge store, searchable via the standard pipeline. Default-OFF behind `connector_linear`; a structurally invisible merge until cut over.

## Linked issues
Tracked as a roadmap feature in **Linear (Core Platform)**, not a GitHub issue — happy to file/link a PLA issue if you want it on the board. Design spec ships on this branch: `docs/architecture/connector-scope-topology/connector-design-specs/linear.md`.

## How (Approach A — see spec §13)
- `LinearConnector` = `SourceConnector` + `PollConnector` + `CredentialsConnector` + `SlimConnector`, mirroring the Notion connector.
- **HTTPS-only** GraphQL client (hard-coded `https://` endpoint + a guard that rejects any non-https scheme + a test); 429/`Retry-After` backoff; no new third-party dependency.
- **Incremental sync** via a **per-entity-type `updatedAt` watermark cursor** (an opaque JSON token) — each type advances independently to its last-emitted item, so no entity type is starved or skipped under the per-tick budget, and the query is skipped entirely once the budget is full.
- Five per-entity Markdown renderers → the existing bronze→silver→chunk path; provenance (author/date/labels/url/sensitivity) on every chunk.
- API-key auth via the secret store; one `linear` collection, `default_sensitivity: internal`.

## Decisions recorded
- **Incremental poll, not webhooks** (spec §13 + a docstring on `LinearConnector`/`make_connector`): roadmap/docs don't need sub-15-min freshness, and webhooks require a public callback that conflicts with hardened/closed deployments. Webhooks, OAuth, guided config, and per-team scoping are phased to later waves (§14).

## Quality
- Built via subagent-driven (Ralph) execution with `safe-commit` backpressure: a coherent core commit, then a cursor-correctness fix and a composed-path E2E.
- Every substantive commit full-gate-green: **10,339 tests, 95.78% coverage, 0 mutation survivors, all 91 fitness rules, mypy-strict**.
- A deep task review caught a real cursor starvation/skip bug (single shared watermark → per-type watermarks) and a missing E2E; a final whole-branch review caught a wasted-API-call efficiency bug — all fixed. No baseline growth, no gate-gaming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)