### PR TITLE
fix(connectors): cursor & boundary resilience — gmail / slack / github re-emit loops

### DIFF
--- a/kairix/connectors/github/connector.py
+++ b/kairix/connectors/github/connector.py
@@ -168,14 +168,24 @@ def _default_flag_reader(name: str) -> bool:
 
 @dataclass
 class PerRepoCursorState:
-    """Per-repo cursor tracking — code SHA + issues ``since=`` timestamp.
+    """Per-repo cursor tracking — code + issues ``since=`` boundary.
 
     Mutable because the connector advances these in place after each
-    successful drain. ``code_sha`` is the most-recent commit SHA; the
-    next list_changes call asks for commits after this SHA.
-    ``issues_since`` is the ISO timestamp of the most-recent issue
-    update; the next list_changes asks for issues with
-    ``updated_at >= issues_since``.
+    successful drain. ``code_sha`` is the most-recent commit's
+    ``committed_at`` ISO timestamp (the value GitHub's ``commits?since=``
+    expects); ``issues_since`` is the most-recent issue's ``updated_at``
+    ISO timestamp (the value GitHub's ``issues?since=`` expects).
+
+    Inclusive-``since`` boundary handling (resilience-audit fix): GitHub's
+    ``?since=`` is INCLUSIVE on the boundary timestamp, so a quiet repo
+    would re-fetch + re-emit the boundary commit/issue every tick. To
+    suppress the re-emit without dropping a genuinely-new commit landing
+    at the SAME second as the boundary, the cursor also tracks the set of
+    commit SHAs (``seen_commit_shas``) and issue item_ids
+    (``seen_issue_ids``) already emitted AT the boundary timestamp. The
+    next drain re-asks ``?since=<boundary>`` (so same-second newcomers are
+    still returned) and skips only the already-seen ids — a compound
+    cursor that is robust to multiple items sharing a timestamp.
 
     Sabotage-proof: replacing this per-repo dict with a single shared
     cursor (e.g. a module-level scalar) flips the
@@ -186,6 +196,8 @@ class PerRepoCursorState:
 
     code_sha: str | None = None
     issues_since: str | None = None
+    seen_commit_shas: frozenset[str] = frozenset()
+    seen_issue_ids: frozenset[str] = frozenset()
 
 
 class GitHubConnector:
@@ -689,12 +701,35 @@ class GitHubConnector:
         return kept
 
     def _drain_repo(self, repo: GitHubRepoRef) -> Iterator[ChangeEvent]:
-        """Drain commits + issues for one repo, advancing the per-repo cursor."""
+        """Drain commits + issues for one repo, advancing the per-repo cursor.
+
+        GitHub's ``?since=`` is inclusive on the boundary timestamp, so the
+        boundary commit/issue from the previous drain is re-returned by the
+        wire. ``_drain_commits`` / ``_drain_issues`` skip the already-seen
+        boundary ids (tracked on the cursor) so a quiet repo re-emits
+        nothing, while a genuinely-new item sharing the boundary second is
+        still emitted. See :class:`PerRepoCursorState`.
+        """
         state = self._per_repo_cursors.setdefault(repo.full_name, PerRepoCursorState())
+        yield from self._drain_commits(repo, state)
+        yield from self._drain_issues(repo, state)
+
+    def _drain_commits(self, repo: GitHubRepoRef, state: PerRepoCursorState) -> Iterator[ChangeEvent]:
+        """Emit new commits for ``repo`` and advance the commit cursor.
+
+        Skips commits whose SHA is in ``state.seen_commit_shas`` (already
+        emitted at the prior boundary timestamp) so the inclusive ``?since=``
+        re-return doesn't double-emit. After the drain, the cursor advances
+        to the max ``committed_at`` across ALL returned commits and records
+        the SHAs at that timestamp as the new boundary seen-set.
+        """
+        sensitivity = sensitivity_from_visibility(repo.visibility)
         commits = self._client.list_commits_since(full_name=repo.full_name, since=state.code_sha)
         for commit in commits:
+            if commit.sha in state.seen_commit_shas:
+                continue
             item_id = f"github://{repo.full_name}/commit/{commit.sha}"
-            envelope = {
+            self._envelope_cache[item_id] = {
                 "sha": commit.sha,
                 "message": commit.message,
                 "committed_at": commit.committed_at,
@@ -702,24 +737,39 @@ class GitHubConnector:
                 "repo": repo.full_name,
                 "kind": "commit",
                 "mime_hint": _MIME_APPLICATION_JSON,
-                _META_SENSITIVITY: sensitivity_from_visibility(repo.visibility),
+                _META_SENSITIVITY: sensitivity,
             }
-            self._envelope_cache[item_id] = envelope
-            state.code_sha = commit.committed_at or state.code_sha
             yield ChangeEvent(
                 op="modified",
                 item_id=item_id,
                 modified_at=commit.committed_at,
                 metadata={
-                    _META_SENSITIVITY: sensitivity_from_visibility(repo.visibility),
+                    _META_SENSITIVITY: sensitivity,
                     "repo": repo.full_name,
                     "kind": "commit",
                 },
             )
+        boundary, seen = _advance_boundary(
+            current_boundary=state.code_sha,
+            items=((commit.committed_at, commit.sha) for commit in commits),
+        )
+        state.code_sha = boundary
+        state.seen_commit_shas = seen
+
+    def _drain_issues(self, repo: GitHubRepoRef, state: PerRepoCursorState) -> Iterator[ChangeEvent]:
+        """Emit new issues/PRs for ``repo`` and advance the issues cursor.
+
+        Mirrors :meth:`_drain_commits` for GitHub's inclusive
+        ``issues?since=`` boundary — skips already-seen item_ids at the
+        boundary ``updated_at`` and advances to the new boundary + seen-set.
+        """
+        sensitivity = sensitivity_from_visibility(repo.visibility)
         issues = self._client.list_issues_since(full_name=repo.full_name, since=state.issues_since)
         for issue in issues:
             item_id = f"github://{repo.full_name}/{issue.kind}s/{issue.number}"
-            envelope_issue: dict[str, Any] = {
+            if item_id in state.seen_issue_ids:
+                continue
+            self._envelope_cache[item_id] = {
                 "title": issue.title,
                 "body": issue.body,
                 "updated_at": issue.updated_at,
@@ -727,20 +777,24 @@ class GitHubConnector:
                 "repo": repo.full_name,
                 "kind": issue.kind,
                 "mime_hint": _MIME_APPLICATION_JSON,
-                _META_SENSITIVITY: sensitivity_from_visibility(repo.visibility),
+                _META_SENSITIVITY: sensitivity,
             }
-            self._envelope_cache[item_id] = envelope_issue
-            state.issues_since = issue.updated_at or state.issues_since
             yield ChangeEvent(
                 op="modified",
                 item_id=item_id,
                 modified_at=issue.updated_at,
                 metadata={
-                    _META_SENSITIVITY: sensitivity_from_visibility(repo.visibility),
+                    _META_SENSITIVITY: sensitivity,
                     "repo": repo.full_name,
                     "kind": issue.kind,
                 },
             )
+        boundary, seen = _advance_boundary(
+            current_boundary=state.issues_since,
+            items=((issue.updated_at, f"github://{repo.full_name}/{issue.kind}s/{issue.number}") for issue in issues),
+        )
+        state.issues_since = boundary
+        state.seen_issue_ids = seen
 
     def _drain_one_container(self, container: Container) -> Iterator[ChangeEvent]:
         """Wave E ON-branch: scope the drain to one repo (Container)."""
@@ -936,10 +990,48 @@ def parse_item_id(item_id: str) -> _ParsedItemId:
     return _ParsedItemId(full_name=full_name, kind=parts[2], identifier=parts[3])
 
 
+def _advance_boundary(
+    *,
+    current_boundary: str | None,
+    items: Iterable[tuple[str, str]],
+) -> tuple[str | None, frozenset[str]]:
+    """Compute the next inclusive-``since`` boundary + its seen-id set.
+
+    ``items`` is an iterable of ``(timestamp, id)`` pairs for every row the
+    drain observed this tick (already-emitted boundary rows included, since
+    GitHub's inclusive ``?since=`` re-returns them). Returns the new
+    boundary timestamp (the max observed timestamp, or the prior boundary
+    when no rows were seen) and the frozenset of ids AT that boundary
+    timestamp — the rows the NEXT tick's inclusive ``?since=`` will
+    re-return and must therefore skip. Rows without a timestamp can't be
+    boundary-tracked, so they're ignored for the boundary computation.
+    """
+    observed = list(items)
+    # ISO-8601 UTC ``Z`` timestamps sort lexicographically == chronologically,
+    # so ``max`` over the non-empty timestamps (seeded with the prior boundary)
+    # yields the new boundary without a hand-rolled comparison.
+    candidates = [timestamp for timestamp, _identifier in observed if timestamp]
+    if current_boundary:
+        candidates.append(current_boundary)
+    if not candidates:
+        return None, frozenset()
+    boundary = max(candidates)
+    seen = frozenset(identifier for timestamp, identifier in observed if timestamp == boundary and identifier)
+    return boundary, seen
+
+
 def serialise_cursor(per_repo: Mapping[str, PerRepoCursorState]) -> str:
-    """JSON-encode the per-repo cursor map."""
+    """JSON-encode the per-repo cursor map (compound inclusive-since cursor)."""
     return json.dumps(
-        {repo: {"code_sha": state.code_sha, "issues_since": state.issues_since} for repo, state in per_repo.items()},
+        {
+            repo: {
+                "code_sha": state.code_sha,
+                "issues_since": state.issues_since,
+                "seen_commit_shas": sorted(state.seen_commit_shas),
+                "seen_issue_ids": sorted(state.seen_issue_ids),
+            }
+            for repo, state in per_repo.items()
+        },
         sort_keys=True,
     )
 
@@ -961,8 +1053,22 @@ def deserialise_cursor(cursor: Cursor | None) -> dict[str, PerRepoCursorState]:
         out[str(repo)] = PerRepoCursorState(
             code_sha=payload.get("code_sha"),
             issues_since=payload.get("issues_since"),
+            seen_commit_shas=_coerce_id_set(payload.get("seen_commit_shas")),
+            seen_issue_ids=_coerce_id_set(payload.get("seen_issue_ids")),
         )
     return out
+
+
+def _coerce_id_set(raw: Any) -> frozenset[str]:
+    """Coerce a deserialised seen-id list into a frozenset of strings.
+
+    Tolerant of stale / pre-fix cursors that omit the field (``None``) or
+    carry a non-list shape — both collapse to an empty set so an older
+    persisted cursor upgrades cleanly without a re-backfill.
+    """
+    if not isinstance(raw, list):
+        return frozenset()
+    return frozenset(str(entry) for entry in raw)
 
 
 def sensitivity_from_visibility(visibility: str) -> Sensitivity:

--- a/kairix/connectors/gmail/connector.py
+++ b/kairix/connectors/gmail/connector.py
@@ -313,7 +313,16 @@ class GmailConnector:
             message = self._client.get_message(message_id)
             self._cache[message_id] = message
             events.append(self._build_change_event(message))
-        self._next_cursor = self._client.last_history_id() or cursor
+        # Don't-clobber contract (SourceConnector.next_cursor): the drain
+        # only advanced the cursor if the History API surfaced an
+        # advancing historyId. When ``last_history_id()`` is None — the
+        # parser defensively collapsed a non-string historyId to None —
+        # we MUST return None so the pipeline preserves the prior
+        # persisted cursor. Echoing the stale input ``cursor`` would
+        # falsely signal an advance to a window we already processed,
+        # making the next tick re-query the identical window and re-emit
+        # every already-processed message.
+        self._next_cursor = self._client.last_history_id()
         return iter(events)
 
     def fetch(self, item_id: str) -> RawArtefact:
@@ -486,7 +495,13 @@ class GmailConnector:
             self._cache[message_id] = message
             event = self._build_change_event(message, extra_metadata={"mailbox": mailbox})
             events.append(event)
-        self._next_cursor_by_container[mailbox] = self._client.last_history_id() or cursor
+        # Don't-clobber contract (mirrors :meth:`list_changes`): only
+        # advance the per-mailbox cursor when the History API surfaced an
+        # advancing historyId. A None ``last_history_id()`` means "no
+        # advance this tick" — return None so the framework preserves the
+        # prior persisted per-mailbox cursor instead of re-asserting a
+        # false advance to an already-processed window.
+        self._next_cursor_by_container[mailbox] = self._client.last_history_id()
         return iter(events)
 
     def _build_change_event(

--- a/kairix/connectors/slack/connector.py
+++ b/kairix/connectors/slack/connector.py
@@ -649,9 +649,18 @@ class SlackConnector:
         for item_id in failed_item_ids:
             channel_id, ts = _split_item_id(item_id)
             try:
-                # Slack history `oldest` is exclusive — pass `ts` directly
-                # to get the message at or shortly after the failed ts.
-                for message in web.conversations_history(channel_id=channel_id, oldest=ts):
+                # Slack's ``conversations.history?oldest=`` is EXCLUSIVE by
+                # default: a message whose ``ts`` equals ``oldest`` is NOT
+                # returned. That exclusivity is what the legacy
+                # ``list_changes`` / ``_drain_channel`` advance path relies
+                # on (re-feed the high-water ``ts`` next tick without
+                # re-emitting the boundary message). The dead-letter replay
+                # wants the OPPOSITE — it targets the failed message's exact
+                # ``ts`` and filters ``message.ts == ts``, so it MUST request
+                # ``inclusive=True`` to make Slack include the boundary
+                # message. Without it the replay returns ZERO on the real
+                # wire (the in-memory fake ignores ``oldest`` and hid this).
+                for message in web.conversations_history(channel_id=channel_id, oldest=ts, inclusive=True):
                     if message.ts != ts:
                         continue
                     self._cache.remember_message(message)

--- a/kairix/connectors/slack/web_client.py
+++ b/kairix/connectors/slack/web_client.py
@@ -242,13 +242,30 @@ class SlackWebClient:
             if not cursor:
                 return
 
-    def conversations_history(self, *, channel_id: str, oldest: str | None = None) -> Iterator[SlackMessage]:
-        """Stream messages in ``channel_id`` newer than ``oldest`` (a ``ts``).
+    def conversations_history(
+        self,
+        *,
+        channel_id: str,
+        oldest: str | None = None,
+        inclusive: bool = False,
+    ) -> Iterator[SlackMessage]:
+        """Stream messages in ``channel_id`` from the ``oldest`` ``ts`` boundary.
 
         Server-side paginates 200 messages at a time per slack.md §6
         ("200 msgs/page cursor pagination").  Each emitted SlackMessage
         carries the channel id so downstream consumers don't need to
         re-thread it.
+
+        ``oldest`` is Slack's boundary timestamp. Slack treats it as
+        EXCLUSIVE by default — a message whose ``ts`` exactly equals
+        ``oldest`` is NOT returned. This is what the poll / list_changes
+        advance path relies on (re-feed the high-water ``ts`` next tick
+        without re-emitting the boundary message). Set ``inclusive=True``
+        to flip Slack into including the boundary message itself — used by
+        the dead-letter replay (:meth:`SlackConnector.reindex`) so a
+        targeted ``oldest=<failed_ts>`` actually returns the failed
+        message. ``inclusive`` is ignored by Slack unless ``oldest`` (or
+        ``latest``) is specified, so it's only threaded when ``oldest`` is.
         """
         cursor: str | None = None
         while True:
@@ -258,6 +275,7 @@ class SlackWebClient:
                     "channel": channel_id,
                     "limit": "200",
                     **({"oldest": oldest} if oldest else {}),
+                    **({"inclusive": "true"} if oldest and inclusive else {}),
                     **({"cursor": cursor} if cursor else {}),
                 },
             )

--- a/tests/bdd/steps/connector_github_steps.py
+++ b/tests/bdd/steps/connector_github_steps.py
@@ -277,7 +277,10 @@ def _distinct_per_repo_cursor(github_ctx: _Ctx) -> None:
     cursor_json = github_ctx.connector.next_cursor()
     parsed = json.loads(cursor_json)
     assert len(parsed) == 2, f"expected per-repo cursor entries for 2 repos; got {parsed!r}"
-    values = {tuple(sorted(v.items())) for v in parsed.values()}
+    # The compound inclusive-since cursor carries list-valued seen-id sets,
+    # so canonicalise each per-repo value to a stable JSON string before
+    # building the distinctness set (lists are unhashable).
+    values = {json.dumps(v, sort_keys=True) for v in parsed.values()}
     assert len(values) == 2, f"expected distinct cursors per repo; got {parsed!r}"
 
 

--- a/tests/integration/test_github_inclusive_since_boundary.py
+++ b/tests/integration/test_github_inclusive_since_boundary.py
@@ -1,0 +1,288 @@
+"""Integration tests for the GitHub connector's inclusive-``since`` boundary fix.
+
+Background (resilience audit, HIGH severity): GitHub's
+``GET /repos/{owner}/{repo}/commits?since=`` and
+``GET /repos/{owner}/{repo}/issues?since=`` parameters are **inclusive**
+on the commit ``committed_at`` / issue ``updated_at`` timestamp. The
+connector persists the boundary commit's ``committed_at`` as the next
+``?since=`` value, so on a quiet repo (no new commits) every tick
+re-fetches, re-extracts, and re-emits the boundary commit (and boundary
+issue) forever — a wasted-work loop that burns fetch/extract every tick.
+
+These tests pin the fix:
+
+1. **Quiet repo re-emits ZERO events on the next tick** — the boundary
+   commit / issue seen on tick 1 must NOT re-emit on tick 2 when nothing
+   new has landed.
+2. **A genuinely-new commit at the SAME timestamp as the boundary is
+   NOT dropped** — the fix must not blindly advance ``since`` by +1s (or
+   otherwise exclude the boundary second), which would silently drop a
+   same-second commit. The compound cursor (boundary timestamp + the set
+   of SHAs already emitted at that timestamp) is robust to this.
+
+Both tests drive the connector via :meth:`GitHubConnector.list_changes`
+with a scripted GitHub client across two ticks, persisting the per-repo
+cursor between ticks (the production path serialises the cursor between
+ticks). The scripted client honours GitHub's inclusive ``since``
+semantics so the test exercises the real wire contract.
+
+F47 — every test reaches production code through the connector's
+constructor; no direct ``*Pipeline(...)`` construction.
+
+Sabotage proofs documented in the commit body — the cursor-advance fix
+was reverted, the quiet-repo-re-emit test confirmed to fail, and the
+code restored to its canonical shape.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kairix.connectors.github import GitHubConnector
+from kairix.connectors.github.api_client import (
+    ClientStatsSnapshot,
+    GitHubCommitRef,
+    GitHubIssueRef,
+    GitHubRepoRef,
+)
+
+pytestmark = pytest.mark.integration
+
+_REPO = "agent-alpha-org/quiet-repo"
+_BOUNDARY_TS = "2026-05-23T01:00:00Z"
+
+
+class _InclusiveSinceClient:
+    """Scripted client honouring GitHub's INCLUSIVE ``since`` semantics.
+
+    ``list_commits_since`` / ``list_issues_since`` return every scripted
+    commit / issue whose timestamp is ``>= since`` (mirroring GitHub's
+    real boundary behaviour), oldest-first — exactly the wire contract
+    that triggers the boundary re-emit bug when the connector persists
+    the boundary timestamp as the next ``since``.
+    """
+
+    def __init__(
+        self,
+        *,
+        commits: list[GitHubCommitRef] | None = None,
+        issues: list[GitHubIssueRef] | None = None,
+    ) -> None:
+        self._commits = list(commits) if commits is not None else []
+        self._issues = list(issues) if issues is not None else []
+        self.commit_since_calls: list[str | None] = []
+        self.issue_since_calls: list[str | None] = []
+        self._stats = ClientStatsSnapshot(
+            rest_requests=0,
+            rest_rate_remaining=5000,
+            rest_rate_reset_epoch=0,
+            rest_403_secondary_total=0,
+            installation_token_rotations=0,
+        )
+
+    def add_commit(self, commit: GitHubCommitRef) -> None:
+        self._commits.append(commit)
+
+    def list_installation_repositories(self) -> tuple[GitHubRepoRef, ...]:
+        return (
+            GitHubRepoRef(
+                repo_id=1,
+                full_name=_REPO,
+                default_branch="main",
+                visibility="private",
+                archived=False,
+            ),
+        )
+
+    def list_commits_since(self, *, full_name: str, since: str | None) -> tuple[GitHubCommitRef, ...]:
+        _ = full_name
+        self.commit_since_calls.append(since)
+        kept = [c for c in self._commits if since is None or c.committed_at >= since]
+        kept.sort(key=lambda c: c.committed_at)  # oldest-first, like the api_client
+        return tuple(kept)
+
+    def list_issues_since(self, *, full_name: str, since: str | None) -> tuple[GitHubIssueRef, ...]:
+        _ = full_name
+        self.issue_since_calls.append(since)
+        kept = [i for i in self._issues if since is None or i.updated_at >= since]
+        kept.sort(key=lambda i: i.updated_at)
+        return tuple(kept)
+
+    def get_tree_recursive(self, *, full_name: str, ref: str) -> tuple[tuple, bool]:
+        _ = (full_name, ref)
+        return (), False
+
+    def fetch_blob(self, *, full_name: str, sha: str) -> bytes:
+        _ = (full_name, sha)
+        return b""
+
+    def stats(self) -> ClientStatsSnapshot:
+        return self._stats
+
+    def invalidate_token(self) -> None:
+        return None
+
+
+def _drain_two_ticks(connector: GitHubConnector) -> tuple[list, list]:
+    """Run two ticks, persisting the cursor between them (production path).
+
+    Tick 2 reconstructs the connector cursor from the serialised cursor
+    string the connector produced after tick 1 — exactly how the
+    orchestrator persists + restores the per-repo cursor between ticks.
+    """
+    first = list(connector.list_changes(cursor=None))
+    cursor = connector.next_cursor()
+    second = list(connector.list_changes(cursor=cursor))
+    return first, second
+
+
+def test_quiet_repo_reemits_zero_events_on_next_tick() -> None:
+    """A repo with no new commits/issues re-emits ZERO events on tick 2.
+
+    The boundary commit + boundary issue emitted on tick 1 must not be
+    re-emitted on tick 2 when nothing new has landed, even though
+    GitHub's inclusive ``since`` re-returns them from the wire.
+
+    Sabotage-proof: reverting the cursor-advance fix (so the connector
+    persists only the boundary timestamp and re-emits everything the
+    inclusive ``since`` returns) flips this test to fail — tick 2
+    re-emits the boundary commit + issue.
+    """
+    client = _InclusiveSinceClient(
+        commits=[
+            GitHubCommitRef(
+                sha="boundary-commit",
+                committed_at=_BOUNDARY_TS,
+                message="boundary",
+                author="agent-alpha",
+            ),
+        ],
+        issues=[
+            GitHubIssueRef(
+                number=7,
+                kind="issue",
+                updated_at=_BOUNDARY_TS,
+                title="boundary issue",
+                body="b",
+                state="open",
+            ),
+        ],
+    )
+    connector = GitHubConnector(client=client)  # type: ignore[arg-type]  # F3 rationale: local stub mirrors GitHubApiClient shape but isn't typed as the Protocol — boundary-only suppression for the test seam
+
+    first, second = _drain_two_ticks(connector)
+
+    # Tick 1 emits the boundary commit + boundary issue.
+    assert len(first) == 2, f"tick 1 should emit the boundary commit + issue; got {first!r}"
+    # Tick 2 re-asks the wire (inclusive since re-returns the boundary
+    # rows) but the connector must NOT re-emit them.
+    assert second == [], f"quiet repo must re-emit ZERO events on tick 2; got {second!r}"
+
+
+def test_genuinely_new_commit_at_same_timestamp_is_not_dropped() -> None:
+    """A new commit sharing the boundary timestamp must still emit on tick 2.
+
+    Guards against the naive +1s cursor-advance pitfall: if the connector
+    advanced ``since`` to ``boundary + 1s`` it would silently drop a
+    genuinely-new commit landing at the SAME second as the boundary. The
+    compound cursor (boundary timestamp + already-seen SHA set) emits the
+    new same-second commit while still skipping the already-seen one.
+
+    Sabotage-proof: advancing the cursor by +1s instead of tracking the
+    seen-SHA set flips this test to fail — the same-second new commit is
+    excluded by the ``since = boundary + 1s`` filter.
+    """
+    boundary_commit = GitHubCommitRef(
+        sha="boundary-commit",
+        committed_at=_BOUNDARY_TS,
+        message="boundary",
+        author="agent-alpha",
+    )
+    client = _InclusiveSinceClient(commits=[boundary_commit])
+    connector = GitHubConnector(client=client)  # type: ignore[arg-type]  # F3 rationale: local stub mirrors GitHubApiClient shape but isn't typed as the Protocol — boundary-only suppression for the test seam
+
+    first = list(connector.list_changes(cursor=None))
+    assert len(first) == 1, f"tick 1 should emit the boundary commit; got {first!r}"
+
+    # A genuinely-new commit lands at the SAME second as the boundary.
+    new_same_second = GitHubCommitRef(
+        sha="new-same-second-commit",
+        committed_at=_BOUNDARY_TS,
+        message="new same-second",
+        author="agent-beta",
+    )
+    client.add_commit(new_same_second)
+
+    cursor = connector.next_cursor()
+    second = list(connector.list_changes(cursor=cursor))
+
+    emitted_ids = [ev.item_id for ev in second]
+    assert any("new-same-second-commit" in i for i in emitted_ids), (
+        f"a genuinely-new same-second commit must NOT be dropped; got {emitted_ids!r}"
+    )
+    assert not any("boundary-commit" in i for i in emitted_ids), (
+        f"the already-seen boundary commit must NOT re-emit; got {emitted_ids!r}"
+    )
+    assert len(second) == 1, f"exactly the one new commit should emit on tick 2; got {emitted_ids!r}"
+
+
+def test_cursor_boundary_is_max_timestamp_with_only_that_seconds_shas_seen() -> None:
+    """After a drain the cursor records the MAX timestamp + only its SHAs.
+
+    Pins the exact boundary computation across multiple distinct commit
+    timestamps:
+
+      * the persisted boundary (``code_sha``) is the MAX ``committed_at``,
+        not an earlier one;
+      * the boundary seen-set (``seen_commit_shas``) holds ONLY the SHAs
+        AT that max second — an earlier-second commit is excluded from the
+        seen-set (else it would be wrongly suppressed when GitHub later
+        re-returns the inclusive boundary), and a same-max-second sibling
+        IS included (else it would re-emit forever).
+
+    This is the observable contract behind the boundary helper: the
+    next-tick inclusive ``?since=<max>`` re-returns exactly the max-second
+    commits, and the connector must skip precisely those and nothing else.
+    Tick 2 confirms the round-trip emits ZERO events on a quiet repo.
+    """
+    earlier = GitHubCommitRef(
+        sha="earlier-sha",
+        committed_at="2026-05-23T01:00:00Z",
+        message="earlier",
+        author="agent-alpha",
+    )
+    max_a = GitHubCommitRef(
+        sha="max-sha-a",
+        committed_at="2026-05-23T02:00:00Z",
+        message="max-a",
+        author="agent-alpha",
+    )
+    max_b = GitHubCommitRef(
+        sha="max-sha-b",
+        committed_at="2026-05-23T02:00:00Z",  # SAME max second as max_a
+        message="max-b",
+        author="agent-beta",
+    )
+    client = _InclusiveSinceClient(commits=[earlier, max_a, max_b])
+    connector = GitHubConnector(client=client)  # type: ignore[arg-type]  # F3 rationale: local stub mirrors GitHubApiClient shape but isn't typed as the Protocol — boundary-only suppression for the test seam
+
+    first = list(connector.list_changes(cursor=None))
+    assert len(first) == 3, f"tick 1 should emit all three commits; got {first!r}"
+
+    state = connector._per_repo_cursors[_REPO]
+    # Boundary advances to the MAX committed_at (kills `>` -> `>=` / and/or
+    # mutations on the boundary scan).
+    assert state.code_sha == "2026-05-23T02:00:00Z", f"boundary must be the max committed_at; got {state.code_sha!r}"
+    # Seen-set holds ONLY the SHAs at the max second — both same-second
+    # siblings, and NOT the earlier-second commit (kills `==` -> `!=` and
+    # the and/or mutation on the seen-set comprehension).
+    assert state.seen_commit_shas == frozenset({"max-sha-a", "max-sha-b"}), (
+        f"seen-set must hold exactly the max-second SHAs; got {sorted(state.seen_commit_shas)!r}"
+    )
+    assert "earlier-sha" not in state.seen_commit_shas, "an earlier-second commit must NOT be in the boundary seen-set"
+
+    # Round-trip: a quiet tick 2 (inclusive since re-returns the two
+    # max-second commits) must re-emit nothing.
+    cursor = connector.next_cursor()
+    second = list(connector.list_changes(cursor=cursor))
+    assert second == [], f"quiet repo must re-emit ZERO events on tick 2; got {second!r}"

--- a/tests/integration/test_gmail_failure_modes.py
+++ b/tests/integration/test_gmail_failure_modes.py
@@ -22,7 +22,9 @@ mutates the production branch, confirms the test fails, restores.
 
 from __future__ import annotations
 
+import sqlite3
 from collections.abc import Iterator
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -33,11 +35,14 @@ from kairix.connectors.gmail.client import (
     GmailMessage,
     HistoryPage,
 )
+from kairix.core import factory
+from kairix.core.db.schema import create_schema
 from kairix.core.protocols import (
     ContainerTransientError,
     CredentialExpiredError,
     InsufficientPermissionsError,
 )
+from tests.fakes import FakeChunkWriter, FakeEntityGraphSink, FakeExtractor
 
 pytestmark = pytest.mark.integration
 
@@ -213,6 +218,48 @@ def test_gmail_list_changes_returns_empty_history_page_emits_no_events() -> None
 
 
 # ---------------------------------------------------------------------------
+# drains-but-no-advance — non-empty drain whose page carried no advancing
+# historyId (the parser defensively collapses a non-string historyId to
+# None). The connector must NOT echo the stale input cursor; it must return
+# None so the pipeline's None-means-don't-clobber contract preserves the
+# prior persisted cursor instead of re-asserting a false advance.
+# ---------------------------------------------------------------------------
+
+
+def test_gmail_list_changes_drains_messages_with_no_advancing_history_id_returns_none() -> None:
+    """A non-empty drain whose page carried no advancing historyId returns
+    ``next_cursor() is None`` — NOT the stale input cursor.
+
+    The ``next_cursor`` Protocol contract: ``None`` means "no cursor
+    advance this tick; the orchestrator MUST NOT clobber the prior
+    cursor". Echoing the input cursor falsely signals a fresh advance to
+    a window we already processed, which makes the next tick re-query the
+    identical window and re-emit every already-processed message.
+
+    Sabotage proof (executed): reverting the fix to
+    ``self._next_cursor = self._client.last_history_id() or cursor`` makes
+    this assertion read the stale ``"warm-cursor"`` and fail.
+    """
+    page = HistoryPage(
+        message_ids=("msg-no-advance",),
+        next_page_token=None,
+        # historyId is None — the parser collapsed a non-string value.
+        history_id=None,
+    )
+    client = _ScriptedClient(
+        history_page=page,
+        message_by_id={"msg-no-advance": _make_message("msg-no-advance")},
+    )
+    connector = GmailConnector(user_email=_USER, client=client)  # type: ignore[arg-type]  # F3 rationale: scripted client stand-in.
+    events = list(connector.list_changes(cursor="warm-cursor"))
+    assert len(events) == 1, f"the message must still be emitted this tick; got {events!r}"
+    assert connector.next_cursor() is None, (
+        "a drain with no advancing historyId must return None (don't-clobber), "
+        f"not the stale input cursor; got {connector.next_cursor()!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # unauthorized — credential expired / scope revoked
 # ---------------------------------------------------------------------------
 
@@ -288,3 +335,126 @@ def test_gmail_fetch_unavailable_propagates_container_transient() -> None:
     connector = GmailConnector(user_email=_USER, client=client)  # type: ignore[arg-type]  # F3 rationale: scripted client stand-in.
     with pytest.raises(ContainerTransientError):
         connector.fetch("msg-transient")
+
+
+# ---------------------------------------------------------------------------
+# Two-tick re-query / re-emit proof through the real ConnectorPipeline.
+#
+# Drives the production pipeline (factory.build_connector_pipeline → real
+# CursorStore on SQLite) across two ticks. Tick 1 drains a message whose
+# History page carried no advancing historyId; the connector must return
+# next_cursor()=None so the pipeline preserves the prior persisted cursor
+# (don't-clobber). Tick 2's page advances cleanly with no new messages —
+# the already-processed message must NOT be re-emitted into a second chunk.
+# ---------------------------------------------------------------------------
+
+
+class _TwoTickScriptedClient:
+    """Scripted GmailClient emitting a non-advancing page then an advancing one.
+
+    Tick 1 (cold-start) seeds the cursor at the live tip. Tick 2 drains a
+    single message from a page whose ``historyId`` collapsed to ``None``
+    (no advance). Tick 3 returns an empty, advancing page so the next-tick
+    horizon moves forward without re-emitting the already-processed
+    message. The ``start_history_id`` each ``iter`` call observed is
+    recorded so the test can assert the window the connector queried.
+    """
+
+    def __init__(self) -> None:
+        self._iter_windows: list[str] = []
+        # Pages consumed FIFO by successive iter_history_message_ids calls.
+        self._pages: list[HistoryPage] = [
+            # First warm tick — one message, NO advancing historyId.
+            HistoryPage(message_ids=("msg-tick1",), next_page_token=None, history_id=None),
+            # Second warm tick — empty, but the horizon advanced.
+            HistoryPage(message_ids=(), next_page_token=None, history_id="tip-after-tick2"),
+        ]
+        self._last_history_id: str | None = None
+
+    @property
+    def iter_windows(self) -> list[str]:
+        return list(self._iter_windows)
+
+    def get_profile_history_id(self) -> str:
+        return "tip-cold-start"
+
+    def list_history(self, *, start_history_id: str, page_token: str | None = None) -> HistoryPage:
+        _ = (start_history_id, page_token)
+        return self._pages[0]
+
+    def iter_history_message_ids(self, *, start_history_id: str) -> Iterator[str]:
+        self._iter_windows.append(start_history_id)
+        page = self._pages.pop(0) if self._pages else HistoryPage(message_ids=(), next_page_token=None, history_id=None)
+        # Mirror the real client: only record an advancing historyId.
+        self._last_history_id = page.history_id
+        yield from page.message_ids
+
+    def last_history_id(self) -> str | None:
+        return self._last_history_id
+
+    def get_message(self, message_id: str) -> GmailMessage:
+        return _make_message(message_id, body=b"tick body")
+
+    def stats(self) -> Any:
+        from kairix.connectors.gmail.client import GmailStatsSnapshot
+
+        return GmailStatsSnapshot(requests=0, rate_limited_403_total=0, token_refreshes=0)
+
+    def invalidate_token(self) -> None:
+        return None
+
+
+def test_gmail_no_advance_tick_does_not_reemit_on_next_tick(tmp_path: Path) -> None:
+    """A drain with no advancing historyId does not re-emit on the next tick.
+
+    Two-tick proof through the real ConnectorPipeline:
+
+      * Cold-start seeds the cursor at the live tip (no events).
+      * Tick 1 drains ``msg-tick1`` from a page whose historyId collapsed
+        to ``None``. The connector returns ``next_cursor()=None`` so the
+        pipeline's None-means-don't-clobber contract preserves the prior
+        cursor rather than re-asserting a false advance.
+      * Tick 2 drains an empty, advancing page — ``msg-tick1`` is NOT
+        re-emitted into a second chunk.
+
+    Sabotage proof (executed): reverting the connector fix to
+    ``self._next_cursor = self._client.last_history_id() or cursor`` makes
+    tick 1's post-drain ``next_cursor()`` read the stale ``"tip-cold-start"``
+    instead of ``None`` — the ``assert connector.next_cursor() is None``
+    below fails. The emitted-once assertion pins that the don't-clobber
+    path leaves the message processed exactly once across both ticks.
+    """
+    client = _TwoTickScriptedClient()
+    connector = GmailConnector(user_email=_USER, client=client)  # type: ignore[arg-type]  # F3 rationale: scripted client stand-in.
+    db_path = tmp_path / "gmail_two_tick.sqlite"
+    db = sqlite3.connect(str(db_path))
+    create_schema(db)
+    chunk_writer = FakeChunkWriter()
+    pipeline = factory.build_connector_pipeline(
+        db=db,
+        collection="gmail-no-advance-two-tick",
+        chunk_writer=chunk_writer,
+        entity_graph_sink=FakeEntityGraphSink(),
+    )
+
+    # Cold-start: seeds the cursor at the live tip with no events.
+    pipeline.run_batch(connector, FakeExtractor())
+    # Tick 1: drains msg-tick1 from a page with NO advancing historyId.
+    pipeline.run_batch(connector, FakeExtractor())
+    # The no-advance drain must NOT echo the input cursor — it returns
+    # None so the pipeline preserved the prior persisted cursor.
+    assert connector.next_cursor() is None, (
+        "after a no-advance drain the connector must report None (don't-clobber), "
+        f"not a false advance; got {connector.next_cursor()!r}"
+    )
+    # Tick 2: empty advancing page — must not re-emit msg-tick1.
+    pipeline.run_batch(connector, FakeExtractor())
+
+    chunks = [chunk for batch in chunk_writer.writes for chunk in batch]
+    item_ids = [chunk.source_uri for chunk in chunks]
+    msg_tick1_count = sum(1 for uri in item_ids if "msg-tick1" in uri)
+    assert msg_tick1_count == 1, (
+        "msg-tick1 must be processed exactly once across both ticks; "
+        f"re-emit means the no-advance tick clobbered the cursor with a false advance. "
+        f"got {msg_tick1_count} occurrences in {item_ids!r}"
+    )

--- a/tests/unit/test_github_connector_unit.py
+++ b/tests/unit/test_github_connector_unit.py
@@ -83,16 +83,46 @@ def test_capabilities_set_matches_spec_section_1() -> None:
 
 
 def test_serialise_then_deserialise_round_trips() -> None:
-    """JSON map round-trips through serialise / deserialise without loss."""
+    """JSON map round-trips through serialise / deserialise without loss.
+
+    Covers the compound inclusive-since cursor — the boundary timestamps
+    AND the per-boundary seen-id sets (``seen_commit_shas`` /
+    ``seen_issue_ids``) must survive the round-trip so the next tick can
+    skip the already-emitted boundary rows.
+    """
     state = {
-        "org/repo-1": PerRepoCursorState(code_sha="sha-1", issues_since="2026-05-23T00:00:00Z"),
+        "org/repo-1": PerRepoCursorState(
+            code_sha="2026-05-23T02:00:00Z",
+            issues_since="2026-05-23T00:00:00Z",
+            seen_commit_shas=frozenset({"sha-a", "sha-b"}),
+            seen_issue_ids=frozenset({"github://org/repo-1/issues/7"}),
+        ),
         "org/repo-2": PerRepoCursorState(code_sha=None, issues_since=None),
     }
     encoded = serialise_cursor(state)
     decoded = deserialise_cursor(encoded)
-    assert decoded["org/repo-1"].code_sha == "sha-1"
+    assert decoded["org/repo-1"].code_sha == "2026-05-23T02:00:00Z"
     assert decoded["org/repo-1"].issues_since == "2026-05-23T00:00:00Z"
+    assert decoded["org/repo-1"].seen_commit_shas == frozenset({"sha-a", "sha-b"})
+    assert decoded["org/repo-1"].seen_issue_ids == frozenset({"github://org/repo-1/issues/7"})
     assert decoded["org/repo-2"].code_sha is None
+    # Stale pre-fix cursors that omit the seen-id fields upgrade to empty sets.
+    assert decoded["org/repo-2"].seen_commit_shas == frozenset()
+    assert decoded["org/repo-2"].seen_issue_ids == frozenset()
+
+
+def test_deserialise_pre_fix_cursor_without_seen_sets_upgrades_cleanly() -> None:
+    """A persisted cursor from before the fix (no seen-id fields) loads cleanly.
+
+    Pins the back-compat path in ``_coerce_id_set`` — a stale cursor that
+    carries only ``code_sha`` / ``issues_since`` upgrades to empty seen-sets
+    rather than crashing or forcing a full re-backfill.
+    """
+    legacy = json.dumps({"org/legacy": {"code_sha": "2026-05-23T01:00:00Z", "issues_since": "2026-05-23T01:00:00Z"}})
+    decoded = deserialise_cursor(legacy)
+    assert decoded["org/legacy"].code_sha == "2026-05-23T01:00:00Z"
+    assert decoded["org/legacy"].seen_commit_shas == frozenset()
+    assert decoded["org/legacy"].seen_issue_ids == frozenset()
 
 
 def test_deserialise_tolerates_malformed_input() -> None:
@@ -1332,3 +1362,125 @@ def test_app_mode_list_repositories_still_uses_installation_endpoint() -> None:
     assert "/installation/repositories" in paths_hit
     assert "/user/repos" not in paths_hit
     assert repos[0].full_name == "tc/app"
+
+
+# ---------------------------------------------------------------------------
+# Inclusive-``since`` boundary cursor advance (resilience-audit fix)
+# ---------------------------------------------------------------------------
+
+
+class _InclusiveSinceUnitClient:
+    """Scripted client honouring GitHub's INCLUSIVE ``since`` semantics.
+
+    ``list_commits_since`` returns every scripted commit whose
+    ``committed_at`` is ``>= since`` (oldest-first), mirroring GitHub's
+    real boundary behaviour — the exact wire contract that triggers the
+    boundary re-emit bug when the connector persists the boundary
+    timestamp as the next ``since``.
+    """
+
+    _REPO = "agent-alpha-org/quiet-repo"
+
+    def __init__(self, *, commits: list[GitHubCommitRef]) -> None:
+        from kairix.connectors.github.api_client import ClientStatsSnapshot
+
+        self._commits = list(commits)
+        self._stats = ClientStatsSnapshot(
+            rest_requests=0,
+            rest_rate_remaining=5000,
+            rest_rate_reset_epoch=0,
+            rest_403_secondary_total=0,
+            installation_token_rotations=0,
+        )
+
+    def list_installation_repositories(self):
+        return (
+            GitHubRepoRef(
+                repo_id=1,
+                full_name=self._REPO,
+                default_branch="main",
+                visibility="private",
+                archived=False,
+            ),
+        )
+
+    def list_commits_since(self, *, full_name: str, since: str | None):
+        _ = full_name
+        kept = [c for c in self._commits if since is None or c.committed_at >= since]
+        kept.sort(key=lambda c: c.committed_at)
+        return tuple(kept)
+
+    def list_issues_since(self, *, full_name: str, since: str | None):
+        _ = (full_name, since)
+        return ()
+
+    def get_tree_recursive(self, *, full_name: str, ref: str):
+        _ = (full_name, ref)
+        return (), False
+
+    def fetch_blob(self, *, full_name: str, sha: str) -> bytes:
+        _ = (full_name, sha)
+        return b""
+
+    def stats(self):
+        return self._stats
+
+    def invalidate_token(self) -> None:
+        return None
+
+
+def test_drain_advances_cursor_to_max_committed_at_with_only_that_seconds_shas() -> None:
+    """A drain records the MAX ``committed_at`` + only the SHAs at that second.
+
+    Pins the inclusive-since boundary computation precisely:
+
+      * the persisted boundary (``code_sha``) is the MAX ``committed_at``
+        across the drained commits — not an earlier one;
+      * the boundary seen-set (``seen_commit_shas``) holds ONLY the SHAs
+        AT that max second (an earlier-second commit is excluded; a
+        same-max-second sibling is included).
+
+    Sabotage-proof: neutering ``_advance_boundary``'s seen-set (returning
+    ``frozenset()``) leaves ``seen_commit_shas`` empty and flips this test
+    to fail; reverting the boundary ``>`` scan to keep an earlier value
+    flips the ``code_sha`` assertion.
+    """
+    commits = [
+        GitHubCommitRef(sha="earlier-sha", committed_at="2026-05-23T01:00:00Z", message="e", author="agent-alpha"),
+        GitHubCommitRef(sha="max-sha-a", committed_at="2026-05-23T02:00:00Z", message="a", author="agent-alpha"),
+        GitHubCommitRef(sha="max-sha-b", committed_at="2026-05-23T02:00:00Z", message="b", author="agent-beta"),
+    ]
+    client = _InclusiveSinceUnitClient(commits=commits)
+    connector = GitHubConnector(client=client)  # type: ignore[arg-type]  # F3 rationale: local stub mirrors GitHubApiClient shape but isn't typed as the Protocol — boundary-only suppression for the test seam
+
+    first = list(connector.list_changes(cursor=None))
+    assert len(first) == 3, f"tick 1 should emit all three commits; got {first!r}"
+
+    state = connector._per_repo_cursors[_InclusiveSinceUnitClient._REPO]
+    assert state.code_sha == "2026-05-23T02:00:00Z", f"boundary must be the max committed_at; got {state.code_sha!r}"
+    assert state.seen_commit_shas == frozenset({"max-sha-a", "max-sha-b"}), (
+        f"seen-set must hold exactly the max-second SHAs; got {sorted(state.seen_commit_shas)!r}"
+    )
+    assert "earlier-sha" not in state.seen_commit_shas, "an earlier-second commit must NOT be in the boundary seen-set"
+
+
+def test_quiet_repo_reemits_zero_commits_on_next_tick() -> None:
+    """A repo with no new commits re-emits ZERO events on tick 2.
+
+    GitHub's inclusive ``commits?since=`` re-returns the boundary commit,
+    but the connector must skip it via the persisted seen-set.
+
+    Sabotage-proof: neutering the seen-set (so the boundary commit is no
+    longer suppressed) flips this test to fail — tick 2 re-emits the
+    boundary commit.
+    """
+    commits = [
+        GitHubCommitRef(sha="boundary-sha", committed_at="2026-05-23T01:00:00Z", message="b", author="agent-alpha"),
+    ]
+    client = _InclusiveSinceUnitClient(commits=commits)
+    connector = GitHubConnector(client=client)  # type: ignore[arg-type]  # F3 rationale: local stub mirrors GitHubApiClient shape but isn't typed as the Protocol — boundary-only suppression for the test seam
+
+    first = list(connector.list_changes(cursor=None))
+    assert len(first) == 1, f"tick 1 should emit the boundary commit; got {first!r}"
+    second = list(connector.list_changes(cursor=connector.next_cursor()))
+    assert second == [], f"quiet repo must re-emit ZERO events on tick 2; got {second!r}"

--- a/tests/unit/test_gmail_connector_unit_coverage.py
+++ b/tests/unit/test_gmail_connector_unit_coverage.py
@@ -447,12 +447,19 @@ def test_list_changes_for_container_flag_on_warm_drain_threads_mailbox_metadata(
     assert connector.next_cursor_for_container(_USER) == "post-drain-tip"
 
 
-def test_list_changes_for_container_flag_on_warm_drain_falls_back_to_cursor_when_no_terminal_tip() -> None:
-    """ON branch — when the client has no last_history_id, cursor falls back.
+def test_list_changes_for_container_flag_on_warm_drain_returns_none_when_no_terminal_tip() -> None:
+    """ON branch — a drain with no advancing historyId returns None (don't-clobber).
 
-    Sabotage proof: removing the ``or cursor`` fallback in the cursor
-    assignment would set the per-mailbox cursor to None and the next
-    tick would refetch the same window.
+    When the client surfaces no ``last_history_id`` the per-mailbox
+    cursor must report None per the ``next_cursor`` Protocol contract:
+    None means "no advance this tick; do not clobber the prior cursor".
+    Echoing the stale input cursor would falsely signal an advance to a
+    window we already drained, making the next tick re-query the
+    identical window and re-emit every already-processed message.
+
+    Sabotage proof: restoring the ``or cursor`` fallback in the cursor
+    assignment makes this read the stale ``"warm-cursor-no-tip"`` and
+    fail.
     """
     msg = _make_message("scoped-msg-no-tip")
     client = _FakeGmailClient(messages=[msg], terminal_history_id=None)
@@ -461,9 +468,10 @@ def test_list_changes_for_container_flag_on_warm_drain_falls_back_to_cursor_when
         client=client,  # type: ignore[arg-type]  # F3 rationale: test-local stub mirrors GmailClient shape.
         flag_reader=lambda _name: True,
     )
-    list(connector.list_changes_for_container(_make_container(cursor_token="fallback-cursor")))
-    # No terminal tip from the client → cursor falls back to the input value.
-    assert connector.next_cursor_for_container(_USER) == "fallback-cursor"
+    events = list(connector.list_changes_for_container(_make_container(cursor_token="warm-cursor-no-tip")))
+    assert len(events) == 1, f"the message must still be emitted this tick; got {events!r}"
+    # No advancing historyId → don't-clobber: report None, never the stale input cursor.
+    assert connector.next_cursor_for_container(_USER) is None
 
 
 def test_next_cursor_for_container_returns_none_for_unknown_mailbox() -> None:

--- a/tests/unit/test_slack_connector_unit.py
+++ b/tests/unit/test_slack_connector_unit.py
@@ -85,8 +85,10 @@ class _InMemoryWeb(SlackWebClient):
         del types
         yield from self._channels
 
-    def conversations_history(self, *, channel_id: str, oldest: str | None = None) -> Iterator[SlackMessage]:
-        del oldest
+    def conversations_history(
+        self, *, channel_id: str, oldest: str | None = None, inclusive: bool = False
+    ) -> Iterator[SlackMessage]:
+        del oldest, inclusive
         exc = self._raise_on_history.get(channel_id)
         if exc is not None:
             raise exc
@@ -598,6 +600,94 @@ def test_reindex_skips_access_denied_items() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Resolver — real-wire ``oldest``/``inclusive`` boundary semantics
+# ---------------------------------------------------------------------------
+#
+# The in-memory ``_InMemoryWeb`` fake does ``del oldest`` and so can't catch
+# the dead-letter-replay bug: it returns the targeted message regardless of
+# the ``oldest``/``inclusive`` boundary. On the real Slack wire,
+# ``conversations.history?oldest=<ts>`` is EXCLUSIVE by default — a message
+# whose ``ts`` exactly equals ``oldest`` is NOT returned unless the request
+# also carries ``inclusive=true`` (Slack docs: "If a message has the same
+# timestamp as oldest or latest it will not be included … you can have both
+# timestamps be included by setting inclusive to true"). ``reindex`` targets
+# the failed message's exact ``ts`` and filters ``message.ts == ts``, so
+# without ``inclusive=true`` the replay returns ZERO messages on the deployed
+# connector. This MockTransport honours the real boundary so the bug is
+# observable.
+
+
+def _wire_honouring_oldest_inclusive(*, channel_id: str, boundary_ts: str) -> SlackWebClient:
+    """Real ``SlackWebClient`` over a transport that models Slack's boundary.
+
+    The handler returns a single message at ``boundary_ts`` ONLY when the
+    request carries BOTH ``oldest=<boundary_ts>`` AND ``inclusive=true`` —
+    the real wire's exclusive-by-default ``oldest`` semantics. A request
+    without ``inclusive=true`` (or with a different ``oldest``) returns an
+    empty page, exactly as Slack would for a boundary-equal ``ts``.
+    """
+    boundary_message = {
+        "ts": boundary_ts,
+        "user": "U_TEST",
+        "text": "the dead-lettered message",
+    }
+    empty_page = {"ok": True, "messages": [], "response_metadata": {"next_cursor": ""}}
+    boundary_page = {"ok": True, "messages": [boundary_message], "response_metadata": {"next_cursor": ""}}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        if "conversations.history" not in str(request.url):
+            return httpx.Response(200, json={"ok": True})
+        form = httpx.QueryParams(bytes(request.content).decode("ascii"))
+        oldest = form.get("oldest")
+        inclusive = form.get("inclusive")
+        # Slack: a message at ts == oldest is excluded unless inclusive=true.
+        if oldest == boundary_ts and inclusive == "true":
+            return httpx.Response(200, json=boundary_page)
+        return httpx.Response(200, json=empty_page)
+
+    shared = httpx.Client(transport=httpx.MockTransport(_handler))
+
+    def _builder(_c: SlackCredentials) -> SlackWebClient:
+        return SlackWebClient(token="xoxb-test-fake-token-value", http_client=shared)
+
+    del channel_id  # only used by the caller to build the item_id
+    connector_web = _builder(SlackCredentials(bot_token="xoxb-test-fake-token-value"))
+    return connector_web
+
+
+def test_reindex_replays_boundary_message_on_real_wire() -> None:
+    """Dead-letter replay returns the targeted message against a real-wire transport.
+
+    Models Slack's exclusive-by-default ``oldest``: the message at
+    ``ts == oldest`` is only returned when the request also carries
+    ``inclusive=true``. ``reindex`` MUST request the inclusive boundary,
+    otherwise the deployed connector silently replays ZERO messages.
+
+    Sabotage proof (executed): reverting ``reindex`` to
+    ``conversations_history(channel_id=..., oldest=ts)`` (dropping
+    ``inclusive=True``) makes this test fail — the transport returns an
+    empty page for the boundary ``ts``, ``events`` is ``[]``, and the
+    ``assert events`` line trips.
+    """
+    boundary_ts = "1715000000.000100"
+    channel_id = "C1"
+    shared_web = _wire_honouring_oldest_inclusive(channel_id=channel_id, boundary_ts=boundary_ts)
+
+    def _builder(_c: SlackCredentials) -> SlackWebClient:
+        return shared_web
+
+    connector = SlackConnector(
+        credentials=SlackCredentials(bot_token="xoxb-test-fake-token-value"),
+        web_client_factory=_builder,
+        flag_reader=FakeFeatureFlagResolver().with_flag("connector_slack", False).get,
+    )
+    events = list(connector.reindex((f"{channel_id}:{boundary_ts}",)))
+    assert events, "reindex replayed ZERO messages — the boundary message was excluded by an exclusive oldest"
+    assert events[0].item_id == f"{channel_id}:{boundary_ts}"
+    assert events[0].op == "created"
+
+
+# ---------------------------------------------------------------------------
 # OAuthConnector
 # ---------------------------------------------------------------------------
 
@@ -720,6 +810,73 @@ def test_web_client_conversations_history_paginates() -> None:
     )
     messages = list(client.conversations_history(channel_id="C1", oldest=None))
     assert [m.ts for m in messages] == ["1.0", "2.0"]
+
+
+def _capture_history_params(**call_kwargs: Any) -> dict[str, str]:
+    """Drive one ``conversations_history`` call and return the wire form params.
+
+    Wires a real :class:`SlackWebClient` to a MockTransport handler that
+    captures the outbound ``conversations.history`` request body, so the
+    test can assert exactly which Slack params (``oldest`` / ``inclusive``)
+    the client put on the wire for a given call signature.
+    """
+    captured: dict[str, str] = {}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        form = httpx.QueryParams(bytes(request.content).decode("ascii"))
+        captured.update({k: form[k] for k in form})
+        return httpx.Response(200, json={"ok": True, "messages": [], "response_metadata": {"next_cursor": ""}})
+
+    client = SlackWebClient(
+        token="xoxb-test-fake-token-value", http_client=httpx.Client(transport=_stub_transport(_handler))
+    )
+    list(client.conversations_history(channel_id="C1", **call_kwargs))
+    return captured
+
+
+def test_web_client_history_default_does_not_send_inclusive() -> None:
+    """The advance/poll path keeps Slack's default-EXCLUSIVE ``oldest`` boundary.
+
+    A plain ``conversations_history(oldest=<ts>)`` (default ``inclusive``)
+    must NOT put ``inclusive=true`` on the wire — the legacy list_changes /
+    _drain_channel advance relies on the boundary message being EXCLUDED so
+    re-feeding the high-water ``ts`` next tick doesn't re-emit it.
+
+    Sabotage proof (executed): flipping the default to ``inclusive: bool =
+    True`` (line 250) makes this assertion fail — the wire then carries
+    ``inclusive=true`` and the poll path would re-emit the boundary message.
+    """
+    params = _capture_history_params(oldest="1715000000.000100")
+    assert params.get("oldest") == "1715000000.000100"
+    assert "inclusive" not in params, f"poll path must not send inclusive; wire carried: {params!r}"
+
+
+def test_web_client_history_inclusive_with_oldest_sends_inclusive_true() -> None:
+    """The replay path sends ``inclusive=true`` so Slack returns the boundary message.
+
+    Sabotage proof (executed): dropping the ``inclusive`` branch on
+    line 278 makes this assertion fail — the wire no longer carries
+    ``inclusive=true`` and the dead-letter replay loses the boundary
+    message on the real wire.
+    """
+    params = _capture_history_params(oldest="1715000000.000100", inclusive=True)
+    assert params.get("oldest") == "1715000000.000100"
+    assert params.get("inclusive") == "true", f"replay path must send inclusive=true; wire carried: {params!r}"
+
+
+def test_web_client_history_inclusive_without_oldest_is_dropped() -> None:
+    """``inclusive`` is meaningless without ``oldest`` and must not reach the wire.
+
+    Slack ignores ``inclusive`` unless ``oldest`` (or ``latest``) is set,
+    so the client must NOT emit a bare ``inclusive=true``.
+
+    Sabotage proof (executed): mutating the guard from ``oldest and
+    inclusive`` to ``oldest or inclusive`` (line 278) makes this assertion
+    fail — the wire then carries ``inclusive=true`` with no ``oldest``.
+    """
+    params = _capture_history_params(inclusive=True)
+    assert "oldest" not in params
+    assert "inclusive" not in params, f"bare inclusive must be dropped; wire carried: {params!r}"
 
 
 def test_web_client_conversations_replies_paginates() -> None:


### PR DESCRIPTION
## What this fixes

Three connectors had cursor/boundary bugs that made them either re-process already-seen items every tick or silently skip a boundary item. Each is a wasted-work or correctness defect on shipped behaviour. Phase 3 (per-connector hardening) of the connector-architecture refactor (design spec #571).

Closes #577
Closes #578
Closes #579

## The three fixes

**gmail** (`#577`) — on a warm tick with no advancing `historyId`, the connector echoed the stale input cursor (`last_history_id() or cursor`), falsely signalling an advance, so the next tick re-emitted every already-processed message. Both warm-tick sites (base + Wave-E per-mailbox) now return `last_history_id()` directly — `None` on a no-advance drain — and the pipeline's don't-clobber discipline preserves the prior cursor.

**slack** (`#578`) — the dead-letter replay path (`reindex`) used Slack's default-exclusive `oldest`, so the targeted boundary message at `ts == oldest` was never returned and zero messages replayed. `reindex` now sends `inclusive=True`; the poll/advance path stays exclusive (no re-emit). A real-wire `httpx.MockTransport` test models the exclusive-by-default / inclusive-opt-in contract.

**github** (`#579`) — `commits?since=` / `issues?since=` are inclusive on the boundary timestamp, so a quiet repo re-fetched + re-emitted the boundary commit/issue every tick forever. `PerRepoCursorState` is now a compound cursor (boundary timestamp + the seen ids at that second); `_drain_commits`/`_drain_issues` skip only already-seen boundary ids, so a quiet repo emits nothing while a genuinely-new same-second item still emits (no `+1s` drop pitfall).

## Tests

Each fix is TDD red-first with executed sabotage-proofs and `safe-commit.sh` full-gate green (mutation parity 0 survivors on all three). Coverage held at ~95.8%.

## Known follow-up (not in scope)

The github `PerRepoCursorState.code_sha` field holds a `committed_at` timestamp, not a SHA — a pre-existing misnomer preserved here to avoid churning the cursor-isolation contract tests that assert `code_sha == committed_at`. Its semantics (the inclusive-since boundary) are now documented on the dataclass. A rename is deferred as separate, behaviour-neutral cleanup.