### PR TITLE
feat(connectors): Phase 1B — redirect ingest + re-extract + ranking-tier readers to canonical topology

### DIFF
--- a/kairix/core/factory.py
+++ b/kairix/core/factory.py
@@ -286,30 +286,38 @@ def select_boosts(
     return boosts
 
 
-def derive_tier_map() -> dict[str, str]:
-    """Derive ``{collection_name: tier_name}`` from the operator's
-    collections config (Issue #432).
+def derive_tier_map(mapping: dict[str, Any] | None = None) -> dict[str, str]:
+    """Derive ``{collection_name: tier_name}`` from the canonical
+    topology collections (Issue #432, canonical-collapse Task 6).
 
-    Reads via :func:`kairix.core.search.config_loader.load_collections`
-    so the env / cwd resolution chain applies — same surface the rest
-    of the kairix-config-aware code uses. Returns an empty dict when
-    no collections config is present, when no collection declares a
-    ``tier:`` field, or when the load fails — in all cases the
+    Reads ``topology_v2.collections[*].tier`` from the operator's MERGED
+    config mapping (base + overlay) via
+    :func:`kairix.config_layers.load_merged_mapping` — the same
+    overlay-aware read path the setup wizard writes through (#492), so a
+    wizard-saved topology block is honoured. Returns an empty dict when
+    no topology collections are present, when no collection declares a
+    ``tier:`` field, or when the parse fails — in all cases the
     :class:`SourceTierBoost` falls back to its default tier (x1.0)
     and preserves pre-#432 ranking byte-for-byte.
 
-    Pure read; no I/O beyond the YAML load. Safe to call at
-    pipeline-construction time.
+    DB-free: this is a config-parse, not a read of the materialised
+    ``topology_collections`` rows, so it stays safe to call at
+    pipeline-construction time before any DB is open. Pass ``mapping=``
+    to inject an explicit merged mapping (mirrors the
+    ``_resolve_retrieval_config(config=...)`` seam); the default resolves
+    the live merged config.
     """
     try:
-        from kairix.core.search.config_loader import load_collections
+        if mapping is None:
+            from kairix.config_layers import load_merged_mapping
 
-        collections = load_collections()
+            mapping = load_merged_mapping()
+        from kairix.config.topology_v2 import parse_topology_v2
+
+        topology = parse_topology_v2(mapping)
     except Exception:
         return {}
-    if collections is None:
-        return {}
-    return {c.name: c.tier for c in collections.shared if c.tier}
+    return {c.name: c.tier for c in topology.collections if c.tier}
 
 
 def _resolve_retrieval_config(config: RetrievalConfig | None) -> RetrievalConfig:

--- a/kairix/worker.py
+++ b/kairix/worker.py
@@ -22,8 +22,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-import yaml
-
 from kairix.paths import (
     connector_sync_disabled,
     data_dir,
@@ -335,24 +333,43 @@ class _SqliteEntityGraphSink:
         return staged
 
 
-def _load_connector_config_entries(mapping: dict[str, Any]) -> list[dict[str, Any]]:
-    """Enumerate ingestable connector entries from ``topology.connectors``.
+def _topology_entry_for_cc_pair(connector: Any, cc_pair: Any) -> dict[str, Any]:
+    """Build one canonical ingest entry dict from a connector + cc_pair.
 
-    Task 4 of the connector canonical-collapse refactor: ingest reads the
-    canonical ``topology`` block (parsed from the overlay-aware MERGED
-    operator mapping), NOT the legacy top-level ``connectors:`` list. This
-    is the wizard-onboarding fix — the setup wizard writes
-    ``topology.connectors`` and ingest now reads it from the same place.
-
-    The overloaded legacy ``entry["name"]`` splits into three canonical
-    values (D1/D2/D3):
+    Single source of truth for the kind/name/config/extractor split so the
+    live-sync reader (:func:`_load_connector_config_entries`, Task 4) and
+    the re-extract reader (:func:`_load_connector_entry`, Task 5) build
+    identical entry dicts. The overloaded legacy ``entry["name"]`` splits
+    into the canonical values (D1/D2/D3):
 
       * ``kind`` — the plugin resolution key (``ConnectorConfig.kind``,
         == entry-point name == ``connector_<kind>`` flag suffix);
       * ``name`` — the cc_pair routing key (chunk-writer collection name),
         from ``CCPairConfig.name``;
       * ``config`` — the connector_specific_config mapping, read back as a
-        dict at the per-connector boundary.
+        dict at the per-connector boundary;
+      * ``extractor`` / ``extractor_chain`` / ``extractor_config`` — the
+        extractor wiring (D1) consumed by ``build_extractor_from_entry``.
+    """
+    return {
+        "name": cc_pair.name,
+        "kind": connector.kind,
+        "config": dict(connector.connector_specific_config),
+        "extractor": connector.extractor,
+        "extractor_chain": list(connector.extractor_chain),
+        "extractor_config": dict(connector.extractor_config),
+    }
+
+
+def _parse_topology_entries(mapping: dict[str, Any]) -> list[dict[str, Any]]:
+    """Parse the merged mapping into one ingest entry per cc_pair.
+
+    Shared parse+split used by both connector readers (Task 4 sync + Task 5
+    re-extract). Reads the canonical ``topology`` block (parsed from the
+    overlay-aware MERGED operator mapping), NOT the legacy top-level
+    ``connectors:`` list — the wizard-onboarding fix: the setup wizard
+    writes ``topology.connectors`` and both readers now read it from the
+    same place.
 
     Yields **one entry per cc_pair** (D2): a topology connector referenced
     by N cc_pairs produces N entries (each cc_pair is the
@@ -361,7 +378,7 @@ def _load_connector_config_entries(mapping: dict[str, Any]) -> list[dict[str, An
     skipped with an INFO log.
 
     Returns ``[]`` when the mapping carries no parseable topology
-    connectors; the worker treats that as a no-op sync.
+    connectors; both readers treat that as "no connector".
     """
     from kairix.config.topology_v2 import parse_topology_v2
 
@@ -386,17 +403,19 @@ def _load_connector_config_entries(mapping: dict[str, Any]) -> list[dict[str, An
             )
             continue
         for cc_pair in pairs:
-            entries.append(
-                {
-                    "name": cc_pair.name,
-                    "kind": connector.kind,
-                    "config": dict(connector.connector_specific_config),
-                    "extractor": connector.extractor,
-                    "extractor_chain": list(connector.extractor_chain),
-                    "extractor_config": dict(connector.extractor_config),
-                }
-            )
+            entries.append(_topology_entry_for_cc_pair(connector, cc_pair))
     return entries
+
+
+def _load_connector_config_entries(mapping: dict[str, Any]) -> list[dict[str, Any]]:
+    """Enumerate ingestable connector entries from ``topology.connectors``.
+
+    Task 4 of the connector canonical-collapse refactor: the live-sync
+    enumeration delegates to the shared :func:`_parse_topology_entries`
+    parse+split so it stays byte-for-byte identical to the re-extract
+    reader (Task 5).
+    """
+    return _parse_topology_entries(mapping)
 
 
 def _run_one_connector_batch(
@@ -736,7 +755,7 @@ def run_reextract_dead_letter(
     source_name: str,
     db: sqlite3.Connection | None = None,
     bronze_root: Path | None = None,
-    config_path: Path | None = None,
+    config_mapping: dict[str, Any] | None = None,
     limit: int | None = None,
     dry_run: bool = False,
 ) -> ReextractResult:
@@ -750,10 +769,10 @@ def run_reextract_dead_letter(
     1. Looks up the ``bronze_records`` row for ``(source_name, item_id)``.
        Missing → skipped_no_bronze.
     2. Reads the raw bytes via ``bronze.read(ref)``.
-    3. Resolves the connector from the live config so
+    3. Resolves the connector from the canonical ``topology`` block so
        ``source_link(item_id)`` and ``sensitivity_for(item_id)`` come
        from the same connector instance that wrote bronze originally.
-       Missing connector entry → skipped_no_connector.
+       No matching cc_pair → skipped_no_connector.
     4. Runs ``extractor.extract(raw, mime)`` (whatever extractor is
        currently registered — picks up fixes like #322 markitdown
        extras). Failure → still_failing (row stays in dead_letter,
@@ -767,10 +786,20 @@ def run_reextract_dead_letter(
     logic but commits nothing — useful for sizing the recovery before
     committing to it. ``limit`` caps the number of items processed
     (None = all).
+
+    Task 5 (connector canonical-collapse): the connector entry is read
+    from the canonical ``topology`` block in the overlay-aware merged
+    operator mapping — the same place the live sync path reads — NOT the
+    legacy single-file ``connectors:`` list. ``config_mapping`` injects an
+    explicit merged mapping (tests pass the wizard-shaped topology dict);
+    when ``None`` it resolves via :func:`_load_merged_config_mapping_default`
+    (base + overlay).
     """
     from kairix.core.connectors import DeadLetterStore
     from kairix.core.db import open_db
     from kairix.core.db.schema import create_schema
+
+    mapping = config_mapping if config_mapping is not None else _load_merged_config_mapping_default()
 
     db_owned = False
     if db is None:
@@ -781,7 +810,7 @@ def run_reextract_dead_letter(
         bronze_root_resolved = bronze_root if bronze_root is not None else _bronze_root_default()
         dead_letter = DeadLetterStore(db)
 
-        entry = _load_connector_entry(source_name, config_path)
+        entry = _load_connector_entry(source_name, mapping)
         if entry is None:
             rows_no_conn = dead_letter.list(source_name)
             return ReextractResult(
@@ -797,7 +826,6 @@ def run_reextract_dead_letter(
         # on ref.raw_path. No bronze store is constructed at this level.
 
         connector, extractor, silver, chunk_writer, entity_graph_sink = _build_reextract_components(
-            source_name=source_name,
             entry=entry,
             db=db,
         )
@@ -821,21 +849,23 @@ def run_reextract_dead_letter(
             db.close()
 
 
-def _load_connector_entry(source_name: str, config_path: Path | None) -> dict[str, Any] | None:
-    """Load the YAML connector entry matching ``source_name``.
+def _load_connector_entry(source_name: str, mapping: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the canonical topology entry whose cc_pair name matches.
 
-    Returns ``None`` when the config file is absent or the named source
-    isn't declared — both shapes map to ``skipped_no_connector`` at the
-    caller, so the caller doesn't need to distinguish.
+    Task 5 of the connector canonical-collapse refactor: the re-extract
+    reader reads the canonical ``topology`` block from the overlay-aware
+    merged ``mapping`` — the SAME parse+split the live-sync reader uses
+    (:func:`_parse_topology_entries`) — and returns the entry whose ``name``
+    (the cc_pair routing key) matches ``source_name`` (the dead_letter
+    routing key). Sharing the builder guarantees the entry dict carries the
+    identical kind/name/config/extractor shape the sync path resolves.
+
+    Returns ``None`` when the mapping declares no topology connectors or no
+    cc_pair matches ``source_name`` — both shapes map to
+    ``skipped_no_connector`` at the caller, so the caller doesn't need to
+    distinguish.
     """
-    resolved = config_path if config_path is not None else _resolve_config_path_default()
-    if resolved is None:
-        return None
-    try:
-        cfg = yaml.safe_load(resolved.read_text(encoding="utf-8")) or {}
-    except Exception:  # pragma: no cover — defensive
-        return None
-    entries = cfg.get("connectors", []) if isinstance(cfg, dict) else []
+    entries = _parse_topology_entries(mapping)
     return next((e for e in entries if e.get("name") == source_name), None)
 
 
@@ -875,7 +905,6 @@ def resolve_collection_for_entry(entry: dict[str, Any]) -> str:
 
 def _build_reextract_components(
     *,
-    source_name: str,
     entry: dict[str, Any],
     db: sqlite3.Connection,
 ) -> tuple[Any, Any, Any, Any, Any]:
@@ -885,12 +914,19 @@ def _build_reextract_components(
     sees identical wiring to the original sync — including the
     ``documents.collection`` tagging invariant via
     :func:`resolve_collection_for_entry`.
+
+    Task 5 canonical-collapse split: the plugin is resolved via the
+    connector ``entry["kind"]`` (``ConnectorConfig.kind`` == entry-point
+    name) — the SAME key the live-sync path
+    (:func:`_run_one_connector_batch`) resolves on — NOT the cc_pair
+    routing name. ``entry["name"]`` keys the chunk-writer collection (via
+    :func:`resolve_collection_for_entry`).
     """
     from kairix.core.connectors import DefaultSilverProcessor, SqliteDocumentsMediaWriter, resolve_connector
     from kairix.core.connectors.collection_router import legacy_chunk_writer
     from kairix.core.connectors.registry import build_extractor_from_entry
 
-    connector = resolve_connector(source_name)(entry.get("config", {}))
+    connector = resolve_connector(entry["kind"])(entry.get("config", {}))
     # Builds either a single extractor or an EscalatingExtractor depending
     # on whether the entry sets ``extractor_chain: [...]`` or ``extractor: <name>``.
     extractor = build_extractor_from_entry(entry)

--- a/kairix/worker.py
+++ b/kairix/worker.py
@@ -335,28 +335,68 @@ class _SqliteEntityGraphSink:
         return staged
 
 
-def _load_connector_config_entries(config_path: Path | None) -> list[dict[str, Any]]:
-    """Read the ``connectors:`` list from ``config_path`` (if present).
+def _load_connector_config_entries(mapping: dict[str, Any]) -> list[dict[str, Any]]:
+    """Enumerate ingestable connector entries from ``topology.connectors``.
 
-    Returns the raw list of operator entries — each one is a dict with
-    at minimum a ``name`` key. Returns ``[]`` when ``config_path`` is
-    ``None``, the file does not exist, or no connectors are configured;
-    the worker treats every such case as a no-op sync.
+    Task 4 of the connector canonical-collapse refactor: ingest reads the
+    canonical ``topology`` block (parsed from the overlay-aware MERGED
+    operator mapping), NOT the legacy top-level ``connectors:`` list. This
+    is the wizard-onboarding fix — the setup wizard writes
+    ``topology.connectors`` and ingest now reads it from the same place.
+
+    The overloaded legacy ``entry["name"]`` splits into three canonical
+    values (D1/D2/D3):
+
+      * ``kind`` — the plugin resolution key (``ConnectorConfig.kind``,
+        == entry-point name == ``connector_<kind>`` flag suffix);
+      * ``name`` — the cc_pair routing key (chunk-writer collection name),
+        from ``CCPairConfig.name``;
+      * ``config`` — the connector_specific_config mapping, read back as a
+        dict at the per-connector boundary.
+
+    Yields **one entry per cc_pair** (D2): a topology connector referenced
+    by N cc_pairs produces N entries (each cc_pair is the
+    connector/credential/collection binding). A connector with **zero**
+    cc_pairs is not ingestable — there is no collection target — so it is
+    skipped with an INFO log.
+
+    Returns ``[]`` when the mapping carries no parseable topology
+    connectors; the worker treats that as a no-op sync.
     """
-    if config_path is None or not config_path.exists():
-        return []
-    try:
-        import yaml
+    from kairix.config.topology_v2 import parse_topology_v2
 
-        with config_path.open(encoding="utf-8") as f:
-            raw = yaml.safe_load(f) or {}
-    except Exception as exc:  # pragma: no cover — yaml parse errors are rare and logged
-        logger.warning("worker: failed to load connector config from %s — %s", config_path, exc)
+    try:
+        parsed = parse_topology_v2(mapping)
+    except Exception as exc:  # pragma: no cover — parse errors are rare and logged
+        logger.warning("worker: failed to parse topology connectors — %s", exc)
         return []
-    entries = raw.get("connectors")
-    if not isinstance(entries, list):
-        return []
-    return [e for e in entries if isinstance(e, dict) and isinstance(e.get("name"), str)]
+
+    cc_pairs_by_connector_id: dict[str, list[Any]] = {}
+    for cc_pair in parsed.cc_pairs:
+        cc_pairs_by_connector_id.setdefault(cc_pair.connector, []).append(cc_pair)
+
+    entries: list[dict[str, Any]] = []
+    for connector in parsed.connectors:
+        pairs = cc_pairs_by_connector_id.get(connector.id, [])
+        if not pairs:
+            logger.info(
+                "worker: connector %s (kind=%s) has no cc_pair — not ingestable, skipping",
+                connector.id,
+                connector.kind,
+            )
+            continue
+        for cc_pair in pairs:
+            entries.append(
+                {
+                    "name": cc_pair.name,
+                    "kind": connector.kind,
+                    "config": dict(connector.connector_specific_config),
+                    "extractor": connector.extractor,
+                    "extractor_chain": list(connector.extractor_chain),
+                    "extractor_config": dict(connector.extractor_config),
+                }
+            )
+    return entries
 
 
 def _run_one_connector_batch(
@@ -370,16 +410,14 @@ def _run_one_connector_batch(
     registry / pipeline construction failures so the caller's per-entry
     try/except logs them and continues to the next connector.
 
-    Topology v2 Wave C: when the ``topology_v2_runtime`` flag is OFF, the
-    chunk writer is constructed via
-    :func:`kairix.core.connectors.collection_router._legacy_chunk_writer`
-    (paying down the F61 baseline — the writer is built inside the
-    framework). When ON, a :class:`CollectionRouter` is built per cc_pair
-    and used as the pipeline's chunk_writer; routing happens per-item.
-    For the Wave C landing, the ON path is wired through the registry
-    but the cc_pair lookup falls back to the legacy single-collection
-    writer when no cc_pair has been registered for ``entry["name"]``
-    (zero-behavioural-change guarantee).
+    Task 4 canonical-collapse split: the overloaded legacy ``name`` is
+    now three distinct values. The plugin is resolved via ``entry["kind"]``
+    (``ConnectorConfig.kind`` == entry-point name); the chunk-writer and
+    cursor routing key is ``entry["name"]`` (the cc_pair name). A cc_pair
+    routes through :class:`CollectionRouter` when a cc_pair + mapping is
+    registered for that name; :func:`legacy_chunk_writer` remains the
+    fallback when no cc_pair has been registered yet (zero-behavioural-
+    change guarantee for entries the operator hasn't fully wired).
     """
     from kairix.core.connectors import (
         ConnectorPipeline,
@@ -393,16 +431,18 @@ def _run_one_connector_batch(
     from kairix.core.connectors.registry import build_bronze_from_entry, build_extractor_from_entry
 
     name = entry["name"]
+    kind = entry["kind"]
     # bronze_root is signature-only; streaming bronze writes no files.
     if bronze_root is not None:
         logger.debug("_run_one_connector_batch: bronze_root parameter is unused.")
-    connector_factory = resolve_connector(name)
+    # Plugin resolution keys on KIND; routing keys on the cc_pair NAME.
+    connector_factory = resolve_connector(kind)
     connector = connector_factory(entry.get("config", {}))
     extractor = build_extractor_from_entry(entry)
     bronze_store = build_bronze_from_entry(entry, db=db)
-    # topology_v2_runtime cutover complete (task #132) — always route through
-    # CollectionRouter when a cc_pair exists for `name`; legacy_chunk_writer
-    # remains the fallback when no cc_pair has been registered for the entry.
+    # Route through CollectionRouter when a cc_pair exists for `name`;
+    # legacy_chunk_writer remains the fallback when no cc_pair has been
+    # registered for the entry.
     chunk_writer = resolve_chunk_writer_for_entry(db, name)
     pipeline = ConnectorPipeline(
         db=db,
@@ -609,7 +649,7 @@ def run_connector_sync_pipeline(deps: ConnectorSyncDeps | None = None) -> Connec
         logger.info("worker: connector sync disabled via KAIRIX_CONNECTOR_SYNC_DISABLED")
         return ConnectorSyncResult(synced=0, failed=0, dead_letter_added=0)
 
-    entries = _load_connector_config_entries(deps.config_path_resolver())
+    entries = _load_connector_config_entries(deps.config_mapping_fn())
     if not entries:
         return ConnectorSyncResult(synced=0, failed=0, dead_letter_added=0)
 
@@ -624,6 +664,12 @@ def run_connector_sync_pipeline(deps: ConnectorSyncDeps | None = None) -> Connec
         failed = 0
         dead_letter_added = 0
         for entry in entries:
+            # D3: enablement keys on connector KIND (``connector_<kind>``).
+            # A registered-and-OFF kind is skipped (logged); a flagless kind
+            # always runs. A sibling connector in the same tick is unaffected.
+            if not connector_enabled(entry["kind"], deps.flag_reader):
+                logger.info("worker: connector %s gated off (flag connector_%s OFF)", entry["kind"], entry["kind"])
+                continue
             try:
                 indexed, dead_lettered = _run_one_connector_batch(db, entry, bronze_root)
             except Exception as exc:

--- a/tests/core/test_factory_tier_map.py
+++ b/tests/core/test_factory_tier_map.py
@@ -1,0 +1,108 @@
+"""Unit tests for ``kairix.core.factory.derive_tier_map`` (Task 6).
+
+The ranking-tier read is sourced from the canonical topology collections
+(``topology_v2.collections[*].tier``) via a config-parse — db-free at
+pipeline-construction time. ``derive_tier_map`` parses the merged config
+mapping and returns ``{collection_name: tier}`` for every collection that
+declares a ``tier:``; collections without a tier are omitted so the
+:class:`SourceTierBoost` falls back to its default (x1.0) multiplier.
+
+Tests inject the mapping through the ``mapping=`` seam (same shape as
+``_resolve_retrieval_config(config=...)`` elsewhere in the factory) — no
+``@patch`` (F1), no ``KAIRIX_*`` setenv (F2), no internal-name imports
+beyond the public ``derive_tier_map`` (F5).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from kairix.core.factory import derive_tier_map
+
+
+def _topology_mapping(collections: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build a merged-config mapping carrying a ``topology_v2.collections``
+    block — the canonical source ``derive_tier_map`` parses from.
+    """
+    return {"topology_v2": {"collections": collections}}
+
+
+@pytest.mark.unit
+def test_derive_tier_map_returns_name_to_tier_for_tiered_collection() -> None:
+    """A topology collection that declares ``tier:`` surfaces in the map
+    keyed by its collection name."""
+    mapping = _topology_mapping(
+        [
+            {"name": "team-canon", "sources": [], "tier": "reference"},
+        ]
+    )
+
+    result = derive_tier_map(mapping=mapping)
+
+    assert result == {"team-canon": "reference"}
+
+
+@pytest.mark.unit
+def test_derive_tier_map_omits_collection_without_tier() -> None:
+    """A collection with no ``tier:`` is omitted (SourceTierBoost then
+    falls back to its default x1.0 multiplier for that collection)."""
+    mapping = _topology_mapping(
+        [
+            {"name": "team-canon", "sources": [], "tier": "reference"},
+            {"name": "team-scratch", "sources": []},
+        ]
+    )
+
+    result = derive_tier_map(mapping=mapping)
+
+    assert result == {"team-canon": "reference"}
+    assert "team-scratch" not in result
+
+
+@pytest.mark.unit
+def test_derive_tier_map_empty_when_no_topology_collections() -> None:
+    """A mapping with no topology collections yields an empty map — the
+    default-safe answer that preserves pre-#432 ranking byte-for-byte."""
+    assert derive_tier_map(mapping={}) == {}
+
+
+@pytest.mark.unit
+def test_derive_tier_map_empty_when_no_collection_declares_tier() -> None:
+    """When every collection omits ``tier:``, the map is empty rather than
+    a name→None dict."""
+    mapping = _topology_mapping(
+        [
+            {"name": "team-canon", "sources": []},
+            {"name": "team-scratch", "sources": []},
+        ]
+    )
+
+    assert derive_tier_map(mapping=mapping) == {}
+
+
+@pytest.mark.unit
+def test_derive_tier_map_maps_multiple_tiered_collections() -> None:
+    """Several tiered collections all surface, each keyed by its own name
+    with its own tier value."""
+    mapping = _topology_mapping(
+        [
+            {"name": "team-canon", "sources": [], "tier": "canonical"},
+            {"name": "team-archive", "sources": [], "tier": "archived"},
+            {"name": "team-scratch", "sources": []},
+        ]
+    )
+
+    result = derive_tier_map(mapping=mapping)
+
+    assert result == {"team-canon": "canonical", "team-archive": "archived"}
+
+
+@pytest.mark.unit
+def test_derive_tier_map_returns_empty_on_malformed_topology() -> None:
+    """A structurally malformed topology block degrades to an empty map
+    rather than raising at pipeline-construction time."""
+    # ``collections`` must be a list; a string trips the parser's type
+    # guard, which derive_tier_map swallows into the default-safe {}.
+    assert derive_tier_map(mapping={"topology_v2": {"collections": "nope"}}) == {}

--- a/tests/e2e/test_composed_reextract_recovery_path.py
+++ b/tests/e2e/test_composed_reextract_recovery_path.py
@@ -25,9 +25,9 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
+from typing import Any
 
 import pytest
-import yaml
 
 from kairix.core.db.schema import create_schema
 from kairix.worker import (
@@ -49,23 +49,34 @@ def _seed_vault(document_root: Path) -> list[str]:
     return bodies
 
 
-def _write_config(tmp_path: Path, vault_root: Path, extractor_name: str) -> Path:
-    cfg = tmp_path / f"config_{extractor_name}.yaml"
-    cfg.write_text(
-        yaml.safe_dump(
-            {
-                "connectors": [
-                    {
-                        "name": "obsidian",
-                        "extractor": extractor_name,
-                        "config": {"vault_root": str(vault_root)},
-                    }
-                ]
-            }
-        ),
-        encoding="utf-8",
-    )
-    return cfg
+def _topology_mapping(vault_root: Path, extractor_name: str) -> dict[str, Any]:
+    """Canonical topology mapping for an obsidian connector + cc_pair.
+
+    Task 5: the composed re-extract path reads ``topology`` (cc_pair name
+    matches the dead_letter ``source_name``; kind resolves the plugin), not
+    the legacy top-level ``connectors:`` list.
+    """
+    return {
+        "topology_v2": {
+            "connectors": [
+                {
+                    "id": "obsidian-conn",
+                    "kind": "obsidian",
+                    "name": "Personal Obsidian Vault",
+                    "extractor": extractor_name,
+                    "connector_specific_config": {"vault_root": str(vault_root)},
+                }
+            ],
+            "cc_pairs": [
+                {
+                    "id": "obsidian-pair",
+                    "connector": "obsidian-conn",
+                    "credential": None,
+                    "name": "obsidian",
+                }
+            ],
+        }
+    }
 
 
 @pytest.mark.e2e
@@ -118,14 +129,14 @@ def test_composed_reextract_recovery_full_path(tmp_path: Path) -> None:
     # passthrough extractor (which exists and works on markdown). Bug D
     # composition: walk dead_letter → re-read bronze → re-run extractor →
     # write chunks → clear dead_letter row. Commits per item.
-    config_path = _write_config(tmp_path, document_root, extractor_name="passthrough")
+    mapping = _topology_mapping(document_root, extractor_name="passthrough")
 
     db = sqlite3.connect(str(db_path), timeout=10.0)
     result = run_reextract_dead_letter(
         source_name="obsidian",
         db=db,
         bronze_root=bronze_root,
-        config_path=config_path,
+        config_mapping=mapping,
     )
     assert isinstance(result, ReextractResult)
     assert result.recovered == 3, (
@@ -187,12 +198,12 @@ def test_composed_reextract_recovery_with_mixed_failure_modes(tmp_path: Path) ->
     # Delete note-1's source file → connector.fetch will fail on re-fetch
     (document_root / "note-1.md").unlink()
 
-    config_path = _write_config(tmp_path, document_root, extractor_name="passthrough")
+    mapping = _topology_mapping(document_root, extractor_name="passthrough")
     result = run_reextract_dead_letter(
         source_name="obsidian",
         db=db,
         bronze_root=bronze_root,
-        config_path=config_path,
+        config_mapping=mapping,
     )
     assert result.recovered == 1, f"only note-0 should recover; got {result}"
     assert result.skipped_source_unavailable == 1, (

--- a/tests/e2e/test_composed_resource_pressure_path.py
+++ b/tests/e2e/test_composed_resource_pressure_path.py
@@ -25,9 +25,9 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
+from typing import Any
 
 import pytest
-import yaml
 
 from kairix.core.db.schema import create_schema
 from kairix.worker import (
@@ -46,23 +46,25 @@ def _seed_vault(document_root: Path, count: int) -> None:
         )
 
 
-def _write_config(tmp_path: Path, vault_root: Path) -> Path:
-    cfg = tmp_path / "kairix.config.yaml"
-    cfg.write_text(
-        yaml.safe_dump(
-            {
-                "connectors": [
-                    {
-                        "name": "obsidian",
-                        "extractor": "passthrough",
-                        "config": {"vault_root": str(vault_root)},
-                    }
-                ]
-            }
-        ),
-        encoding="utf-8",
-    )
-    return cfg
+def _topology_mapping(vault_root: Path) -> dict[str, Any]:
+    """Canonical ``topology.connectors`` + cc_pair mapping for an obsidian
+    connector — the read shape ingest enumerates after the Task 4
+    canonical-collapse redirect (no legacy top-level ``connectors:``).
+    """
+    return {
+        "topology_v2": {
+            "connectors": [
+                {
+                    "id": "obsidian-conn",
+                    "kind": "obsidian",
+                    "name": "Obsidian Vault",
+                    "extractor": "passthrough",
+                    "connector_specific_config": {"vault_root": str(vault_root)},
+                }
+            ],
+            "cc_pairs": [{"id": "obsidian-pair", "connector": "obsidian-conn", "credential": None, "name": "obsidian"}],
+        }
+    }
 
 
 @pytest.mark.e2e
@@ -94,10 +96,10 @@ def test_composed_pipeline_leaves_scratch_clean_after_50_item_batch(tmp_path: Pa
     create_schema(db)
     db.close()
 
-    config_path = _write_config(tmp_path, document_root)
+    mapping = _topology_mapping(document_root)
     deps = ConnectorSyncDeps(
         disabled_fn=lambda: False,
-        config_path_resolver=lambda: config_path,
+        config_mapping_fn=lambda: mapping,
         db_factory=lambda: sqlite3.connect(str(db_path), timeout=10.0),
         bronze_root_resolver=lambda: bronze_root,
     )
@@ -140,10 +142,10 @@ def test_composed_pipeline_bronze_records_match_documents_count(tmp_path: Path) 
     create_schema(db)
     db.close()
 
-    config_path = _write_config(tmp_path, document_root)
+    mapping = _topology_mapping(document_root)
     deps = ConnectorSyncDeps(
         disabled_fn=lambda: False,
-        config_path_resolver=lambda: config_path,
+        config_mapping_fn=lambda: mapping,
         db_factory=lambda: sqlite3.connect(str(db_path), timeout=10.0),
         bronze_root_resolver=lambda: bronze_root,
     )

--- a/tests/integration/test_bronze_streaming_pipeline.py
+++ b/tests/integration/test_bronze_streaming_pipeline.py
@@ -12,9 +12,9 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
+from typing import Any
 
 import pytest
-import yaml
 
 from kairix.core.db.schema import create_schema
 from kairix.worker import ConnectorSyncDeps, run_via_connector_pipeline
@@ -31,23 +31,25 @@ def _seed_vault(document_root: Path, count: int) -> None:
         )
 
 
-def _write_obsidian_config(tmp_path: Path, vault_root: Path) -> Path:
-    cfg = tmp_path / "kairix.config.yaml"
-    cfg.write_text(
-        yaml.safe_dump(
-            {
-                "connectors": [
-                    {
-                        "name": "obsidian",
-                        "extractor": "passthrough",
-                        "config": {"vault_root": str(vault_root)},
-                    }
-                ]
-            }
-        ),
-        encoding="utf-8",
-    )
-    return cfg
+def _obsidian_topology_mapping(vault_root: Path) -> dict[str, Any]:
+    """Canonical ``topology.connectors`` + cc_pair mapping for an obsidian
+    connector — the read shape ingest enumerates after the Task 4
+    canonical-collapse redirect (no legacy top-level ``connectors:``).
+    """
+    return {
+        "topology_v2": {
+            "connectors": [
+                {
+                    "id": "obsidian-conn",
+                    "kind": "obsidian",
+                    "name": "Obsidian Vault",
+                    "extractor": "passthrough",
+                    "connector_specific_config": {"vault_root": str(vault_root)},
+                }
+            ],
+            "cc_pairs": [{"id": "obsidian-pair", "connector": "obsidian-conn", "credential": None, "name": "obsidian"}],
+        }
+    }
 
 
 def test_streaming_bronze_pipeline_writes_no_disk_blobs(tmp_path: Path) -> None:
@@ -77,10 +79,10 @@ def test_streaming_bronze_pipeline_writes_no_disk_blobs(tmp_path: Path) -> None:
     create_schema(db)
     db.close()
 
-    config_path = _write_obsidian_config(tmp_path, document_root)
+    mapping = _obsidian_topology_mapping(document_root)
     deps = ConnectorSyncDeps(
         disabled_fn=lambda: False,
-        config_path_resolver=lambda: config_path,
+        config_mapping_fn=lambda: mapping,
         db_factory=lambda: sqlite3.connect(str(db_path), timeout=10.0),
         bronze_root_resolver=lambda: bronze_root,
     )
@@ -110,50 +112,27 @@ def test_streaming_bronze_pipeline_writes_no_disk_blobs(tmp_path: Path) -> None:
 
 
 def test_legacy_bronze_mode_field_fails_fast(tmp_path: Path) -> None:
-    """Phase 7 removed the bronze_mode config field. Configs that still
-    carry it must surface a fix-pointer error at first connector
-    resolution so operators see the failure at deploy time.
+    """Phase 7 removed the bronze_mode config field. An entry that still
+    carries it must surface a fix-pointer error at bronze-store
+    construction so operators see the failure at deploy time.
 
-    Sabotage proof: drop the ``raise ValueError`` from build_bronze_from_entry;
-    this test fails because the sync proceeds instead of failing with the
-    fix-pointer message.
+    Driven through the public ``build_bronze_from_entry`` boundary — the
+    canonical Task 4 ingest entry never carries a top-level ``bronze_mode``
+    key, so the guard is exercised at the registry boundary it protects,
+    not via a legacy top-level ``connectors:`` config block (that read
+    path is gone).
+
+    Sabotage proof: drop the ``raise ValueError`` from
+    build_bronze_from_entry; this test fails because no ValueError is
+    raised.
     """
-    document_root = tmp_path / "vault"
-    bronze_root = tmp_path / "bronze"
+    from kairix.core.connectors.registry import build_bronze_from_entry
+
     db_path = tmp_path / "index.sqlite"
-
-    _seed_vault(document_root, count=3)
-
     db = sqlite3.connect(str(db_path), timeout=10.0)
     create_schema(db)
-    db.close()
-
-    # Legacy config with the obsolete bronze_mode field
-    cfg = tmp_path / "kairix.config.yaml"
-    cfg.write_text(
-        yaml.safe_dump(
-            {
-                "connectors": [
-                    {
-                        "name": "obsidian",
-                        "bronze_mode": "filesystem",
-                        "extractor": "passthrough",
-                        "config": {"vault_root": str(document_root)},
-                    }
-                ]
-            }
-        ),
-        encoding="utf-8",
-    )
-
-    deps = ConnectorSyncDeps(
-        disabled_fn=lambda: False,
-        config_path_resolver=lambda: cfg,
-        db_factory=lambda: sqlite3.connect(str(db_path), timeout=10.0),
-        bronze_root_resolver=lambda: bronze_root,
-    )
-    # Worker absorbs per-connector failures (logs warning, returns zero
-    # synced for the failed connector). Sync reports 0 synced and 0 failed
-    # because the failure happened at resolution before any item was processed.
-    result = run_via_connector_pipeline(deps)
-    assert result.synced == 0, f"legacy bronze_mode field should prevent sync; got {result}"
+    try:
+        with pytest.raises(ValueError, match="bronze_mode"):
+            build_bronze_from_entry({"name": "obsidian", "bronze_mode": "filesystem"}, db=db)
+    finally:
+        db.close()

--- a/tests/integration/test_reextract_edge_cases.py
+++ b/tests/integration/test_reextract_edge_cases.py
@@ -20,9 +20,9 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
+from typing import Any
 
 import pytest
-import yaml
 
 from kairix.core.connectors import DeadLetterStore, StreamingBronzeStore
 from kairix.core.db.schema import create_schema
@@ -31,23 +31,34 @@ from kairix.worker import ReextractResult, run_reextract_dead_letter
 pytestmark = pytest.mark.integration
 
 
-def _write_obsidian_config(tmp_path: Path, vault: Path, extractor_name: str = "passthrough") -> Path:
-    cfg = tmp_path / "kairix.config.yaml"
-    cfg.write_text(
-        yaml.safe_dump(
-            {
-                "connectors": [
-                    {
-                        "name": "obsidian",
-                        "extractor": extractor_name,
-                        "config": {"vault_root": str(vault)},
-                    }
-                ]
-            }
-        ),
-        encoding="utf-8",
-    )
-    return cfg
+def _obsidian_mapping(vault: Path, extractor_name: str = "passthrough") -> dict[str, Any]:
+    """Canonical topology mapping for an obsidian connector + cc_pair.
+
+    Task 5: re-extract reads ``topology`` (cc_pair name matches the
+    dead_letter ``source_name``; kind resolves the plugin), not the legacy
+    top-level ``connectors:`` list.
+    """
+    return {
+        "topology_v2": {
+            "connectors": [
+                {
+                    "id": "obsidian-conn",
+                    "kind": "obsidian",
+                    "name": "Personal Obsidian Vault",
+                    "extractor": extractor_name,
+                    "connector_specific_config": {"vault_root": str(vault)},
+                }
+            ],
+            "cc_pairs": [
+                {
+                    "id": "obsidian-pair",
+                    "connector": "obsidian-conn",
+                    "credential": None,
+                    "name": "obsidian",
+                }
+            ],
+        }
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -84,12 +95,12 @@ def test_reextract_streaming_row_when_source_file_missing(tmp_path: Path) -> Non
     # Now delete the source file — connector.fetch will fail on re-fetch
     note.unlink()
 
-    config_path = _write_obsidian_config(tmp_path, vault)
+    mapping = _obsidian_mapping(vault)
     result = run_reextract_dead_letter(
         source_name="obsidian",
         db=db,
         bronze_root=bronze_root,
-        config_path=config_path,
+        config_mapping=mapping,
     )
 
     assert isinstance(result, ReextractResult)
@@ -132,12 +143,12 @@ def test_reextract_uses_currently_registered_extractor(tmp_path: Path) -> None:
     db.commit()
 
     # Config uses passthrough — should succeed for markdown content
-    config_path = _write_obsidian_config(tmp_path, vault, extractor_name="passthrough")
+    mapping = _obsidian_mapping(vault, extractor_name="passthrough")
     result = run_reextract_dead_letter(
         source_name="obsidian",
         db=db,
         bronze_root=bronze_root,
-        config_path=config_path,
+        config_mapping=mapping,
     )
     assert result.recovered == 1, f"current-extractor recovery should succeed; got {result}"
 
@@ -166,13 +177,13 @@ def test_reextract_with_empty_dead_letter_is_noop(tmp_path: Path) -> None:
     vault.mkdir()
     db = sqlite3.connect(":memory:")
     create_schema(db)
-    config_path = _write_obsidian_config(tmp_path, vault)
+    mapping = _obsidian_mapping(vault)
 
     result = run_reextract_dead_letter(
         source_name="obsidian",
         db=db,
         bronze_root=tmp_path / "bronze",
-        config_path=config_path,
+        config_mapping=mapping,
     )
     assert result == ReextractResult(recovered=0, still_failing=0, skipped_no_bronze=0, skipped_no_connector=0)
 
@@ -205,12 +216,12 @@ def test_reextract_with_limit_larger_than_available_processes_all(tmp_path: Path
         DeadLetterStore(db).record("obsidian", f"note-{i}.md", "boot failure")
     db.commit()
 
-    config_path = _write_obsidian_config(tmp_path, vault)
+    mapping = _obsidian_mapping(vault)
     result = run_reextract_dead_letter(
         source_name="obsidian",
         db=db,
         bronze_root=bronze_root,
-        config_path=config_path,
+        config_mapping=mapping,
         limit=100,  # 100 > 3 rows available
     )
     assert result.recovered == 3, f"limit=100 vs 3 rows should process all 3; got {result}"
@@ -244,12 +255,12 @@ def test_reextract_dry_run_does_not_clear_dead_letter_on_success(tmp_path: Path)
     DeadLetterStore(db).record("obsidian", "alpha.md", "first-pass failed")
     db.commit()
 
-    config_path = _write_obsidian_config(tmp_path, vault)
+    mapping = _obsidian_mapping(vault)
     result = run_reextract_dead_letter(
         source_name="obsidian",
         db=db,
         bronze_root=bronze_root,
-        config_path=config_path,
+        config_mapping=mapping,
         dry_run=True,
     )
     # Counter increments to show the recovery WOULD work

--- a/tests/integration/test_reextract_streaming_mode.py
+++ b/tests/integration/test_reextract_streaming_mode.py
@@ -14,9 +14,9 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
+from typing import Any
 
 import pytest
-import yaml
 
 from kairix.core.connectors import DeadLetterStore, StreamingBronzeStore
 from kairix.core.db.schema import create_schema
@@ -25,24 +25,34 @@ from kairix.worker import ReextractResult, run_reextract_dead_letter
 pytestmark = pytest.mark.integration
 
 
-def _write_streaming_obsidian_config(tmp_path: Path, vault: Path) -> Path:
-    cfg = tmp_path / "kairix.config.yaml"
-    cfg.write_text(
-        yaml.safe_dump(
-            {
-                "connectors": [
-                    {
-                        "name": "obsidian",
-                        "bronze_mode": "streaming",
-                        "extractor": "passthrough",
-                        "config": {"vault_root": str(vault)},
-                    }
-                ]
-            }
-        ),
-        encoding="utf-8",
-    )
-    return cfg
+def _streaming_obsidian_mapping(vault: Path) -> dict[str, Any]:
+    """Canonical topology mapping for a streaming-bronze obsidian connector.
+
+    Task 5: re-extract reads ``topology`` (cc_pair name matches the
+    dead_letter ``source_name``; kind resolves the plugin), not the legacy
+    top-level ``connectors:`` list.
+    """
+    return {
+        "topology_v2": {
+            "connectors": [
+                {
+                    "id": "obsidian-conn",
+                    "kind": "obsidian",
+                    "name": "Personal Obsidian Vault",
+                    "extractor": "passthrough",
+                    "connector_specific_config": {"vault_root": str(vault)},
+                }
+            ],
+            "cc_pairs": [
+                {
+                    "id": "obsidian-pair",
+                    "connector": "obsidian-conn",
+                    "credential": None,
+                    "name": "obsidian",
+                }
+            ],
+        }
+    }
 
 
 def test_reextract_streaming_row_recovers_via_connector_fetch(tmp_path: Path) -> None:
@@ -66,12 +76,12 @@ def test_reextract_streaming_row_recovers_via_connector_fetch(tmp_path: Path) ->
     DeadLetterStore(db).record("obsidian", "alpha.md", "first-pass failed; should recover via re-fetch")
     db.commit()
 
-    config_path = _write_streaming_obsidian_config(tmp_path, vault)
+    mapping = _streaming_obsidian_mapping(vault)
     result = run_reextract_dead_letter(
         source_name="obsidian",
         db=db,
         bronze_root=tmp_path / "bronze",
-        config_path=config_path,
+        config_mapping=mapping,
     )
     assert isinstance(result, ReextractResult)
     assert result.recovered == 1, f"streaming-mode recovery via re-fetch should succeed; got {result}"
@@ -111,12 +121,12 @@ def test_reextract_streaming_row_with_source_deleted_routes_to_skipped(tmp_path:
     # Delete the source file so the connector can't re-fetch it
     note.unlink()
 
-    config_path = _write_streaming_obsidian_config(tmp_path, vault)
+    mapping = _streaming_obsidian_mapping(vault)
     result = run_reextract_dead_letter(
         source_name="obsidian",
         db=db,
         bronze_root=tmp_path / "bronze",
-        config_path=config_path,
+        config_mapping=mapping,
     )
     assert result.recovered == 0
     assert result.skipped_source_unavailable == 1, (
@@ -166,12 +176,12 @@ def test_reextract_mixed_streaming_and_filesystem_rows(tmp_path: Path) -> None:
     DeadLetterStore(db).record("obsidian", "filesystem-note.md", "first-pass failed")
     db.commit()
 
-    config_path = _write_streaming_obsidian_config(tmp_path, vault)
+    mapping = _streaming_obsidian_mapping(vault)
     result = run_reextract_dead_letter(
         source_name="obsidian",
         db=db,
         bronze_root=bronze_root,
-        config_path=config_path,
+        config_mapping=mapping,
     )
     assert result.recovered == 2, f"both mixed-mode rows should recover; got {result}"
     db.close()

--- a/tests/test_worker_connector_sync.py
+++ b/tests/test_worker_connector_sync.py
@@ -1,13 +1,26 @@
-"""Tests for IM-3 — ``run_connector_sync_pipeline`` wires the production
-``ConnectorPipeline`` against operator-configured connectors.
+"""Tests for IM-3 + Task 4 — ``run_connector_sync_pipeline`` enumerates
+the canonical ``topology.connectors`` block and wires the production
+``ConnectorPipeline`` against each cc_pair.
+
+Task 4 of the connector canonical-collapse refactor (Phase 1) moves
+ingest enumeration off the legacy top-level ``connectors:`` list onto
+``topology.connectors`` read through the overlay-aware merged mapping
+(``ConnectorSyncDeps.config_mapping_fn``). The overloaded legacy
+``entry["name"]`` splits into three canonical values: ``kind`` (plugin
+resolution), the cc_pair ``name`` (routing / chunk-writer key), and
+``config`` (the connector_specific_config mapping).
 
 Covers:
   - disabled short-circuit returns zero counters without touching the
     config / DB / bronze paths;
   - end-to-end run against a real Obsidian vault + passthrough extractor
-    indexes the configured markdown files;
+    enumerated from ``topology.connectors`` + a cc_pair, indexes both
+    markdown files and lands them in the cc_pair-named collection;
   - per-connector failure is logged and the loop continues — sibling
-    connectors still report their own counters.
+    connectors still report their own counters;
+  - a connector with zero cc_pairs is skipped (no collection target);
+  - the ``connector_enabled`` predicate is consulted per entry — a
+    registered kind gated OFF is skipped, a flagless sibling still runs.
 
 Sabotage-proof (executed by the agent, recorded for the reader): in
 ``run_connector_sync_pipeline`` comment out the ``pipeline.run_batch(...)``
@@ -19,11 +32,12 @@ processed). Restore the call; the test passes again.
 
 from __future__ import annotations
 
+import logging
 import sqlite3
 from pathlib import Path
+from typing import Any
 
 import pytest
-import yaml
 
 from kairix.worker import (
     ConnectorSyncDeps,
@@ -39,6 +53,37 @@ def _no_db_factory() -> sqlite3.Connection:
     raise AssertionError("db_factory must not be invoked on the short-circuit path")
 
 
+def _obsidian_topology(vault: Path, *, cc_pair_name: str = "obsidian-personal") -> dict[str, Any]:
+    """Build a minimal merged mapping with one obsidian connector + cc_pair.
+
+    Mirrors the canonical ``topology.connectors`` / ``topology.cc_pairs``
+    shape the setup wizard writes — the connector carries ``kind`` +
+    ``connector_specific_config``, and a single cc_pair binds it to a
+    routing name (the chunk-writer collection key).
+    """
+    return {
+        "topology_v2": {
+            "connectors": [
+                {
+                    "id": "obsidian-conn",
+                    "kind": "obsidian",
+                    "name": "Personal Obsidian Vault",
+                    "extractor": "passthrough",
+                    "connector_specific_config": {"vault_root": str(vault)},
+                }
+            ],
+            "cc_pairs": [
+                {
+                    "id": "obsidian-pair",
+                    "connector": "obsidian-conn",
+                    "credential": None,
+                    "name": cc_pair_name,
+                }
+            ],
+        }
+    }
+
+
 @pytest.mark.unit
 def test_disabled_short_circuits(tmp_path: Path) -> None:
     """When ``deps.disabled_fn`` returns True, ``run_connector_sync_pipeline``
@@ -51,7 +96,7 @@ def test_disabled_short_circuits(tmp_path: Path) -> None:
     """
     deps = ConnectorSyncDeps(
         disabled_fn=lambda: True,
-        config_path_resolver=lambda: tmp_path / "missing.yaml",
+        config_mapping_fn=dict,
         db_factory=_no_db_factory,
         bronze_root_resolver=lambda: tmp_path / "bronze",
     )
@@ -63,15 +108,21 @@ def test_disabled_short_circuits(tmp_path: Path) -> None:
 
 @pytest.mark.integration
 def test_runs_configured_obsidian_pipeline(tmp_path: Path) -> None:
-    """A real vault with two markdown files + a minimal
-    ``kairix.config.yaml`` declaring an obsidian connector drives the
-    full ``ConnectorPipeline`` and indexes both items.
+    """A real vault with two markdown files + a ``topology.connectors``
+    block (one obsidian connector + one cc_pair) drives the full
+    ``ConnectorPipeline`` and indexes both items.
 
-    Uses real :class:`FilesystemBronzeStore`, :class:`DefaultSilverProcessor`,
+    Proves the canonical-topology ingest redirect (Task 4): ingest
+    enumerates ``topology.connectors`` from the merged mapping, NOT the
+    legacy top-level ``connectors:`` list. This is the wizard-onboarding
+    fix — the wizard writes ``topology.connectors`` and ingest now reads
+    it.
+
+    Uses real :class:`StreamingBronzeStore`, :class:`DefaultSilverProcessor`,
     :class:`CursorStore`, :class:`DeadLetterStore`, the in-process
-    SQLite chunk-writer / entity-graph sink wired by IM-3, and the
-    real Obsidian connector + passthrough extractor resolved through
-    the entry-point registry. No fakes at this seam — F47-clean.
+    SQLite chunk-writer / entity-graph sink, and the real Obsidian
+    connector + passthrough extractor resolved through the entry-point
+    registry. No fakes at this seam — F47-clean.
 
     Sabotage proof (the brief's mandated one): comment out
     ``pipeline.run_batch(connector, extractor)`` inside
@@ -84,27 +135,11 @@ def test_runs_configured_obsidian_pipeline(tmp_path: Path) -> None:
     (vault / "alpha.md").write_text("# Alpha\n\nFirst note body content.\n", encoding="utf-8")
     (vault / "beta.md").write_text("# Beta\n\nSecond note body content.\n", encoding="utf-8")
 
-    config_path = tmp_path / "kairix.config.yaml"
-    config_path.write_text(
-        yaml.safe_dump(
-            {
-                "connectors": [
-                    {
-                        "name": "obsidian",
-                        "extractor": "passthrough",
-                        "config": {"vault_root": str(vault)},
-                    }
-                ]
-            }
-        ),
-        encoding="utf-8",
-    )
-
     db_path = tmp_path / "index.sqlite"
 
     deps = ConnectorSyncDeps(
         disabled_fn=lambda: False,
-        config_path_resolver=lambda: config_path,
+        config_mapping_fn=lambda: _obsidian_topology(vault),
         db_factory=lambda: sqlite3.connect(str(db_path)),
         bronze_root_resolver=lambda: tmp_path / "bronze",
     )
@@ -119,25 +154,26 @@ def test_runs_configured_obsidian_pipeline(tmp_path: Path) -> None:
     assert result.failed == 0
     assert result.dead_letter_added == 0
 
-    # #336 — wired-writer regression pin. The worker's _run_one_connector_batch
-    # must pass SqliteDocumentsMediaWriter to DefaultSilverProcessor; without it,
-    # silver.process() takes the "writer is None" branch and the per-document
-    # row is silently skipped (production accumulated 14.5K bronze rows + 0
-    # documents_media rows for ~2 years before this fix). Both notes should now
-    # land one row each.
-    #
-    # Sabotage proof: remove ``documents_media_writer=SqliteDocumentsMediaWriter(db)``
-    # from kairix/worker.py:_run_one_connector_batch's DefaultSilverProcessor()
-    # call; the count drops to 0 and this assertion fails.
     db = sqlite3.connect(str(db_path))
     try:
+        # #336 — wired-writer regression pin. Without
+        # documents_media_writer=SqliteDocumentsMediaWriter(db) silver skips
+        # the per-document row. Both notes should land one row each.
         (media_count,) = db.execute("SELECT COUNT(*) FROM documents_media").fetchone()
+        # The chunk-writer routing key is the cc_pair name — chunks land in
+        # the cc_pair-named collection, NOT the connector kind or the
+        # connector name. Pins the D2 kind-vs-cc_pair-name split.
+        collections = {row[0] for row in db.execute("SELECT DISTINCT collection FROM documents").fetchall()}
     finally:
         db.close()
     assert media_count == 2, (
         f"expected documents_media populated for both notes (#336 regression pin); got {media_count}. "
         "fix: confirm DefaultSilverProcessor is constructed with documents_media_writer=SqliteDocumentsMediaWriter(db) "
         "in kairix.worker._run_one_connector_batch and _build_reextract_components."
+    )
+    assert collections == {"obsidian-personal"}, (
+        "chunks must land in the cc_pair-named collection (routing keys on cc_pair name, "
+        f"not connector kind 'obsidian'); got {collections}."
     )
 
 
@@ -151,10 +187,11 @@ def test_failing_connector_logged_and_loop_continues(
     must reflect only the second connector's counters and the worker
     must log the failure rather than crash.
 
-    Uses a fictional ``does-not-exist`` connector name for the first
-    entry (forces ``resolve_connector`` to raise ``KeyError``) plus a
-    valid obsidian entry against an empty vault for the second (zero
-    items but the entry resolves cleanly).
+    Uses a fictional ``does-not-exist`` kind for the first connector
+    (forces ``resolve_connector`` to raise ``KeyError``) plus a valid
+    obsidian connector against an empty vault for the second (zero items
+    but the entry resolves cleanly). Each connector has a cc_pair so both
+    are enumerated.
 
     Sabotage proof: remove the ``except Exception`` block inside the
     ``for entry in entries`` loop; the ``KeyError`` from the unknown
@@ -162,33 +199,33 @@ def test_failing_connector_logged_and_loop_continues(
     test fails with an unhandled error. Restored, the test passes
     because the per-entry try/except absorbs the failure.
     """
-    import logging
-
     empty_vault = tmp_path / "vault"
     empty_vault.mkdir()
 
-    config_path = tmp_path / "kairix.config.yaml"
-    config_path.write_text(
-        yaml.safe_dump(
-            {
-                "connectors": [
-                    {"name": "does-not-exist", "config": {}},
-                    {
-                        "name": "obsidian",
-                        "extractor": "passthrough",
-                        "config": {"vault_root": str(empty_vault)},
-                    },
-                ]
-            }
-        ),
-        encoding="utf-8",
-    )
+    mapping: dict[str, Any] = {
+        "topology_v2": {
+            "connectors": [
+                {"id": "missing-conn", "kind": "does-not-exist", "name": "Missing"},
+                {
+                    "id": "obsidian-conn",
+                    "kind": "obsidian",
+                    "name": "Empty Vault",
+                    "extractor": "passthrough",
+                    "connector_specific_config": {"vault_root": str(empty_vault)},
+                },
+            ],
+            "cc_pairs": [
+                {"id": "missing-pair", "connector": "missing-conn", "credential": None, "name": "missing-cc"},
+                {"id": "obsidian-pair", "connector": "obsidian-conn", "credential": None, "name": "obsidian-cc"},
+            ],
+        }
+    }
 
     db_path = tmp_path / "index.sqlite"
 
     deps = ConnectorSyncDeps(
         disabled_fn=lambda: False,
-        config_path_resolver=lambda: config_path,
+        config_mapping_fn=lambda: mapping,
         db_factory=lambda: sqlite3.connect(str(db_path)),
         bronze_root_resolver=lambda: tmp_path / "bronze",
     )
@@ -204,16 +241,17 @@ def test_failing_connector_logged_and_loop_continues(
     assert result.dead_letter_added == 0
 
     failure_logs: list[str] = [
-        rec.getMessage() for rec in caplog.records if "connector does-not-exist failed" in rec.getMessage()
+        rec.getMessage() for rec in caplog.records if "missing-cc" in rec.getMessage() and "failed" in rec.getMessage()
     ]
     assert failure_logs, (
-        f"expected a warning naming the failing connector; got {[r.getMessage() for r in caplog.records]}"
+        f"expected a warning naming the failing cc_pair; got {[r.getMessage() for r in caplog.records]}"
     )
 
 
 @pytest.mark.unit
-def test_no_config_file_returns_zero_counter_no_op(tmp_path: Path) -> None:
-    """No config file → zero-counter result, no DB construction, no raise.
+def test_no_topology_returns_zero_counter_no_op(tmp_path: Path) -> None:
+    """No topology connectors → zero-counter result, no DB construction,
+    no raise.
 
     Sabotage proof: change the early-return after the no-entries check
     to ``return ConnectorSyncResult(synced=9, ...)``; ``result.synced ==
@@ -221,7 +259,7 @@ def test_no_config_file_returns_zero_counter_no_op(tmp_path: Path) -> None:
     """
     deps = ConnectorSyncDeps(
         disabled_fn=lambda: False,
-        config_path_resolver=lambda: tmp_path / "missing.yaml",
+        config_mapping_fn=dict,
         db_factory=_no_db_factory,
         bronze_root_resolver=lambda: tmp_path / "bronze",
     )
@@ -229,3 +267,186 @@ def test_no_config_file_returns_zero_counter_no_op(tmp_path: Path) -> None:
     result = run_connector_sync_pipeline(deps)
 
     assert result == ConnectorSyncResult(synced=0, failed=0, dead_letter_added=0)
+
+
+@pytest.mark.unit
+def test_zero_cc_pair_connector_is_skipped(tmp_path: Path) -> None:
+    """A topology connector referenced by zero cc_pairs is not ingestable
+    (no collection target) → skipped, no DB construction, zero counters.
+
+    A connector with no cc_pair yields no entry, so the no-entries guard
+    short-circuits before the db_factory is touched.
+
+    Sabotage proof: yield a synthetic entry for a cc_pair-less connector
+    (drop the ``connector.id in cc_pairs_by_connector_id`` guard) → the
+    _no_db_factory sentinel fires when the loop builds the DB, failing
+    this test.
+    """
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    mapping: dict[str, Any] = {
+        "topology_v2": {
+            "connectors": [
+                {
+                    "id": "lonely-conn",
+                    "kind": "obsidian",
+                    "name": "No cc_pair",
+                    "connector_specific_config": {"vault_root": str(vault)},
+                }
+            ],
+            # No cc_pairs referencing lonely-conn.
+            "cc_pairs": [],
+        }
+    }
+
+    deps = ConnectorSyncDeps(
+        disabled_fn=lambda: False,
+        config_mapping_fn=lambda: mapping,
+        db_factory=_no_db_factory,
+        bronze_root_resolver=lambda: tmp_path / "bronze",
+    )
+
+    result = run_connector_sync_pipeline(deps)
+
+    assert result == ConnectorSyncResult(synced=0, failed=0, dead_letter_added=0)
+
+
+@pytest.mark.integration
+def test_connector_enabled_gates_per_entry_in_loop(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The per-entry loop consults ``connector_enabled(entry["kind"], ...)``
+    — a registered kind whose flag reads OFF is skipped, while a flagless
+    sibling still runs.
+
+    Two connectors: ``sharepoint`` (registered ``connector_sharepoint``
+    flag, pinned OFF) and ``obsidian`` (flagless, always-on) over a real
+    two-note vault. With the flag OFF, the sharepoint plugin never
+    resolves (it would otherwise need a Graph credential); obsidian still
+    indexes both notes.
+
+    Sabotage proof: drop the ``connector_enabled`` skip in the loop — the
+    sharepoint entry resolves + runs, but the ``gated off`` INFO log no
+    longer fires, so the assertion below fails. Restored, the predicate
+    skips sharepoint before resolution and the log fires.
+    """
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "alpha.md").write_text("# Alpha\n\nFirst note.\n", encoding="utf-8")
+    (vault / "beta.md").write_text("# Beta\n\nSecond note.\n", encoding="utf-8")
+
+    mapping: dict[str, Any] = {
+        "topology_v2": {
+            "connectors": [
+                {
+                    "id": "sharepoint-conn",
+                    "kind": "sharepoint",
+                    "name": "Corp SharePoint",
+                    "connector_specific_config": {},
+                },
+                {
+                    "id": "obsidian-conn",
+                    "kind": "obsidian",
+                    "name": "Personal Vault",
+                    "extractor": "passthrough",
+                    "connector_specific_config": {"vault_root": str(vault)},
+                },
+            ],
+            "cc_pairs": [
+                {"id": "sp-pair", "connector": "sharepoint-conn", "credential": None, "name": "sharepoint-cc"},
+                {"id": "ob-pair", "connector": "obsidian-conn", "credential": None, "name": "obsidian-cc"},
+            ],
+        }
+    }
+
+    db_path = tmp_path / "index.sqlite"
+
+    def _flag_reader(_name: str) -> bool:
+        # connector_sharepoint OFF (and any other registered kind defaults OFF).
+        return False
+
+    deps = ConnectorSyncDeps(
+        disabled_fn=lambda: False,
+        config_mapping_fn=lambda: mapping,
+        flag_reader=_flag_reader,
+        db_factory=lambda: sqlite3.connect(str(db_path)),
+        bronze_root_resolver=lambda: tmp_path / "bronze",
+    )
+
+    with caplog.at_level(logging.INFO, logger="kairix.worker"):
+        result = run_connector_sync_pipeline(deps)
+
+    # Obsidian (flagless) still ran and indexed both notes.
+    assert result.synced == 2, f"flagless obsidian sibling must still sync; got {result}"
+    assert result.failed == 0
+
+    gated_logs = [
+        rec.getMessage()
+        for rec in caplog.records
+        if "sharepoint" in rec.getMessage().lower() and "gated" in rec.getMessage().lower()
+    ]
+    assert gated_logs, (
+        f"expected a 'connector sharepoint gated off' INFO log; got {[r.getMessage() for r in caplog.records]}"
+    )
+
+
+@pytest.mark.unit
+def test_multi_cc_pair_connector_yields_one_entry_per_pair(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A single topology connector referenced by TWO cc_pairs yields two
+    ingest entries (D2: one entry per cc_pair) — each carries the cc_pair
+    name as its routing key.
+
+    Proven cursor-independently: the connector kind is unresolvable
+    (``does-not-exist``), so every entry fails at ``resolve_connector``
+    and the per-entry try/except logs a failure naming the cc_pair. Two
+    cc_pairs → two distinct failure logs (one per cc_pair name). If the
+    enumeration yielded one entry per CONNECTOR instead of per cc_pair,
+    only one of the two cc_pair names would ever appear.
+
+    Sabotage proof: yield one entry per CONNECTOR (iterate
+    ``parsed.connectors`` and emit a single entry per connector) → only
+    one cc_pair name is logged, so the ``{"pair-a-cc", "pair-b-cc"}``
+    assertion fails. Restored, both cc_pair names appear.
+    """
+    mapping: dict[str, Any] = {
+        "topology_v2": {
+            "connectors": [
+                {
+                    "id": "shared-conn",
+                    "kind": "does-not-exist",
+                    "name": "Shared Connector",
+                    "connector_specific_config": {},
+                }
+            ],
+            "cc_pairs": [
+                {"id": "pair-a", "connector": "shared-conn", "credential": None, "name": "pair-a-cc"},
+                {"id": "pair-b", "connector": "shared-conn", "credential": None, "name": "pair-b-cc"},
+            ],
+        }
+    }
+
+    db_path = tmp_path / "index.sqlite"
+
+    deps = ConnectorSyncDeps(
+        disabled_fn=lambda: False,
+        config_mapping_fn=lambda: mapping,
+        db_factory=lambda: sqlite3.connect(str(db_path)),
+        bronze_root_resolver=lambda: tmp_path / "bronze",
+    )
+
+    with caplog.at_level(logging.WARNING, logger="kairix.worker"):
+        run_connector_sync_pipeline(deps)
+
+    failed_pairs = {
+        name
+        for name in ("pair-a-cc", "pair-b-cc")
+        if any(name in rec.getMessage() and "failed" in rec.getMessage() for rec in caplog.records)
+    }
+    assert failed_pairs == {"pair-a-cc", "pair-b-cc"}, (
+        "each cc_pair must produce its own ingest entry (one entry per cc_pair, D2); "
+        f"only these cc_pair names reached the per-entry loop: {failed_pairs}."
+    )

--- a/tests/test_worker_reextract.py
+++ b/tests/test_worker_reextract.py
@@ -4,6 +4,15 @@ dead-lettered items after a fixed extractor or new converter library ships.
 Drives the function in-process with a tmp_path-rooted DB + bronze + real
 Obsidian connector + passthrough extractor. Each test sabotage-proves by
 mutating production code (recorded inline) so the assertion has teeth.
+
+Task 5 (connector canonical-collapse): re-extract now reads the canonical
+``topology`` block (parsed from the overlay-aware MERGED mapping, injected
+via the ``config_mapping`` seam), NOT the legacy top-level
+``connectors:`` list. The connector entry is matched by **cc_pair name**
+(the dead_letter ``source_name`` routing key), the plugin resolves via the
+connector **kind**, and the extractor flows from the connector's extractor
+fields — the same kind/name/config/extractor split Task 4 established for
+the live sync path. ``_obsidian_topology_mapping`` builds that shape.
 """
 
 from __future__ import annotations
@@ -12,9 +21,9 @@ import io
 import json
 import sqlite3
 from pathlib import Path
+from typing import Any
 
 import pytest
-import yaml
 
 from kairix.core.connectors import DeadLetterStore, StreamingBronzeStore
 from kairix.core.db.schema import create_schema
@@ -46,23 +55,41 @@ def _seed_bronze_and_dead_letter(
     db.commit()
 
 
-def _write_obsidian_config(*, tmp_path: Path, vault_root: Path) -> Path:
-    config_path = tmp_path / "kairix.config.yaml"
-    config_path.write_text(
-        yaml.safe_dump(
-            {
-                "connectors": [
-                    {
-                        "name": "obsidian",
-                        "extractor": "passthrough",
-                        "config": {"vault_root": str(vault_root)},
-                    }
-                ]
-            }
-        ),
-        encoding="utf-8",
-    )
-    return config_path
+def _obsidian_topology_mapping(
+    *,
+    vault_root: Path,
+    cc_pair_name: str = "obsidian",
+    extractor: str = "passthrough",
+) -> dict[str, Any]:
+    """Build a merged mapping with one obsidian connector + cc_pair.
+
+    Mirrors the canonical ``topology.connectors`` / ``topology.cc_pairs``
+    shape the setup wizard writes. The cc_pair ``name`` is the routing key
+    re-extract matches against ``source_name`` (and the dead_letter rows are
+    keyed on); the connector ``kind`` resolves the plugin; the connector's
+    ``extractor`` flows through to the re-extract extractor.
+    """
+    return {
+        "topology_v2": {
+            "connectors": [
+                {
+                    "id": "obsidian-conn",
+                    "kind": "obsidian",
+                    "name": "Personal Obsidian Vault",
+                    "extractor": extractor,
+                    "connector_specific_config": {"vault_root": str(vault_root)},
+                }
+            ],
+            "cc_pairs": [
+                {
+                    "id": "obsidian-pair",
+                    "connector": "obsidian-conn",
+                    "credential": None,
+                    "name": cc_pair_name,
+                }
+            ],
+        }
+    }
 
 
 def test_recovers_dead_lettered_item_clears_row_and_writes_chunks(tmp_path: Path) -> None:
@@ -91,13 +118,13 @@ def test_recovers_dead_lettered_item_clears_row_and_writes_chunks(tmp_path: Path
         raw_path=note,
     )
 
-    config_path = _write_obsidian_config(tmp_path=tmp_path, vault_root=vault)
+    mapping = _obsidian_topology_mapping(vault_root=vault)
 
     result = run_reextract_dead_letter(
         source_name="obsidian",
         db=db,
         bronze_root=bronze_root,
-        config_path=config_path,
+        config_mapping=mapping,
     )
 
     assert isinstance(result, ReextractResult)
@@ -118,13 +145,128 @@ def test_recovers_dead_lettered_item_clears_row_and_writes_chunks(tmp_path: Path
     db.close()
 
 
-def test_skipped_no_connector_when_source_not_in_config(tmp_path: Path) -> None:
-    """A dead_letter row whose ``source_name`` isn't in the loaded config
+def test_reextract_matches_cc_pair_name_and_resolves_plugin_via_kind(tmp_path: Path) -> None:
+    """Task 5 — re-extract reads the canonical topology entry split: it
+    matches the connector entry by **cc_pair name** (the dead_letter
+    routing key) while resolving the plugin via the connector **kind**.
+
+    The topology here gives the cc_pair a name (``vault-personal``) that is
+    DISTINCT from the connector kind (``obsidian``). Recovery succeeds only
+    if (1) the entry is matched on the cc_pair name passed as
+    ``source_name`` AND (2) the obsidian plugin is resolved via the
+    connector's ``kind`` — not via ``source_name`` (which would try to
+    resolve a non-existent ``vault-personal`` plugin). The recovered
+    documents land in the ``vault-personal`` collection (the cc_pair name),
+    proving the routing key flows through.
+
+    Sabotage proof (executed): in ``_build_reextract_components``, change
+    ``resolve_connector(entry["kind"])`` back to
+    ``resolve_connector(source_name)``; this test fails because
+    ``resolve_connector("vault-personal")`` raises (no such plugin) so
+    nothing recovers. Restored, it passes.
+    """
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    note = vault / "alpha.md"
+    note.write_text("# Alpha\n\nBody content for the split test.\n", encoding="utf-8")
+
+    db_path = tmp_path / "index.sqlite"
+    db = sqlite3.connect(str(db_path))
+    create_schema(db)
+    bronze_root = tmp_path / "bronze"
+    # dead_letter + bronze rows are keyed on the cc_pair name (source_name).
+    _seed_bronze_and_dead_letter(
+        db=db,
+        bronze_root=bronze_root,
+        source_name="vault-personal",
+        item_id="alpha.md",
+        raw_path=note,
+    )
+
+    # Connector kind=obsidian, cc_pair name=vault-personal (kind != name).
+    mapping = _obsidian_topology_mapping(vault_root=vault, cc_pair_name="vault-personal")
+
+    result = run_reextract_dead_letter(
+        source_name="vault-personal",
+        db=db,
+        bronze_root=bronze_root,
+        config_mapping=mapping,
+    )
+
+    assert result.recovered == 1, f"recovery must match the cc_pair name and resolve the plugin via kind; got {result}"
+    assert result.skipped_no_connector == 0
+
+    # Routing key flows through: recovered docs carry the cc_pair-name
+    # collection, NOT the connector kind 'obsidian'.
+    collections = {
+        row[0] for row in db.execute("SELECT DISTINCT collection FROM documents WHERE active = 1").fetchall()
+    }
+    assert collections == {"vault-personal"}, (
+        f"recovered docs must land in the cc_pair-name collection 'vault-personal' "
+        f"(the routing key), not the connector kind; got {collections}."
+    )
+
+    db.close()
+
+
+def test_reextract_threads_topology_extractor_through(tmp_path: Path) -> None:
+    """Task 5 — the connector's ``extractor`` field flows from the topology
+    entry into the re-extract extractor resolution.
+
+    The bronze row holds bytes that are NOT a valid PDF; the topology
+    connector declares ``extractor: pdf_fallback``. Re-extract must resolve
+    pdf_fallback (from the entry's extractor field) and fail to parse the
+    junk bytes → ``still_failing``. A passthrough extractor would have
+    "recovered" the junk bytes verbatim, so a green ``still_failing == 1``
+    proves the topology extractor field threaded through (not a default).
+
+    Sabotage proof (executed): in ``_load_connector_entry`` / the shared
+    builder, drop the ``"extractor"`` key from the entry dict; re-extract
+    falls back to passthrough, the junk bytes "recover", and this test
+    fails with ``recovered == 1``. Restored, it lands in still_failing.
+    """
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    junk = b"NOT A REAL PDF - a lure for the pdf_fallback extractor"
+    (vault / "broken.pdf").write_bytes(junk)
+
+    db = sqlite3.connect(":memory:")
+    create_schema(db)
+    StreamingBronzeStore(db).write("obsidian", "broken.pdf", junk, "application/pdf")
+    DeadLetterStore(db).record("obsidian", "broken.pdf", "first-pass failed")
+    db.commit()
+
+    mapping = _obsidian_topology_mapping(vault_root=vault, extractor="pdf_fallback")
+
+    result = run_reextract_dead_letter(
+        source_name="obsidian",
+        db=db,
+        bronze_root=tmp_path / "bronze",
+        config_mapping=mapping,
+    )
+
+    assert result.still_failing == 1, (
+        f"the topology extractor (pdf_fallback) must thread through and fail on junk PDF bytes; got {result}"
+    )
+    assert result.recovered == 0, (
+        f"a recovered==1 would mean passthrough ran — the topology extractor field did not thread through; got {result}"
+    )
+
+    db.close()
+
+
+def test_skipped_no_connector_when_source_not_in_topology(tmp_path: Path) -> None:
+    """A dead_letter row whose ``source_name`` matches no topology cc_pair
     counts as ``skipped_no_connector`` and the row is preserved.
 
-    Sabotage proof: replace the ``if entry is None`` early-return with
-    ``entry = entries[0]``; the test fails because the function blows up
-    resolving the missing connector. Restored, it passes.
+    Pins the Task-5 ``_load_connector_entry(...) is None`` path through the
+    public re-extract surface: the topology declares an ``obsidian`` cc_pair
+    only, so a ``ghost`` source has no matching entry.
+
+    Sabotage proof: in ``_load_connector_entry``, replace
+    ``e.get("name") == source_name`` with ``True`` (match the first entry);
+    the test fails because re-extract then resolves the obsidian connector
+    for the ghost rows instead of skipping. Restored, it passes.
     """
     vault = tmp_path / "vault"
     vault.mkdir()
@@ -134,19 +276,19 @@ def test_skipped_no_connector_when_source_not_in_config(tmp_path: Path) -> None:
     create_schema(db)
     bronze_root = tmp_path / "bronze"
 
-    # Seed a dead_letter row for "ghost" — no matching config entry.
+    # Seed a dead_letter row for "ghost" — no matching topology cc_pair.
     dead_letter = DeadLetterStore(db)
     dead_letter.record("ghost", "item-1", "stale row from removed connector")
     db.commit()
 
-    # Config only declares obsidian, not ghost.
-    config_path = _write_obsidian_config(tmp_path=tmp_path, vault_root=vault)
+    # Topology only declares an obsidian cc_pair, not ghost.
+    mapping = _obsidian_topology_mapping(vault_root=vault)
 
     result = run_reextract_dead_letter(
         source_name="ghost",
         db=db,
         bronze_root=bronze_root,
-        config_path=config_path,
+        config_mapping=mapping,
     )
 
     assert result.skipped_no_connector == 1
@@ -164,10 +306,18 @@ def test_skipped_no_connector_when_source_not_in_config(tmp_path: Path) -> None:
     db.close()
 
 
-def test_skipped_no_connector_when_config_path_is_none(tmp_path: Path) -> None:
-    """When the resolver returns no config at all, every dead_letter row
-    is skipped_no_connector. Pre-deploy boundary — operator runs reextract
-    against a fresh data dir before kairix.config.yaml is in place.
+def test_skipped_no_connector_when_mapping_has_no_topology(tmp_path: Path) -> None:
+    """When the merged mapping carries no topology connectors at all, every
+    dead_letter row is skipped_no_connector. Pre-deploy boundary — operator
+    runs reextract against a fresh data dir before the wizard has written a
+    ``topology`` block.
+
+    Injects an empty mapping through the ``config_mapping`` seam so the
+    skip is deterministic (no dependence on the host's resolved config).
+
+    Sabotage proof: change the ``if entry is None`` early-return body in
+    ``run_reextract_dead_letter`` to fall through; the function raises
+    resolving a connector from an empty entry. Restored, it skips.
     """
     db_path = tmp_path / "index.sqlite"
     db = sqlite3.connect(str(db_path))
@@ -182,15 +332,15 @@ def test_skipped_no_connector_when_config_path_is_none(tmp_path: Path) -> None:
         source_name="orphan",
         db=db,
         bronze_root=tmp_path / "bronze",
-        config_path=None,  # Simulates "no config" — but because we pass
-        # explicit None the default resolver kicks in. To force the no-config
-        # branch reliably we point at a file that doesn't exist instead.
+        config_mapping={},  # empty merged mapping (no topology connectors)
     )
-    # The default resolver may still find a config in the user's env, so
-    # we don't assert a specific shape here — just that the function runs
-    # without raising and returns a valid ReextractResult.
     assert isinstance(result, ReextractResult)
-    assert (result.skipped_no_connector + result.recovered + result.still_failing + result.skipped_no_bronze) >= 0
+    assert result.skipped_no_connector == 2, (
+        f"both orphan rows should skip when no topology connector matches; got {result}"
+    )
+    assert result.recovered == 0
+    assert result.still_failing == 0
+    assert result.skipped_no_bronze == 0
 
     db.close()
 
@@ -215,13 +365,13 @@ def test_skipped_no_bronze_when_bronze_row_missing(tmp_path: Path) -> None:
     dead_letter.record("obsidian", "lost.md", "bronze pruned")
     db.commit()
 
-    config_path = _write_obsidian_config(tmp_path=tmp_path, vault_root=vault)
+    mapping = _obsidian_topology_mapping(vault_root=vault)
 
     result = run_reextract_dead_letter(
         source_name="obsidian",
         db=db,
         bronze_root=tmp_path / "bronze",
-        config_path=config_path,
+        config_mapping=mapping,
     )
 
     assert result.skipped_no_bronze == 1, f"expected skipped_no_bronze=1, got {result}"
@@ -258,13 +408,13 @@ def test_dry_run_does_not_commit_or_clear(tmp_path: Path) -> None:
         raw_path=note,
     )
 
-    config_path = _write_obsidian_config(tmp_path=tmp_path, vault_root=vault)
+    mapping = _obsidian_topology_mapping(vault_root=vault)
 
     result = run_reextract_dead_letter(
         source_name="obsidian",
         db=db,
         bronze_root=bronze_root,
-        config_path=config_path,
+        config_mapping=mapping,
         dry_run=True,
     )
 
@@ -308,13 +458,13 @@ def test_limit_caps_processed_rows(tmp_path: Path) -> None:
         db=db, bronze_root=bronze_root, source_name="obsidian", item_id="beta.md", raw_path=note_b
     )
 
-    config_path = _write_obsidian_config(tmp_path=tmp_path, vault_root=vault)
+    mapping = _obsidian_topology_mapping(vault_root=vault)
 
     result = run_reextract_dead_letter(
         source_name="obsidian",
         db=db,
         bronze_root=bronze_root,
-        config_path=config_path,
+        config_mapping=mapping,
         limit=1,
     )
 

--- a/tests/test_worker_reextract_bookkeeping.py
+++ b/tests/test_worker_reextract_bookkeeping.py
@@ -27,9 +27,9 @@ import sqlite3
 import time
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 import pytest
-import yaml
 
 from kairix.core.connectors import StreamingBronzeStore
 from kairix.core.db.schema import create_schema
@@ -55,27 +55,35 @@ _OLD_ERROR = "stale error from boot"
 _OLD_ATTEMPT_ISO = "2020-01-01T00:00:00+00:00"
 
 
-def _write_pdf_fallback_config(tmp_path: Path, vault: Path) -> Path:
-    """Write a kairix.config.yaml routing obsidian through pdf_fallback.
+def _pdf_fallback_mapping(vault: Path) -> dict[str, Any]:
+    """Canonical topology mapping routing obsidian through pdf_fallback.
 
     pdf_fallback is the extractor that will raise on invalid PDF bytes.
+    Task 5: re-extract reads ``topology`` (cc_pair name matches the
+    dead_letter ``source_name``; kind resolves the plugin), not the legacy
+    top-level ``connectors:`` list.
     """
-    cfg = tmp_path / "kairix.config.yaml"
-    cfg.write_text(
-        yaml.safe_dump(
-            {
-                "connectors": [
-                    {
-                        "name": "obsidian",
-                        "extractor": "pdf_fallback",
-                        "config": {"vault_root": str(vault)},
-                    }
-                ]
-            }
-        ),
-        encoding="utf-8",
-    )
-    return cfg
+    return {
+        "topology_v2": {
+            "connectors": [
+                {
+                    "id": "obsidian-conn",
+                    "kind": "obsidian",
+                    "name": "Personal Obsidian Vault",
+                    "extractor": "pdf_fallback",
+                    "connector_specific_config": {"vault_root": str(vault)},
+                }
+            ],
+            "cc_pairs": [
+                {
+                    "id": "obsidian-pair",
+                    "connector": "obsidian-conn",
+                    "credential": None,
+                    "name": "obsidian",
+                }
+            ],
+        }
+    }
 
 
 def _seed_dead_letter_with_history(
@@ -146,7 +154,7 @@ def test_reextract_failure_bumps_failure_count_and_records_fresh_error(tmp_path:
     StreamingBronzeStore(db).write(source_name, item_id, _BAD_PDF_BYTES, "application/pdf")
     _seed_dead_letter_with_history(db=db, source_name=source_name, item_id=item_id)
 
-    config_path = _write_pdf_fallback_config(tmp_path, vault)
+    mapping = _pdf_fallback_mapping(vault)
 
     before_ts = datetime.now(timezone.utc)
     # Sleep a tick so timestamp ordering is unambiguous on fast CI runners.
@@ -156,7 +164,7 @@ def test_reextract_failure_bumps_failure_count_and_records_fresh_error(tmp_path:
         source_name=source_name,
         db=db,
         bronze_root=tmp_path / "bronze",
-        config_path=config_path,
+        config_mapping=mapping,
     )
 
     assert isinstance(result, ReextractResult)
@@ -212,13 +220,13 @@ def test_reextract_dry_run_failure_does_not_touch_bookkeeping(tmp_path: Path) ->
     StreamingBronzeStore(db).write(source_name, item_id, _BAD_PDF_BYTES, "application/pdf")
     _seed_dead_letter_with_history(db=db, source_name=source_name, item_id=item_id)
 
-    config_path = _write_pdf_fallback_config(tmp_path, vault)
+    mapping = _pdf_fallback_mapping(vault)
 
     result = run_reextract_dead_letter(
         source_name=source_name,
         db=db,
         bronze_root=tmp_path / "bronze",
-        config_path=config_path,
+        config_mapping=mapping,
         dry_run=True,
     )
 

--- a/tests/unit/test_worker_connector_sync.py
+++ b/tests/unit/test_worker_connector_sync.py
@@ -7,10 +7,10 @@ source) — plus the module-level :func:`kairix.worker.connector_enabled`
 predicate that keys on connector KIND (``connector_<kind>`` == REGISTRY
 suffix), NOT the cc_pair name.
 
-The predicate is landed but NOT yet wired into
-``run_connector_sync_pipeline``'s per-entry loop — Task 4 wires it once
-entries carry ``kind``. These tests pin the predicate behaviour and the
-new default-factory wiring.
+Task 4 wires this predicate into ``run_connector_sync_pipeline``'s
+per-entry loop (the loop-wiring test lives in
+``tests/test_worker_connector_sync.py``). These tests pin the predicate
+behaviour and the default-factory wiring in isolation.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Linked issues
Connector refactor **Phase 1 — Phase B (reader redirects)**. Builds on the foundation (#572). Spec: `docs/architecture/connector-architecture-refactor.md`.

## Summary
Redirects the connector readers off the legacy config blocks onto the canonical `topology`. **Code-only** — the live ingest behaviour change takes effect only at the gated VM deploy.

- **Task 4** — ingest enumeration (`_load_connector_config_entries`) reads `topology.connectors` (one entry per cc_pair; kind/cc_pair-name/config/extractor split; `connector_enabled` flag gate wired into the loop). **This is the wizard-onboarding fix** (wizard writes topology, ingest now reads it).
- **Task 5** — the re-extract reader (`_load_connector_entry`) redirected via a shared `_parse_topology_entries`/`_topology_entry_for_cc_pair` helper (DRY with Task 4). Caught + fixed a latent bug: re-extract resolved the plugin via `source_name` instead of `kind`.
- **Task 6** — ranking-tier map sourced from `topology.collections` (db-free, overlay-aware); `SourceTierBoost` unchanged.

## Deferred (documented): legacy `collections:` parser deletion (Task 7)
Task 7 (delete the legacy `collections:` parser) is **blocked by prerequisite schema work** and intentionally not done here: `load_collections` still serves (a) per-collection retrieval overrides and (b) the document-scan FS `path`/`glob` walk — neither modelled on the canonical topology `CollectionConfig`. The default-scope-membership migration it nominally owned is already complete in production (#132). Full collection-collapse needs topology `CollectionConfig` to grow `retrieval_overrides` + FS-scan fields — tracked as a follow-on.

## Test plan
- Full `safe-commit` gate green on every commit; mutation parity clean with **no skip** (the harness `test_<mod>_*.py` fix from #572 held).
- Executed sabotage-proofs on every behaviour change (kind/name split, flag gate, re-extract match, tier derivation). Wizard-onboarding ingest, multi/zero-cc_pair, and the e2e composed paths covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
