### PR TITLE
fix(connectors): retire deleted/archived items from the index (op-aware delete dispatch)

### DIFF
--- a/kairix/core/connectors/pipeline.py
+++ b/kairix/core/connectors/pipeline.py
@@ -71,6 +71,18 @@ logger = logging.getLogger(__name__)
 # ``_process_batch`` to bump the right :class:`BatchResult` counter.
 _OUTCOME_PROCESSED = "processed"
 _OUTCOME_DEAD_LETTERED = "dead_lettered"
+_OUTCOME_DELETED = "deleted"
+
+# ChangeEvent.op values that mean "remove this item from the index"
+# (connector-architecture-refactor §3.3 primitive #1). ``deleted`` is a
+# hard removal; ``archived`` is a recoverable soft-delete; ``access_lost``
+# means the credential was revoked so the item is no longer re-fetchable.
+# All three retire the previously-indexed chunks via
+# :meth:`ChunkWriter.delete_by_source_uri` — re-indexing them (or leaving
+# them searchable) is the deletion-staleness bug this set fixes. The
+# ``ChangeEvent.op`` literal (protocols.py) does NOT include "cancelled";
+# connectors that observe a cancellation surface it as ``deleted``.
+_DELETE_OPS = frozenset({"deleted", "archived", "access_lost"})
 
 
 @dataclass
@@ -80,6 +92,7 @@ class _BatchTotals:
     processed: int = 0
     dead_lettered: int = 0
     poisoned_skipped: int = 0
+    deleted: int = 0
 
 
 @dataclass
@@ -88,11 +101,12 @@ class _ChunkAccumulator:
 
     processed: int = 0
     dead_lettered: int = 0
+    deleted: int = 0
     latest_modified_at: str | None = None
 
     @property
     def size(self) -> int:
-        return self.processed + self.dead_lettered
+        return self.processed + self.dead_lettered + self.deleted
 
     def record(self, outcome: str, modified_at: str) -> None:
         self.latest_modified_at = modified_at
@@ -100,10 +114,13 @@ class _ChunkAccumulator:
             self.processed += 1
         elif outcome == _OUTCOME_DEAD_LETTERED:
             self.dead_lettered += 1
+        elif outcome == _OUTCOME_DELETED:
+            self.deleted += 1
 
     def reset(self) -> None:
         self.processed = 0
         self.dead_lettered = 0
+        self.deleted = 0
         self.latest_modified_at = None
 
 
@@ -130,6 +147,16 @@ class BatchResult:
       drained. The partial cursor is committed; the next tick resumes
       from there. The operator's signal that a backlog is converging
       over many ticks.
+
+    Connector-architecture-refactor §3.3 primitive #1:
+
+    * ``deleted`` — count of items whose :class:`~kairix.core.protocols.ChangeEvent`
+      carried a delete-op (``deleted`` / ``archived`` / ``access_lost``)
+      and were retired from the index via
+      :meth:`ChunkWriter.delete_by_source_uri`. These items skipped
+      fetch / extract / upsert entirely, so they do NOT count toward
+      ``processed``; ``deleted`` is the operator's signal that
+      upstream removals are propagating instead of silently re-indexing.
     """
 
     processed: int
@@ -137,6 +164,7 @@ class BatchResult:
     poisoned_skipped: int
     skipped_low_disk: bool = False
     budget_yielded: bool = False
+    deleted: int = 0
 
 
 _BUDGET_EXHAUSTED_SENTINEL = "F66:budget_exhausted"
@@ -343,6 +371,7 @@ class ConnectorPipeline:
             dead_lettered=totals.dead_lettered,
             poisoned_skipped=totals.poisoned_skipped,
             budget_yielded=budget_yielded,
+            deleted=totals.deleted,
         )
 
     def _process_change(
@@ -386,6 +415,7 @@ class ConnectorPipeline:
         self._db.commit()
         totals.processed += chunk.processed
         totals.dead_lettered += chunk.dead_lettered
+        totals.deleted += chunk.deleted
         chunk.reset()
 
     def _process_item(
@@ -394,7 +424,24 @@ class ConnectorPipeline:
         extractor: Extractor,
         change: object,
     ) -> str:
-        """Process one :class:`ChangeEvent`; return ``"processed"`` or ``"dead_lettered"``.
+        """Process one :class:`ChangeEvent`; return the outcome tag.
+
+        Returns ``"processed"`` (flowed end-to-end through Bronze +
+        Silver + writer + sink), ``"dead_lettered"`` (fetch / extract
+        raised), or ``"deleted"`` (a delete-op event retired the item).
+
+        Connector-architecture-refactor §3.3 primitive #1 — delete
+        dispatch. When ``change.op`` is a delete-op
+        (``deleted`` / ``archived`` / ``access_lost``), the item's
+        previously-indexed chunks are removed via
+        :meth:`ChunkWriter.delete_by_source_uri` and fetch / extract /
+        upsert are skipped entirely. ``connector.source_link(item_id)``
+        is the same ``source_uri`` the chunks were written under (Silver
+        sets ``Chunk.source_uri = connector.source_link(item_id)`` on
+        the create / modify path below), so the delete targets exactly
+        those rows. Without this branch a deleted item is re-indexed
+        with stale content (if fetch still returns a payload) or
+        dead-lettered forever (if fetch 404s) — never removed.
 
         Per-item failures (fetch / extract raised) are recorded in
         dead_letter and absorbed — sibling items still process. Silver
@@ -416,6 +463,16 @@ class ConnectorPipeline:
         # across future ChangeEvent extensions.
         item_id = change.item_id  # type: ignore[attr-defined]  # F3-rationale: change is ChangeEvent from connector.list_changes; attr is on the dataclass.
         modified_at = change.modified_at  # type: ignore[attr-defined]  # F3-rationale: same as item_id above.
+        op = change.op  # type: ignore[attr-defined]  # F3-rationale: ChangeEvent.op literal from connector.list_changes; attr is on the dataclass.
+        if op in _DELETE_OPS:
+            # Delete-op: retire the item's prior chunks by the URI they
+            # were written under; skip fetch / extract / upsert. The
+            # delete is part of the per-batch transaction (same commit
+            # discipline as upsert) — it commits with the chunk in
+            # ``_commit_and_flush`` or rolls back with a failing chunk.
+            source_uri = connector.source_link(item_id)
+            self._chunk_writer.delete_by_source_uri(source_uri)
+            return _OUTCOME_DELETED
         try:
             raw = connector.fetch(item_id)
         except Exception as exc:

--- a/tests/integration/test_connector_pipeline_contract.py
+++ b/tests/integration/test_connector_pipeline_contract.py
@@ -44,6 +44,7 @@ from kairix.core.connectors.dead_letter import DeadLetterStore
 from kairix.core.connectors.pipeline import BatchResult, ConnectorPipeline
 from kairix.core.connectors.silver import DefaultSilverProcessor
 from kairix.core.db.schema import create_schema
+from kairix.core.factory import build_connector_pipeline
 from kairix.core.protocols import ChangeEvent
 from tests.fakes import FakeChunkWriter, FakeEntityGraphSink, FakeExtractor, FakeSourceConnector
 
@@ -297,5 +298,150 @@ def test_silver_failure_rolls_back_entire_batch(tmp_path: Path) -> None:
             fresh.close()
         assert chunk_writer.writes == []
         assert entity_graph_sink.staged == []
+    finally:
+        db.close()
+
+
+# ----------------------------------------------------------------------
+# Delete-dispatch (connector-architecture-refactor §3.3 primitive #1).
+#
+# Before this primitive ``ConnectorPipeline._process_item`` never
+# branched on ``ChangeEvent.op`` — every event ran fetch→bronze→silver→
+# upsert, so a ``deleted`` event RE-INDEXED the item (if fetch returned
+# a payload) instead of removing it. These tests drive a ``created``
+# event then a ``deleted`` event for the SAME item through the real
+# ``build_connector_pipeline`` path and assert the chunk is gone from
+# ``documents`` (and from FTS5 search) after the delete tick.
+#
+# Sabotage proof (executed by the agent, recorded for the reader):
+#   In ``kairix/core/connectors/pipeline.py`` ``_process_item``, remove
+#   the ``op in _DELETE_OPS`` branch (or change the body to call
+#   ``upsert`` instead of ``delete_by_source_uri``). Re-run
+#   ``test_deleted_event_removes_indexed_chunk``: the post-delete
+#   ``documents`` count assertion fails because the row survives (or is
+#   re-indexed). Restore the branch; the test passes again.
+# ----------------------------------------------------------------------
+
+
+def _doc_count_for(db: sqlite3.Connection, *, collection: str, source_uri: str) -> int:
+    """Active ``documents`` rows for ``source_uri`` in ``collection``."""
+    return int(
+        db.execute(
+            "SELECT COUNT(*) FROM documents WHERE collection = ? AND source_uri = ?",  # F63-bounded: one URI scope
+            (collection, source_uri),
+        ).fetchone()[0]
+    )
+
+
+def _bm25_hits_for(db: sqlite3.Connection, *, collection: str, term: str) -> int:
+    """Count FTS5 BM25 hits for ``term`` in ``collection`` — proves searchability."""
+    return int(
+        db.execute(
+            "SELECT COUNT(*) FROM documents d JOIN documents_fts fts ON fts.rowid = d.id "
+            "WHERE documents_fts MATCH ? AND d.collection = ?",
+            (term, collection),
+        ).fetchone()[0]
+    )
+
+
+@pytest.mark.parametrize("delete_op", ["deleted", "archived", "access_lost"])
+def test_deleted_event_removes_indexed_chunk(tmp_path: Path, delete_op: str) -> None:
+    """A ``created`` event indexes a chunk; a later delete-op event removes it.
+
+    Drives both ticks through the production ``build_connector_pipeline``
+    path (real SQLite chunk writer + FTS5) so the assertion is against
+    ``documents`` / searchable state — exactly the live-staleness class
+    the audit named. ``source_link(item_id)`` is the ``source_uri`` the
+    chunk was written under, so the delete targets the right rows.
+    """
+    db_path = tmp_path / "delete_dispatch.sqlite"
+    db = sqlite3.connect(str(db_path))
+    try:
+        create_schema(db, dims=4)
+        collection = "obsidian"
+        item_id = "deleted-note.md"
+
+        # Tick 1: created → chunk lands + is searchable.
+        created = FakeSourceConnector(
+            name=collection,
+            events=[ChangeEvent(op="created", item_id=item_id, modified_at="2026-06-21T10:00:00Z")],
+            content={item_id: b"# Stale Note\n\nThis note about retrieval will be deleted soon."},
+        )
+        pipeline = build_connector_pipeline(db=db, collection=collection)
+        created_result = pipeline.run_batch(created, FakeExtractor())
+        db.commit()
+        assert created_result.processed == 1, f"create tick should index the item; got {created_result}"
+
+        source_uri = created.source_link(item_id)
+        assert _doc_count_for(db, collection=collection, source_uri=source_uri) >= 1, (
+            "create tick must leave at least one indexed documents row"
+        )
+        assert _bm25_hits_for(db, collection=collection, term="retrieval") >= 1, (
+            "create tick must leave the chunk searchable via BM25"
+        )
+
+        # Tick 2: delete-op for the SAME item → chunk removed, no re-index.
+        deleted = FakeSourceConnector(
+            name=collection,
+            events=[ChangeEvent(op=delete_op, item_id=item_id, modified_at="2026-06-21T11:00:00Z")],  # type: ignore[arg-type]  # F3-rationale: delete_op is a member of the ChangeEvent.op literal, parametrized for table coverage.
+            content={item_id: b"# Stale Note\n\nThis note about retrieval will be deleted soon."},
+        )
+        delete_pipeline = build_connector_pipeline(db=db, collection=collection)
+        delete_pipeline.run_batch(deleted, FakeExtractor())
+        db.commit()
+
+        # The chunk is gone from documents AND from FTS5 search.
+        assert _doc_count_for(db, collection=collection, source_uri=source_uri) == 0, (
+            f"{delete_op!r} event must remove the indexed documents row; the deletion-staleness "
+            "bug (re-index or never-remove) has returned"
+        )
+        assert _bm25_hits_for(db, collection=collection, term="retrieval") == 0, (
+            f"{delete_op!r} event must leave zero BM25 hits — the chunk stayed searchable after delete"
+        )
+
+        # The delete path did NOT fetch the item (fetch/extract/upsert skipped).
+        assert deleted.fetch_calls == [], (
+            "delete-op processing must skip fetch entirely; a fetched delete-op item is re-indexed"
+        )
+    finally:
+        db.close()
+
+
+def test_deleted_event_skips_fetch_and_calls_delete(tmp_path: Path) -> None:
+    """Delete-op dispatch contract: delete_by_source_uri is called with the
+    item's source_uri and fetch/silver are skipped.
+
+    Uses the ``FakeChunkWriter`` (capture-only) so the assertion is on the
+    exact delete call — F68-shape contract proof for the delete branch.
+    """
+    db = _open_db(tmp_path)
+    try:
+        pipeline, chunk_writer, entity_graph_sink = _build_pipeline(db, tmp_path / "bronze")
+        item_id = "gone.md"
+        connector = FakeSourceConnector(
+            name="fake-source",
+            events=[ChangeEvent(op="deleted", item_id=item_id, modified_at="2026-06-21T12:00:00Z")],
+            content={item_id: b"would-be-reindexed body"},
+        )
+
+        result = pipeline.run_batch(connector, FakeExtractor())
+
+        # Delete-op does not write a chunk (processed counts end-to-end
+        # upserts only); it is not a fetch/extract failure either.
+        assert result.processed == 0, f"delete-op must not count as a processed upsert; got {result}"
+        assert result.dead_lettered == 0, "delete-op must not dead-letter"
+        assert chunk_writer.writes == [], "delete-op must not upsert any chunk"
+        assert entity_graph_sink.staged == [], "delete-op must not buffer entity signals"
+
+        # The delete call targeted the item's source_uri.
+        expected_uri = connector.source_link(item_id)
+        assert chunk_writer.deletes == [expected_uri], (
+            f"delete-op must call delete_by_source_uri({expected_uri!r}); got {chunk_writer.deletes!r}"
+        )
+
+        # Fetch/extract/silver were skipped — no bronze row, no fetch call.
+        assert connector.fetch_calls == [], "delete-op must skip fetch"
+        bronze_rows = db.execute("SELECT COUNT(*) FROM bronze_records").fetchone()[0]
+        assert bronze_rows == 0, "delete-op must not write a bronze record"
     finally:
         db.close()

--- a/tests/unit/test_connector_pipeline.py
+++ b/tests/unit/test_connector_pipeline.py
@@ -144,6 +144,166 @@ def test_empty_change_stream_is_a_no_op(tmp_path: Path) -> None:
         db.close()
 
 
+# ----------------------------------------------------------------------
+# Delete-dispatch (connector-architecture-refactor §3.3 primitive #1).
+#
+# Sabotage proof (executed by the agent, recorded for the reader):
+#   In ``kairix/core/connectors/pipeline.py`` ``_process_item``, delete
+#   the ``if op in _DELETE_OPS:`` branch. Re-run
+#   ``test_delete_op_calls_delete_by_source_uri_and_skips_fetch``: the
+#   item falls through to the fetch→upsert path, so ``chunk_writer.deletes``
+#   stays empty and ``connector.fetch_calls`` records the item — both
+#   assertions fail. Restore the branch; the test passes again.
+# ----------------------------------------------------------------------
+
+
+def _build_pipeline_with_writer(
+    db: sqlite3.Connection,
+) -> tuple[ConnectorPipeline, FakeChunkWriter]:
+    """Pipeline whose chunk writer is returned so deletes can be asserted."""
+    writer = FakeChunkWriter()
+    pipeline = ConnectorPipeline(
+        db=db,
+        bronze=StreamingBronzeStore(db),
+        silver=DefaultSilverProcessor(),
+        chunk_writer=writer,
+        entity_graph_sink=FakeEntityGraphSink(),
+        cursor_store=CursorStore(db),
+        dead_letter=DeadLetterStore(db),
+    )
+    return pipeline, writer
+
+
+@pytest.mark.parametrize("delete_op", ["deleted", "archived", "access_lost"])
+def test_delete_op_calls_delete_by_source_uri_and_skips_fetch(tmp_path: Path, delete_op: str) -> None:
+    """Every delete-op routes to delete_by_source_uri(source_link(item_id)) and skips fetch."""
+    db = _open_db(tmp_path)
+    try:
+        pipeline, writer = _build_pipeline_with_writer(db)
+        item_id = "gone.md"
+        connector = FakeSourceConnector(
+            name="fake-source",
+            events=[ChangeEvent(op=delete_op, item_id=item_id, modified_at="2026-06-21T10:00:00Z")],  # type: ignore[arg-type]  # F3-rationale: delete_op is a ChangeEvent.op literal member, parametrized for table coverage.
+            content={item_id: b"would-be-reindexed"},
+        )
+
+        result = pipeline.run_batch(connector, FakeExtractor())
+
+        # The delete branch fired: writer received exactly the item URI;
+        # fetch was skipped; nothing was upserted.
+        assert writer.deletes == [connector.source_link(item_id)]
+        assert connector.fetch_calls == []
+        assert writer.writes == []
+        # Outcome accounting: delete is not a processed upsert.
+        assert result.processed == 0
+        assert result.dead_lettered == 0
+        assert result.deleted == 1
+    finally:
+        db.close()
+
+
+def test_created_then_deleted_removes_chunk_and_does_not_reindex(tmp_path: Path) -> None:
+    """A created tick indexes the chunk; a deleted tick removes it (via the same writer).
+
+    Asserted through the writer's public surface: the create tick upserts
+    chunks for the URI; the delete tick calls ``delete_by_source_uri`` for
+    that same URI and skips fetch (no re-index).
+    """
+    db = _open_db(tmp_path)
+    try:
+        pipeline, writer = _build_pipeline_with_writer(db)
+        item_id = "note.md"
+
+        created = FakeSourceConnector(
+            name="fake-source",
+            events=[ChangeEvent(op="created", item_id=item_id, modified_at="2026-06-21T10:00:00Z")],
+            content={item_id: b"body content that becomes a chunk"},
+        )
+        create_result = pipeline.run_batch(created, FakeExtractor())
+        assert create_result.processed == 1
+        source_uri = created.source_link(item_id)
+        # The create tick upserted at least one chunk under this URI.
+        upserted_uris = {getattr(c, "source_uri", "") for batch in writer.writes for c in batch}
+        assert source_uri in upserted_uris
+
+        deleted = FakeSourceConnector(
+            name="fake-source",
+            events=[ChangeEvent(op="deleted", item_id=item_id, modified_at="2026-06-21T11:00:00Z")],
+            content={item_id: b"body content that becomes a chunk"},
+        )
+        delete_result = pipeline.run_batch(deleted, FakeExtractor())
+
+        assert delete_result.deleted == 1
+        assert delete_result.processed == 0
+        # The delete tick targeted the same URI the create tick wrote.
+        assert writer.deletes == [source_uri]
+        # The delete tick did not re-fetch / re-index.
+        assert deleted.fetch_calls == []
+    finally:
+        db.close()
+
+
+def test_created_and_deleted_in_one_batch_nets_to_removed(tmp_path: Path) -> None:
+    """Within a single batch a delete-op for a sibling item removes only that item.
+
+    Two created items + one deleted item: both created items index; the
+    deleted item routes to delete_by_source_uri without disturbing the
+    siblings (per-item dispatch, not batch-wide).
+    """
+    db = _open_db(tmp_path)
+    try:
+        pipeline, writer = _build_pipeline_with_writer(db)
+        events = [
+            ChangeEvent(op="created", item_id="a.md", modified_at="2026-06-21T10:00:00Z"),
+            ChangeEvent(op="deleted", item_id="b.md", modified_at="2026-06-21T10:01:00Z"),
+            ChangeEvent(op="created", item_id="c.md", modified_at="2026-06-21T10:02:00Z"),
+        ]
+        connector = FakeSourceConnector(
+            name="fake-source",
+            events=events,
+            content={"a.md": b"alpha body", "c.md": b"gamma body"},
+        )
+
+        result = pipeline.run_batch(connector, FakeExtractor())
+
+        assert result.processed == 2
+        assert result.deleted == 1
+        # Only b.md hit the delete path; a.md/c.md were fetched.
+        assert writer.deletes == [connector.source_link("b.md")]
+        assert sorted(connector.fetch_calls) == ["a.md", "c.md"]
+    finally:
+        db.close()
+
+
+def test_delete_op_source_link_failure_propagates_as_batch_rollback(tmp_path: Path) -> None:
+    """If source_link raises on a delete-op, the failure propagates (batch rollback).
+
+    F68-adjacent failure injection: the delete branch reads
+    ``connector.source_link(item_id)``. When that raises (the
+    ``raise_on_source_link`` seam) the exception is NOT swallowed into
+    dead-letter — it propagates to ``run_batch``'s except clause which
+    rolls back, matching the silver/writer/sink batch-level discipline.
+    """
+    db = _open_db(tmp_path)
+    try:
+        pipeline, writer = _build_pipeline_with_writer(db)
+        item_id = "boom.md"
+        connector = FakeSourceConnector(
+            name="fake-source",
+            events=[ChangeEvent(op="deleted", item_id=item_id, modified_at="2026-06-21T10:00:00Z")],
+            raise_on_source_link={item_id},
+        )
+
+        with pytest.raises(RuntimeError, match="source_link"):
+            pipeline.run_batch(connector, FakeExtractor())
+
+        # No delete was recorded (the failure happened before the call
+        # could land in a committed chunk).
+        assert writer.deletes == []
+    finally:
+        db.close()
+
+
 def test_fetch_failure_records_dead_letter(tmp_path: Path) -> None:
     """When ``connector.fetch`` raises, the item lands in dead_letter (fetch path)."""
     db = _open_db(tmp_path)


### PR DESCRIPTION
## What this fixes

Removed upstream items — deleted files, removed notes, access-revoked documents, cancelled events — currently **stay searchable forever**. The connector sees the removal, but the index is never updated, so deleted material remains discoverable across every connector.

Closes #574

## Root cause

`ConnectorPipeline._process_item` never branched on `ChangeEvent.op`. Every event went through `fetch → bronze → silver → upsert`, so a removal event either re-indexed stale content or dead-lettered forever — the original chunks were never retired.

## The change

Op-aware dispatch: when `change.op` is a delete-op (`deleted` / `archived` / `access_lost`), retire the item's prior chunks via `chunk_writer.delete_by_source_uri(connector.source_link(item_id))` and skip fetch/extract/upsert. `source_link(item_id)` is exactly the `source_uri` the chunks were written under, so the delete targets precisely those rows under the existing per-batch transaction discipline. `BatchResult` gains a default-0 `deleted` counter so operators see removals propagating.

This is Phase 2 (P0) of the connector-architecture refactor (design spec #571, §3.3 primitive #1).

## Tests

- **Integration** — create → delete-op tick through `factory.build_connector_pipeline().run_batch`, parametrized over all three delete-ops, asserting the `documents` row + BM25 hit are gone after the delete tick (these failed before the fix: re-index, `assert 1 == 0`).
- **Unit** — per-op dispatch calls `delete_by_source_uri` + skips fetch; created-then-deleted multi-tick removal; sibling isolation within one batch; `source_link` failure on a delete-op propagates as batch rollback.

Both sabotage-proofs executed (remove the branch → 9 fail; `upsert([])` instead of delete → 8 fail). Full local gate green (10,490 passed, 95.80% coverage, mutation parity 0 survivors).