### PR TITLE
feat(connectors): pre-extract file-compatibility gate (skip unprocessable binaries)

### DIFF
--- a/kairix/core/connectors/compat.py
+++ b/kairix/core/connectors/compat.py
@@ -1,0 +1,263 @@
+"""File-compatibility classifier — a pre-extract triage gate.
+
+Some source connectors (SharePoint via Microsoft Graph, most notably)
+hand the pipeline files whose declared MIME is unreliable: Graph
+frequently omits the ``Content-Type`` so the connector falls back to
+``application/octet-stream`` (see
+``kairix.connectors.sharepoint.connector.DEFAULT_FETCH_MIME``). Two
+failure modes follow:
+
+* **Genuinely-unprocessable binaries** (``.exe``, ``.vsdx``, true
+  ``.zip`` archives, legacy binary Office) reach ``extractor.extract``,
+  raise, and land in the dead-letter queue. After ``failure_count >=
+  threshold`` they poison and the operator sees a dead-letter backlog
+  that no retry can ever clear.
+* **Office documents with a stripped Content-Type** arrive as
+  ``application/octet-stream`` even though they are perfectly-valid
+  OOXML (a ``.docx`` is a ZIP container with a ``word/`` member). The
+  generic MIME means the docx/markitdown extractors never claim them.
+
+:func:`classify_compat` resolves both by inspecting the strongest
+available signal — magic bytes, then MIME, then filename extension as a
+tiebreak — and returning a :class:`CompatResult` the pipeline uses to
+(a) *skip* known-unsupported formats BEFORE extraction (no extract
+attempt, no dead-letter), or (b) *correct* the MIME for an
+OOXML-document-that-looks-like-a-ZIP so it routes to the right
+extractor.
+
+Design constraints:
+
+* **stdlib only** — ``zipfile`` + ``io``; no new dependencies. The
+  module is pure and side-effect-free.
+* **Conservative by construction** — the extension signal is a
+  *tiebreak* that can only push toward ``KNOWN_UNSUPPORTED``; it never
+  *upgrades* an item to ``SUPPORTED``. Anything we cannot positively
+  classify returns ``UNKNOWN`` (NOT ``KNOWN_UNSUPPORTED``) so the
+  existing extract path still runs — today's behaviour for
+  mislabeled-but-valid files is preserved.
+"""
+
+from __future__ import annotations
+
+import enum
+import io
+import zipfile
+from dataclasses import dataclass
+
+# --- OOXML (Office Open XML) MIME types -----------------------------------
+# The three modern Office container MIMEs. A docx/pptx/xlsx is a ZIP whose
+# namelist carries a tell-tale top-level directory (word/ ppt/ xl/).
+_MIME_DOCX = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+_MIME_PPTX = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+_MIME_XLSX = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+
+# --- magic byte signatures -------------------------------------------------
+_MAGIC_PDF = b"%PDF"
+_MAGIC_ZIP = b"PK\x03\x04"
+_MAGIC_PNG = b"\x89PNG\r\n\x1a\n"
+_MAGIC_JPEG = b"\xff\xd8\xff"
+_MAGIC_GIF87 = b"GIF87a"
+_MAGIC_GIF89 = b"GIF89a"
+
+# --- supported MIME universe (when magic gives nothing decisive) ----------
+# Union of every wired extractor's ``can_extract`` MIME set
+# (passthrough text/*, pdf, the OOXML trio, html, images). ``text/*`` is
+# handled by prefix below; the rest are exact matches.
+_SUPPORTED_MIMES: frozenset[str] = frozenset(
+    {
+        "application/pdf",
+        _MIME_DOCX,
+        _MIME_PPTX,
+        _MIME_XLSX,
+        "text/html",
+        "application/xhtml+xml",
+        "image/png",
+        "image/jpeg",
+        "image/jpg",
+        "image/gif",
+        "image/tiff",
+        "image/bmp",
+    }
+)
+
+# --- known-unsupported MIME prefixes / exacts -----------------------------
+# Formats with no extractor and no prospect of one in this wave: legacy
+# binary Office (.doc/.ppt/.xls via msword etc.), Visio, executables,
+# ODF, MS Publisher. Skipping these pre-extract keeps them out of the
+# dead-letter queue.
+_KNOWN_UNSUPPORTED_MIMES: frozenset[str] = frozenset(
+    {
+        "application/msword",
+        "application/vnd.ms-powerpoint",
+        "application/vnd.ms-excel",
+        "application/x-msdownload",
+        "application/vnd.ms-publisher",
+    }
+)
+_KNOWN_UNSUPPORTED_MIME_PREFIXES: tuple[str, ...] = (
+    "application/vnd.ms-visio",
+    "application/vnd.oasis.opendocument.",  # ODF: odt / ods / odp
+)
+
+# --- known-unsupported extensions (TIEBREAK only — never upgrades) --------
+_KNOWN_UNSUPPORTED_EXTENSIONS: frozenset[str] = frozenset(
+    {
+        ".exe",
+        ".dll",
+        ".vsd",
+        ".vsdx",
+        ".msg",
+        ".odt",
+        ".ods",
+        ".odp",
+        ".pub",
+    }
+)
+
+
+class Compat(enum.Enum):
+    """Pre-extract compatibility verdict for one item.
+
+    * ``SUPPORTED`` — a wired extractor can handle this format; route to
+      extraction as normal (with :attr:`CompatResult.effective_mime`).
+    * ``KNOWN_UNSUPPORTED`` — positively identified as a format with no
+      extractor (true archive, legacy binary Office, executable, ODF,
+      corrupt ZIP). The pipeline SKIPS extraction and records the item
+      so it is consumed without dead-lettering.
+    * ``UNKNOWN`` — could not positively classify (generic
+      octet-stream, unrecognised MIME, no decisive magic/extension).
+      The pipeline falls through to the existing extract path so a
+      mislabeled-but-valid file still gets a chance.
+    """
+
+    SUPPORTED = "supported"
+    KNOWN_UNSUPPORTED = "known_unsupported"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class CompatResult:
+    """Outcome of :func:`classify_compat`.
+
+    ``effective_mime`` is the MIME the pipeline should route extraction
+    with. It equals the input ``mime`` in every case EXCEPT the
+    OOXML-from-ZIP disambiguation branch, where a ZIP container whose
+    namelist proves it is a docx/pptx/xlsx is re-labelled with the
+    correct OOXML MIME so the format-specific extractor claims it.
+    """
+
+    compat: Compat
+    effective_mime: str
+
+
+def _classify_zip(data: bytes, mime: str) -> CompatResult:
+    """Disambiguate a ``PK\\x03\\x04``-prefixed payload.
+
+    OOXML Office documents are ZIP containers; a true archive is also a
+    ZIP. We open the central directory and look for the tell-tale
+    top-level member (``word/`` / ``ppt/`` / ``xl/``). A document maps
+    to ``SUPPORTED`` with the corrected OOXML ``effective_mime``; any
+    other (real archive / unknown ZIP) is ``KNOWN_UNSUPPORTED`` — we
+    skip true archives per the product decision. A ``PK`` header that
+    cannot be opened as a ZIP at all — corrupt, truncated, or a
+    malformed central directory (which raises ``BadZipFile`` /
+    ``struct.error`` / ``OSError`` / ``EOFError``) — is likewise
+    ``KNOWN_UNSUPPORTED``: this classifier is total and must never
+    raise, so any failure to read the container is the safe default.
+    """
+    try:
+        with zipfile.ZipFile(io.BytesIO(data)) as zf:
+            names = zf.namelist()
+    except Exception:  # classifier must be total — any zip read failure ⇒ unsupported
+        # PK magic but the ZIP could not be opened/read: not just
+        # ``BadZipFile`` but also a ``struct.error`` from a malformed /
+        # truncated central directory (common for partially-downloaded
+        # SharePoint files), ``OSError``/``EOFError`` on a short read,
+        # etc. This function is a pre-extract gate whose contract is
+        # totality — it must NEVER raise (an escape would propagate
+        # through ``_process_item`` and crash the whole batch). Any
+        # failure to open the container ⇒ treat as KNOWN_UNSUPPORTED,
+        # the safe default.
+        return CompatResult(Compat.KNOWN_UNSUPPORTED, mime)
+    if any(n.startswith("word/") for n in names):
+        return CompatResult(Compat.SUPPORTED, _MIME_DOCX)
+    if any(n.startswith("ppt/") for n in names):
+        return CompatResult(Compat.SUPPORTED, _MIME_PPTX)
+    if any(n.startswith("xl/") for n in names):
+        return CompatResult(Compat.SUPPORTED, _MIME_XLSX)
+    # A valid ZIP that is not an OOXML Office document → true archive.
+    return CompatResult(Compat.KNOWN_UNSUPPORTED, mime)
+
+
+def _extension(name: str) -> str:
+    """Lower-cased final extension of ``name`` (``""`` when none)."""
+    dot = name.rfind(".")
+    if dot < 0:
+        return ""
+    return name[dot:].lower()
+
+
+def classify_compat(mime: str, name: str, data: bytes) -> CompatResult:
+    """Classify an item's processability BEFORE extraction.
+
+    Args:
+        mime: the connector-declared MIME hint (may be the generic
+            ``application/octet-stream`` when the source stripped the
+            Content-Type).
+        name: the item filename WITH extension (e.g. from
+            ``ChangeEvent.metadata["name"]``). Used only as a tiebreak;
+            ``""`` when unavailable.
+        data: the full file bytes already fetched by the connector. Only
+            the leading bytes (magic) and — for ZIP payloads — the
+            central directory are inspected.
+
+    Returns:
+        A :class:`CompatResult` whose ``compat`` drives the skip gate
+        and whose ``effective_mime`` drives extraction routing.
+
+    Resolution order (strongest signal first):
+
+    1. **Magic bytes** (``data[:8]``) — PDF / image / ZIP-family. ZIP
+       payloads are disambiguated into OOXML-document (SUPPORTED, MIME
+       corrected) vs. true-archive/corrupt (KNOWN_UNSUPPORTED).
+    2. **MIME** — when magic was indecisive: supported universe →
+       SUPPORTED; known-unsupported set/prefixes → KNOWN_UNSUPPORTED.
+    3. **Extension** (tiebreak, KNOWN_UNSUPPORTED-only) — a
+       known-unsupported extension demotes an otherwise-unknown item.
+    4. **Fall-through** — generic / unrecognised → UNKNOWN (the extract
+       path still runs; today's behaviour is preserved).
+    """
+    head = data[:8]
+
+    # 1. Magic bytes — the most trustworthy signal.
+    if head.startswith(_MAGIC_PDF):
+        return CompatResult(Compat.SUPPORTED, mime)
+    if (
+        head.startswith(_MAGIC_PNG)
+        or head.startswith(_MAGIC_JPEG)
+        or head.startswith(_MAGIC_GIF87)
+        or head.startswith(_MAGIC_GIF89)
+    ):
+        return CompatResult(Compat.SUPPORTED, mime)
+    if head.startswith(_MAGIC_ZIP):
+        return _classify_zip(data, mime)
+
+    # 2. MIME — when magic gave nothing decisive.
+    normalised_mime = (mime or "").strip().lower()
+    if normalised_mime.startswith("text/"):
+        return CompatResult(Compat.SUPPORTED, mime)
+    if normalised_mime in _SUPPORTED_MIMES:
+        return CompatResult(Compat.SUPPORTED, mime)
+    if normalised_mime in _KNOWN_UNSUPPORTED_MIMES:
+        return CompatResult(Compat.KNOWN_UNSUPPORTED, mime)
+    if any(normalised_mime.startswith(prefix) for prefix in _KNOWN_UNSUPPORTED_MIME_PREFIXES):
+        return CompatResult(Compat.KNOWN_UNSUPPORTED, mime)
+
+    # 3. Extension — TIEBREAK only; can demote to KNOWN_UNSUPPORTED but
+    # never upgrade to SUPPORTED.
+    if _extension(name) in _KNOWN_UNSUPPORTED_EXTENSIONS:
+        return CompatResult(Compat.KNOWN_UNSUPPORTED, mime)
+
+    # 4. Generic / unrecognised (e.g. application/octet-stream with no
+    # decisive magic/extension) — do NOT auto-skip. Let extraction try.
+    return CompatResult(Compat.UNKNOWN, mime)

--- a/kairix/core/connectors/pipeline.py
+++ b/kairix/core/connectors/pipeline.py
@@ -49,10 +49,11 @@ import logging
 import shutil
 import sqlite3
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
+from kairix.core.connectors.compat import Compat, classify_compat
 from kairix.core.connectors.cursor_store import CursorStore
 from kairix.core.connectors.dead_letter import DeadLetterStore
 from kairix.core.protocols import (
@@ -479,8 +480,41 @@ class ConnectorPipeline:
             self._dead_letter.record(connector.name, item_id, f"fetch: {exc}")
             return _OUTCOME_DEAD_LETTERED
         ref = self._bronze.write(connector.name, item_id, raw.raw, raw.mime)
+        # PR-2 — pre-extract compatibility gate. Classify the item from
+        # the full bytes already fetched BEFORE attempting extraction so
+        # that (a) genuinely-unprocessable binaries are skipped instead
+        # of dead-lettered, and (b) Office docs that arrive with a
+        # stripped/generic Content-Type get their MIME corrected and
+        # reach the right extractor. ``item_name`` (with extension) is a
+        # tiebreak signal surfaced on ChangeEvent.metadata by the
+        # SharePoint connector; absent for connectors that don't set it
+        # (then the classifier relies on magic bytes + MIME only).
+        item_name = _change_item_name(change)
+        compat_result = classify_compat(raw.mime, item_name, raw.raw)
+        if compat_result.compat is Compat.KNOWN_UNSUPPORTED:
+            # Known-unsupported format: record the outcome (best-effort,
+            # never escalates) and consume the change WITHOUT running the
+            # extractor and WITHOUT recording a dead-letter — so the item
+            # never poisons the queue and the cursor advances normally.
+            # ``skipped_unsupported`` (NOT ``unsupported``) marks that NO
+            # extract ran and ZERO chunks landed (see the constant docs).
+            _safe_outcome_write(
+                self._silver,
+                ref=ref,
+                source_modified_at=modified_at,
+                extractor=extractor,
+                extraction_status=_EXTRACTION_STATUS_SKIPPED_UNSUPPORTED,
+            )
+            return _OUTCOME_PROCESSED
+        # OOXML disambiguation: when the classifier recognised a docx /
+        # pptx / xlsx ZIP that was mislabeled (e.g. application/zip or
+        # octet-stream), route extraction with the corrected MIME so the
+        # format-specific extractor claims it. For every other case
+        # ``effective_mime == raw.mime`` — non-SharePoint / already-
+        # correct items are byte-for-byte unaffected.
+        extract_mime = compat_result.effective_mime
         try:
-            doc = extractor.extract(raw.raw, raw.mime)
+            doc = extractor.extract(raw.raw, extract_mime)
         except Exception as exc:
             # GH #336 — record the failure on documents_media so the
             # dashboard sees it, then dead-letter for retry as before.
@@ -499,7 +533,10 @@ class ConnectorPipeline:
         # never fatal — silver falls back to the legacy single-source
         # shape via the connector_metadata / extractor_metadata defaults.
         connector_metadata = _safe_connector_metadata(connector, item_id)
-        extractor_metadata = _safe_extractor_metadata(extractor, raw.raw, raw.mime)
+        # Use the compat-corrected MIME so the extractor's metadata_for
+        # sees the same MIME it extracted with (matters for the OOXML
+        # disambiguation path; a no-op when effective_mime == raw.mime).
+        extractor_metadata = _safe_extractor_metadata(extractor, raw.raw, extract_mime)
         extractor_name = getattr(extractor, "name", None)
         extractor_version = getattr(extractor, "version", None)
         # GH #336 — derive extraction_status from quality_ok: when the
@@ -536,6 +573,31 @@ class ConnectorPipeline:
 _EXTRACTION_STATUS_OK = "ok"
 _EXTRACTION_STATUS_FAILED = "failed"
 _EXTRACTION_STATUS_UNSUPPORTED = "unsupported"
+# Pre-extract skip status (PR-2 / compat gate). Distinct from
+# ``unsupported``: ``unsupported`` means an extractor DID run, returned a
+# doc, but quality_ok was False — chunks still landed. ``skipped_unsupported``
+# means the compat classifier (:mod:`kairix.core.connectors.compat`)
+# positively identified a known-unsupported format BEFORE extraction was
+# attempted — NO extract ran and ZERO chunks landed. Kept in sync with
+# the same constant + ``_ALLOWED_EXTRACTION_STATUSES`` in silver.py.
+_EXTRACTION_STATUS_SKIPPED_UNSUPPORTED = "skipped_unsupported"
+
+
+def _change_item_name(change: object) -> str:
+    """Return the item filename (with extension) from ``ChangeEvent.metadata``.
+
+    PR-2 — the SharePoint connector surfaces the drive-item name on
+    ``ChangeEvent.metadata["name"]`` (with its extension), which the
+    compat classifier uses as a tiebreak signal. Connectors that don't
+    populate ``metadata["name"]`` (or whose ``metadata`` is absent /
+    not a mapping) yield ``""`` — the classifier then relies on magic
+    bytes + MIME only, so those connectors are unaffected.
+    """
+    metadata = getattr(change, "metadata", None)
+    if not isinstance(metadata, Mapping):
+        return ""
+    name = metadata.get("name")
+    return name if isinstance(name, str) else ""
 
 
 def _safe_quality_ok(extractor: Extractor, doc: object) -> bool:

--- a/kairix/core/connectors/silver.py
+++ b/kairix/core/connectors/silver.py
@@ -57,12 +57,29 @@ from kairix.core.protocols import (
 # (per ADR-024 Bundle B / GH #336) — set by the pipeline when no
 # extractor in the escalation chain claimed the format via
 # ``can_extract`` or when ``quality_ok`` was False across the chain.
+#
+# ``skipped_unsupported`` (new) is set by the pre-extract compatibility
+# gate (:mod:`kairix.core.connectors.compat`) when an item is positively
+# identified as a known-unsupported format BEFORE extraction is even
+# attempted — zero chunks land and no extract runs. This is distinct
+# from ``unsupported``, which means "an extractor DID run, produced a
+# doc, but quality_ok was False (chunks still landed)". ``skipped_*``
+# = never attempted; ``unsupported`` = attempted-but-low-quality.
+#
+# The column is plain free-text TEXT (no CHECK / enum) so adding a value
+# needs only this Python-side allow-list edit — no SQL migration.
 _EXTRACTION_STATUS_OK = "ok"
 _EXTRACTION_STATUS_FAILED = "failed"
 _EXTRACTION_STATUS_UNSUPPORTED = "unsupported"
+_EXTRACTION_STATUS_SKIPPED_UNSUPPORTED = "skipped_unsupported"
 
 _ALLOWED_EXTRACTION_STATUSES: frozenset[str] = frozenset(
-    {_EXTRACTION_STATUS_OK, _EXTRACTION_STATUS_FAILED, _EXTRACTION_STATUS_UNSUPPORTED}
+    {
+        _EXTRACTION_STATUS_OK,
+        _EXTRACTION_STATUS_FAILED,
+        _EXTRACTION_STATUS_UNSUPPORTED,
+        _EXTRACTION_STATUS_SKIPPED_UNSUPPORTED,
+    }
 )
 
 # Target chunk size at paragraph boundaries (characters). Smaller than
@@ -319,7 +336,7 @@ class SqliteDocumentsMediaWriter:
             raise ValueError(
                 f"extraction_status must be one of {sorted(_ALLOWED_EXTRACTION_STATUSES)!r}; "
                 f"got {extraction_status!r}. "
-                "fix: pass 'ok' / 'failed' / 'unsupported' from the orchestrator. "
+                "fix: pass 'ok' / 'failed' / 'unsupported' / 'skipped_unsupported' from the orchestrator. "
                 "run: bash scripts/safe-commit.sh"
             )
         self._db.execute(

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -2425,7 +2425,9 @@ class FakeSourceConnector:
     Constructor takes events to emit and an optional ``fail_on_fetch``
     set — item_ids in that set raise ``RuntimeError`` from ``fetch``.
     ``content`` maps item_id to the raw bytes ``fetch`` returns; absent
-    entries return empty bytes.
+    entries return empty bytes. ``mime_overrides`` maps item_id to the
+    MIME ``fetch`` reports; absent entries fall back to the legacy
+    ``.md → text/markdown, else text/plain`` rule.
 
     Used by ``tests/integration/test_connector_pipeline.py`` to drive
     the per-batch orchestration through the real Bronze + Silver + Cursor
@@ -2459,6 +2461,7 @@ class FakeSourceConnector:
         per_tick_max_items: int = 500,
         disk_watermark_min_free_bytes: int | None = None,
         metadata: dict[str, Any] | None = None,
+        mime_overrides: dict[str, str] | None = None,
     ) -> None:
         from kairix.core.protocols import ChangeEvent  # local import — avoids reordering top-of-file
 
@@ -2495,6 +2498,12 @@ class FakeSourceConnector:
         # Missing entries return an empty SourceMetadata so tests that
         # don't care about envelope metadata stay terse.
         self._metadata: dict[str, Any] = dict(metadata) if metadata is not None else {}
+        # PR-2 (compat gate): per-item MIME override keyed by item_id.
+        # Absent entries fall back to the legacy ``.md → text/markdown,
+        # else text/plain`` rule, so existing tests are unaffected. Set
+        # an override to drive the MIME-driven skip path (e.g. an
+        # ``application/msword`` item with no recognizable magic bytes).
+        self._mime_overrides: dict[str, str] = dict(mime_overrides) if mime_overrides is not None else {}
         # next_cursor() shapes:
         #   - cursor_token=<str>: returned verbatim (opaque-token shape;
         #     mirrors SharePoint/Graph/Slack deltaLink behaviour).
@@ -2531,7 +2540,9 @@ class FakeSourceConnector:
         if item_id in self._fail_on_fetch:
             raise RuntimeError(f"fake-source: simulated fetch failure for {item_id!r}")
         raw = self._content.get(item_id, b"")
-        mime = "text/markdown" if item_id.endswith(".md") else "text/plain"
+        mime = self._mime_overrides.get(item_id)
+        if mime is None:
+            mime = "text/markdown" if item_id.endswith(".md") else "text/plain"
         fetched_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
         return RawArtefact(raw=raw, mime=mime, fetched_at=fetched_at)
 

--- a/tests/integration/test_connector_pipeline_compat.py
+++ b/tests/integration/test_connector_pipeline_compat.py
@@ -1,0 +1,227 @@
+"""PR-2 — pre-extract compatibility gate, driven through the real pipeline.
+
+Three scenarios, all run the production
+:class:`~kairix.core.connectors.pipeline.ConnectorPipeline` built via
+``kairix.core.factory.build_connector_pipeline`` (F47-compliant) so the
+documents_media writer + dead-letter store + chunk writer are the wired
+surfaces, not stubs:
+
+1. **skip_path (magic-byte branch)** — an item the compat classifier
+   identifies as a known-unsupported format via magic bytes (a true ZIP
+   archive — ``PK\\x03\\x04`` header) is recorded on ``documents_media``
+   with ``extraction_status='skipped_unsupported'``, lands ZERO chunks,
+   and is NOT dead-lettered (the ``connector_deadletter`` table stays
+   empty for it). The change is consumed — ``result.processed`` counts
+   it.
+
+2. **ooxml_disambiguation_path** — a docx-as-application/zip item is NOT
+   skipped; the corrected MIME routes it to extraction, the extractor
+   sees the corrected OOXML MIME, chunks land, and the row records
+   ``extraction_status='ok'``.
+
+3. **skip_path (MIME branch)** — a legacy binary ``application/msword``
+   item with NO recognizable magic header (an OLE2 ``.doc``) is skipped
+   on the MIME signal alone (the magic-byte branch never fires), proving
+   the MIME-driven gate — not just the magic-byte gate — produces
+   ``extraction_status='skipped_unsupported'`` end-to-end.
+
+The extract is exercised with a recording :class:`FakeExtractor` so the
+second test can assert the MIME the extractor actually received.
+"""
+
+from __future__ import annotations
+
+import io
+import sqlite3
+import zipfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from kairix.core import factory
+from kairix.core.db.schema import create_schema
+from kairix.core.protocols import ChangeEvent
+from tests.fakes import FakeChunkWriter, FakeEntityGraphSink, FakeExtractor, FakeSourceConnector
+
+pytestmark = pytest.mark.integration
+
+_MIME_DOCX = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+
+
+def _build_pipeline(db: sqlite3.Connection, chunk_writer: FakeChunkWriter) -> Any:
+    return factory.build_connector_pipeline(
+        db=db,
+        collection="compat-gate-test",
+        chunk_writer=chunk_writer,
+        entity_graph_sink=FakeEntityGraphSink(),
+    )
+
+
+def _media_rows(db: sqlite3.Connection) -> list[dict[str, Any]]:
+    cursor = db.execute(
+        "SELECT hash, path, format, extraction_status, extractor_name FROM documents_media ORDER BY hash"
+    )
+    cols = [c[0] for c in cursor.description]
+    return [dict(zip(cols, row, strict=True)) for row in cursor.fetchall()]
+
+
+def _deadletter_count(db: sqlite3.Connection, item_id: str) -> int:
+    row = db.execute(
+        "SELECT COUNT(*) FROM connector_deadletter WHERE item_id = ?",
+        (item_id,),
+    ).fetchone()
+    return int(row[0])
+
+
+def _true_archive_zip() -> bytes:
+    """A valid ZIP of loose files — KNOWN_UNSUPPORTED (no OOXML member)."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("readme.txt", "hello")
+        zf.writestr("inner/data.csv", "a,b,c")
+    return buf.getvalue()
+
+
+def _docx_zip() -> bytes:
+    """A minimal docx — a ZIP carrying a ``word/`` member."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("word/document.xml", "<w:document>real docx body text here</w:document>")
+        zf.writestr("[Content_Types].xml", "<Types/>")
+    return buf.getvalue()
+
+
+def test_known_unsupported_item_is_skipped_not_dead_lettered(tmp_path: Path) -> None:
+    """A true-archive ZIP is recorded skipped_unsupported, lands no chunks, and is NOT dead-lettered."""
+    db = sqlite3.connect(str(tmp_path / "skip.sqlite"))
+    create_schema(db)
+    chunk_writer = FakeChunkWriter()
+    pipeline = _build_pipeline(db, chunk_writer)
+
+    archive = _true_archive_zip()
+    connector = FakeSourceConnector(
+        name="sharepoint-like",
+        events=[
+            ChangeEvent(
+                op="created",
+                item_id="bundle-1",
+                modified_at="2026-06-01T10:00:00Z",
+                metadata={"name": "bundle.zip", "mime": "application/zip"},
+            )
+        ],
+        content={"bundle-1": archive},
+        cursor_token="cursor-skip-1",
+    )
+
+    result = pipeline.run_batch(connector, FakeExtractor())
+
+    # Consumed (cursor advances), NOT dead-lettered.
+    assert result.processed == 1
+    assert result.dead_lettered == 0
+    assert _deadletter_count(db, "bundle-1") == 0
+
+    # Zero chunks landed (skip is pre-extract — upsert was never called).
+    assert chunk_writer.writes == []
+
+    # documents_media records the pre-extract skip status.
+    rows = _media_rows(db)
+    assert len(rows) == 1, f"expected one outcome row; got {rows!r}"
+    assert rows[0]["extraction_status"] == "skipped_unsupported"
+    assert rows[0]["path"] == "bundle-1"
+
+
+def test_docx_as_application_zip_is_routed_to_extraction(tmp_path: Path) -> None:
+    """A docx mislabeled application/zip is NOT skipped — the corrected MIME reaches the extractor."""
+    db = sqlite3.connect(str(tmp_path / "docx.sqlite"))
+    create_schema(db)
+    chunk_writer = FakeChunkWriter()
+    pipeline = _build_pipeline(db, chunk_writer)
+
+    docx = _docx_zip()
+    extractor = FakeExtractor()
+    connector = FakeSourceConnector(
+        name="sharepoint-like",
+        events=[
+            ChangeEvent(
+                op="created",
+                item_id="report-1",
+                modified_at="2026-06-01T11:00:00Z",
+                metadata={"name": "report", "mime": "application/zip"},
+            )
+        ],
+        content={"report-1": docx},
+        cursor_token="cursor-docx-1",
+    )
+
+    result = pipeline.run_batch(connector, extractor)
+
+    # NOT skipped, NOT dead-lettered — it flowed end-to-end.
+    assert result.processed == 1
+    assert result.dead_lettered == 0
+    assert _deadletter_count(db, "report-1") == 0
+
+    # The extractor was called WITH the compat-corrected OOXML MIME, not
+    # the mislabeled application/zip the connector handed over.
+    assert len(extractor.extract_calls) == 1
+    _called_bytes, called_mime = extractor.extract_calls[0]
+    assert called_mime == _MIME_DOCX
+
+    # Chunks landed and the row records a normal 'ok' extraction.
+    assert any(len(batch) > 0 for batch in chunk_writer.writes)
+    rows = _media_rows(db)
+    assert len(rows) == 1
+    assert rows[0]["extraction_status"] == "ok"
+
+
+def test_mime_only_known_unsupported_item_is_skipped_not_dead_lettered(tmp_path: Path) -> None:
+    """A legacy .doc skipped on the MIME signal alone (no magic bytes) → skipped_unsupported.
+
+    Distinct from the magic-byte skip test above: here the payload is an
+    OLE2 ``.doc`` whose leading bytes (``\\xd0\\xcf\\x11\\xe0``) are NOT
+    in the classifier's magic-byte set, so the magic branch is a no-op
+    and the skip MUST come from the ``application/msword`` MIME — driving
+    the MIME-driven gate end-to-end through the real pipeline.
+    """
+    db = sqlite3.connect(str(tmp_path / "msword.sqlite"))
+    create_schema(db)
+    chunk_writer = FakeChunkWriter()
+    pipeline = _build_pipeline(db, chunk_writer)
+
+    # OLE2 / Compound File Binary header — the real legacy .doc magic,
+    # which the compat classifier does NOT recognise (so no magic-byte
+    # short-circuit); the skip must therefore come from the MIME.
+    ole2_doc = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1" + b"legacy binary office payload" * 4
+    connector = FakeSourceConnector(
+        name="sharepoint-like",
+        events=[
+            ChangeEvent(
+                op="created",
+                item_id="legacy-1",
+                modified_at="2026-06-01T12:00:00Z",
+                metadata={"name": "legacy", "mime": "application/msword"},
+            )
+        ],
+        content={"legacy-1": ole2_doc},
+        mime_overrides={"legacy-1": "application/msword"},
+        cursor_token="cursor-msword-1",
+    )
+
+    extractor = FakeExtractor()
+    result = pipeline.run_batch(connector, extractor)
+
+    # Consumed (cursor advances), NOT dead-lettered, extractor NEVER ran.
+    assert result.processed == 1
+    assert result.dead_lettered == 0
+    assert _deadletter_count(db, "legacy-1") == 0
+    assert extractor.extract_calls == []
+
+    # Zero chunks landed (skip is pre-extract).
+    assert chunk_writer.writes == []
+
+    # documents_media records the pre-extract skip status — proving the
+    # MIME branch (not the magic-byte branch) drove the skip.
+    rows = _media_rows(db)
+    assert len(rows) == 1, f"expected one outcome row; got {rows!r}"
+    assert rows[0]["extraction_status"] == "skipped_unsupported"
+    assert rows[0]["path"] == "legacy-1"

--- a/tests/unit/test_connector_compat.py
+++ b/tests/unit/test_connector_compat.py
@@ -1,0 +1,235 @@
+"""Unit tests for the pre-extract compatibility classifier.
+
+Covers every branch of
+:func:`kairix.core.connectors.compat.classify_compat`:
+
+* magic-byte signals (PDF / images / ZIP-family);
+* OOXML-from-ZIP disambiguation (docx/pptx/xlsx → SUPPORTED + corrected
+  ``effective_mime``);
+* true-archive ZIP and corrupt ZIP → KNOWN_UNSUPPORTED;
+* MIME-driven SUPPORTED / KNOWN_UNSUPPORTED;
+* extension tiebreak (KNOWN_UNSUPPORTED-only, never an upgrade);
+* the generic octet-stream → UNKNOWN fall-through that preserves
+  today's extract-anyway behaviour.
+
+F8 carries ``@pytest.mark.unit``.
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+
+import pytest
+
+from kairix.core.connectors.compat import (
+    Compat,
+    CompatResult,
+    classify_compat,
+)
+
+pytestmark = pytest.mark.unit
+
+_MIME_DOCX = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+_MIME_PPTX = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+_MIME_XLSX = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+
+
+def _ooxml_zip(member_dir: str) -> bytes:
+    """Build a tiny in-memory ZIP carrying one OOXML tell-tale member."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr(f"{member_dir}/main.xml", "<xml/>")
+        zf.writestr("[Content_Types].xml", "<xml/>")
+    return buf.getvalue()
+
+
+def _loose_zip() -> bytes:
+    """A valid ZIP of loose files — a true archive, no OOXML member."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("readme.txt", "hello")
+        zf.writestr("data/values.csv", "a,b,c")
+    return buf.getvalue()
+
+
+# --- magic bytes -----------------------------------------------------------
+
+
+def test_pdf_magic_on_octet_stream_is_supported() -> None:
+    """``%PDF`` magic beats a generic octet-stream MIME → SUPPORTED."""
+    result = classify_compat("application/octet-stream", "report", b"%PDF-1.7\n%trailer junk")
+    assert result == CompatResult(Compat.SUPPORTED, "application/octet-stream")
+
+
+@pytest.mark.parametrize(
+    "head",
+    [
+        b"\x89PNG\r\n\x1a\n",  # PNG
+        b"\xff\xd8\xff\xe0",  # JPEG (JFIF)
+        b"GIF87a",  # GIF (legacy)
+        b"GIF89a",  # GIF (modern)
+    ],
+)
+def test_image_magic_is_supported(head: bytes) -> None:
+    """Common raster-image magics → SUPPORTED (the OCR extractor claims them)."""
+    result = classify_compat("application/octet-stream", "image", head + b"\x00\x01\x02payload")
+    assert result.compat is Compat.SUPPORTED
+
+
+def test_docx_zip_labeled_application_zip_is_supported_with_corrected_mime() -> None:
+    """A docx ZIP mislabeled application/zip → SUPPORTED + corrected effective_mime."""
+    data = _ooxml_zip("word")
+    result = classify_compat("application/zip", "monthly-report", data)
+    assert result.compat is Compat.SUPPORTED
+    assert result.effective_mime == _MIME_DOCX
+
+
+def test_pptx_zip_is_supported_with_corrected_mime() -> None:
+    data = _ooxml_zip("ppt")
+    result = classify_compat("application/octet-stream", "deck", data)
+    assert result.compat is Compat.SUPPORTED
+    assert result.effective_mime == _MIME_PPTX
+
+
+def test_xlsx_zip_is_supported_with_corrected_mime() -> None:
+    data = _ooxml_zip("xl")
+    result = classify_compat("application/octet-stream", "sheet", data)
+    assert result.compat is Compat.SUPPORTED
+    assert result.effective_mime == _MIME_XLSX
+
+
+def test_loose_zip_is_known_unsupported() -> None:
+    """A true archive (valid ZIP, no OOXML member) → KNOWN_UNSUPPORTED (skip archives)."""
+    data = _loose_zip()
+    result = classify_compat("application/zip", "bundle.zip", data)
+    assert result.compat is Compat.KNOWN_UNSUPPORTED
+    # MIME is NOT corrected for a non-OOXML ZIP.
+    assert result.effective_mime == "application/zip"
+
+
+def test_corrupt_zip_magic_is_known_unsupported() -> None:
+    """PK magic that is NOT a parseable ZIP (corrupt) → KNOWN_UNSUPPORTED."""
+    result = classify_compat("application/octet-stream", "x", b"PK\x03\x04" + b"not-a-real-zip" * 4)
+    assert result.compat is Compat.KNOWN_UNSUPPORTED
+    assert result.effective_mime == "application/octet-stream"
+
+
+def test_truncated_zip_magic_does_not_raise() -> None:
+    """A truncated ZIP (malformed central directory) must NOT raise.
+
+    ``zipfile.ZipFile`` can raise ``struct.error`` (not just
+    ``BadZipFile``) on a truncated / malformed central directory — a
+    common shape for partially-downloaded SharePoint files. The
+    classifier is a pre-extract gate whose contract is totality: any
+    failure to read the container ⇒ KNOWN_UNSUPPORTED, never an escape.
+    """
+    truncated = b"PK\x03\x04" + b"\x14\x00\x00\x00\x00\x00" + b"\x00" * 100
+    result = classify_compat("application/octet-stream", "x.zip", truncated)
+    assert result.compat is Compat.KNOWN_UNSUPPORTED
+
+
+def test_bare_pk_magic_only_does_not_raise() -> None:
+    """Just the 4-byte PK signature with no body ⇒ KNOWN_UNSUPPORTED (no raise)."""
+    result = classify_compat("application/octet-stream", "x.zip", b"PK\x03\x04")
+    assert result.compat is Compat.KNOWN_UNSUPPORTED
+
+
+def test_empty_bytes_does_not_raise() -> None:
+    """Zero-length payload (no magic at all) ⇒ UNKNOWN, never an escape."""
+    result = classify_compat("application/octet-stream", "x.zip", b"")
+    assert result.compat is Compat.UNKNOWN
+
+
+# --- MIME-driven -----------------------------------------------------------
+
+
+def test_text_markdown_mime_is_supported() -> None:
+    result = classify_compat("text/markdown", "note.md", b"# heading\n\nbody")
+    assert result == CompatResult(Compat.SUPPORTED, "text/markdown")
+
+
+def test_text_prefix_any_subtype_is_supported() -> None:
+    """The ``text/*`` prefix mirrors the passthrough extractor's rule."""
+    result = classify_compat("text/x-rst", "doc.rst", b"some restructured text")
+    assert result.compat is Compat.SUPPORTED
+
+
+def test_pdf_mime_without_magic_is_supported() -> None:
+    """A declared application/pdf MIME (no magic in the sniffed head) is SUPPORTED."""
+    result = classify_compat("application/pdf", "doc.pdf", b"corrupt-no-magic-but-declared")
+    assert result.compat is Compat.SUPPORTED
+
+
+def test_visio_mime_is_known_unsupported() -> None:
+    """Visio (no extractor) → KNOWN_UNSUPPORTED via the MIME prefix."""
+    result = classify_compat("application/vnd.ms-visio.drawing", "diagram", b"binary-visio-bytes")
+    assert result == CompatResult(Compat.KNOWN_UNSUPPORTED, "application/vnd.ms-visio.drawing")
+
+
+def test_legacy_binary_office_mime_is_known_unsupported() -> None:
+    """Legacy binary .doc (application/msword) → KNOWN_UNSUPPORTED."""
+    result = classify_compat("application/msword", "legacy.doc", b"\xd0\xcf\x11\xe0 ole2 header")
+    assert result.compat is Compat.KNOWN_UNSUPPORTED
+
+
+def test_odf_mime_prefix_is_known_unsupported() -> None:
+    result = classify_compat("application/vnd.oasis.opendocument.text", "doc.odt", b"random-odf-bytes")
+    assert result.compat is Compat.KNOWN_UNSUPPORTED
+
+
+def test_msdownload_mime_is_known_unsupported() -> None:
+    result = classify_compat("application/x-msdownload", "tool", b"MZ binary header")
+    assert result.compat is Compat.KNOWN_UNSUPPORTED
+
+
+# --- extension tiebreak ----------------------------------------------------
+
+
+def test_known_unsupported_extension_demotes_unknown_to_skip() -> None:
+    """An octet-stream with NO decisive magic but a .exe name → KNOWN_UNSUPPORTED."""
+    result = classify_compat("application/octet-stream", "installer.exe", b"MZ\x90\x00 random")
+    assert result.compat is Compat.KNOWN_UNSUPPORTED
+
+
+@pytest.mark.parametrize("ext", [".dll", ".vsd", ".vsdx", ".msg", ".odt", ".ods", ".odp", ".pub"])
+def test_each_known_unsupported_extension_demotes(ext: str) -> None:
+    result = classify_compat("application/octet-stream", f"file{ext}", b"opaque-bytes-no-magic")
+    assert result.compat is Compat.KNOWN_UNSUPPORTED
+
+
+def test_extension_never_upgrades_to_supported() -> None:
+    """A .pdf NAME on octet-stream bytes with no PDF magic must NOT become SUPPORTED.
+
+    The extension signal is a KNOWN_UNSUPPORTED-only tiebreak — it can
+    demote but never upgrade. Lacking magic/MIME, this stays UNKNOWN so
+    extraction still gets a chance.
+    """
+    result = classify_compat("application/octet-stream", "mystery.pdf", b"not-a-pdf-no-magic")
+    assert result.compat is Compat.UNKNOWN
+
+
+# --- fall-through ----------------------------------------------------------
+
+
+def test_plain_octet_stream_no_magic_is_unknown() -> None:
+    """Generic octet-stream, no magic / unknown extension → UNKNOWN (extract anyway)."""
+    result = classify_compat("application/octet-stream", "mystery", b"some opaque payload bytes")
+    assert result == CompatResult(Compat.UNKNOWN, "application/octet-stream")
+
+
+def test_unrecognised_mime_no_signals_is_unknown() -> None:
+    result = classify_compat("application/x-weird-thing", "data", b"opaque")
+    assert result.compat is Compat.UNKNOWN
+
+
+def test_empty_name_falls_back_to_magic_and_mime_only() -> None:
+    """A missing filename (connector didn't surface ``name``) is tolerated."""
+    result = classify_compat("application/octet-stream", "", b"%PDF-1.4 body")
+    assert result.compat is Compat.SUPPORTED
+
+
+def test_empty_bytes_octet_stream_is_unknown() -> None:
+    """Zero-length payload with a generic MIME → UNKNOWN (no signal at all)."""
+    result = classify_compat("application/octet-stream", "empty", b"")
+    assert result.compat is Compat.UNKNOWN


### PR DESCRIPTION
## Why

On the Customer-Zero VM the SharePoint connector had **455 dead-lettered items (85 poisoned)** — mostly binaries SharePoint serves with a stripped/generic `Content-Type`. Today the pipeline calls `extractor.extract()` with **no pre-check**, so every unprocessable binary funnels through extraction, fails, retries, and poisons the dead-letter queue. Conversely, Office docs that arrive as `application/octet-stream` (Graph dropped the type) are wrongly treated as unextractable.

## What

A pure, total **compatibility classifier** + a **pre-extract skip gate** in the ingestion hot path.

### `kairix/core/connectors/compat.py` (new)
`classify_compat(mime, name, data) -> CompatResult(compat, effective_mime)` with a 3-way taxonomy:
- **Magic bytes first** (`%PDF`, PNG/JPEG/GIF, `PK\x03\x04`). For zips, peek the central directory: `word/`/`ppt/`/`xl/` → **OOXML disambiguation** (corrects `effective_mime` so a docx-as-octet-stream routes to the docx extractor); a true archive or unreadable zip → `KNOWN_UNSUPPORTED`. The zip open is **total** (catches `BadZipFile`, `struct.error`, anything) so a truncated/partial download can never crash the batch.
- **MIME** next (text/*, pdf, OOXML, images → SUPPORTED; legacy `.doc`/`.ppt`/`.xls`, Visio, ODF, Publisher, executables → KNOWN_UNSUPPORTED).
- **Extension** as a demote-only tiebreak (never upgrades to SUPPORTED).
- Unrecognized/generic octet-stream → `UNKNOWN` (falls through to extraction — preserves today's behaviour for mislabeled-but-valid files).

### Pre-extract gate (`pipeline.py`)
Between the bronze write and `extractor.extract`, classify using the full bytes + `change.metadata["name"]`:
- `KNOWN_UNSUPPORTED` → write a `documents_media` outcome with the new `skipped_unsupported` status and return a **consumed** outcome — never calls `extract`, never calls `dead_letter.record`, lands no chunks. The item never poisons; the cursor advances.
- OOXML disambiguation → extract with the corrected MIME.
- `SUPPORTED`/`UNKNOWN` → unchanged path (non-SharePoint connectors are byte-for-byte unaffected).

`skipped_unsupported` is distinct from `unsupported` (which means "extracted but low quality, chunks landed"). Free-text column — **no schema migration**; added to `_ALLOWED_EXTRACTION_STATUSES`.

## Tests
- Unit: every taxonomy branch incl. truncated/empty/bare-PK zips (totality), OOXML-as-zip disambiguation, MIME-driven skip, extension demote-only.
- Integration (real factory-built pipeline): a `KNOWN_UNSUPPORTED` item is recorded `skipped_unsupported`, lands no chunks, creates **no dead-letter**; a docx-as-`application/zip` is routed to extraction; a MIME-only `application/msword` (OLE2, no magic) is skipped via the MIME branch.
- **37 new + 129 regression pass; ruff + mypy clean; arch-fitness gate passes (F16/F17 clean).**

## Scope notes
- True ZIP archives are skipped (member-expansion deferred). `.msg`/Visio/ODF/Publisher are skipped as unsupported here; a follow-up **gotenberg conversion tier** will make Office/Visio/ODF indexable. A separate follow-up auto-drains the existing 455 backlog using these skip semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)