### PR TITLE
chore(deps): add gomod Dependabot ecosystem for services/* Go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,35 @@ updates:
           - "minor"
           - "patch"
 
+  # Go modules — the two services/<name>/go.mod modules gated by
+  # go-quality.yml. Without these entries Dependabot never raised a Go
+  # update PR (broken targeting, not the OFF toggle): the pip + actions
+  # ecosystems below only cover the repo root, so the Go module tree was
+  # invisible to version + security updates. `directories:` (glob) targets
+  # both modules with one entry and auto-covers any future services/* module.
+  - package-ecosystem: gomod
+    directories:
+      - "/services/*"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "03:00"
+      timezone: "Australia/Sydney"
+    open-pull-requests-limit: 3
+    reviewers:
+      - quanyeomans
+    labels:
+      - dependency
+      - automated
+      - go
+    commit-message:
+      prefix: "chore(deps)"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 7
+
   # GitHub Actions
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Wave 0 (Build & Release Health) — O4 security quick win: Dependabot targeting

### Problem
The two Go service modules — `services/hello` and `services/alpha-deploy-webhook` (both gated by `go-quality.yml`) — were **invisible to Dependabot**. `.github/dependabot.yml` declared only the `pip` and `github-actions` ecosystems, both rooted at `/`. There was no `gomod` ecosystem at all, so no Go version-update or security-advisory PR could ever be raised for the module tree.

This is the **broken-TARGETING** class the Wave-0 diagnosis flagged (the ecosystem was *missing*, not toggled off), applied to kairix's actual surface. (Kairix has no npm/`directories:`-pointing-at-non-existent-dirs problem — there is no JS ecosystem in the repo — so the npm variant of the diagnosis does not apply here; the Go gap is the equivalent.)

### Change
Adds a `gomod` ecosystem entry using `directories: ["/services/*"]` (glob), so:
- both current modules are covered by one rule, and
- any future `services/*` module is auto-covered.

It reuses the existing supply-chain conventions: 7-day (14-day semver-major) cooldown, `quanyeomans` reviewer, `dependency`/`automated`/`go` labels, `chore(deps)` commit prefix.

### Verification
- `python3 -c "import yaml; ..."` → parses to 3 update entries: `[pip, gomod, github-actions]`.
- Glob `/services/*` resolves to exactly the two dirs containing a `go.mod` (`services/README.md` has none and is skipped by the gomod ecosystem).
- `.github/dependabot.yml` is not a workflow file, so the `actionlint` pre-commit hook does not gate it; no fitness rule references dependabot. No gate impact.

> Note: both `go.mod` files currently have **zero external `require` dependencies** (pure stdlib, no `go.sum`), so this raises no PR *today* — it closes the targeting gap so future Go deps and CVE advisories are covered from the moment they are introduced.

Do not merge without maintainer review (kairix team owns the CI surface).