### PR TITLE
feat(extractors): gotenberg conversion tier (Office/Visio/ODF → PDF → indexable)

### DIFF
--- a/docker-compose.gotenberg.yml
+++ b/docker-compose.gotenberg.yml
@@ -1,0 +1,50 @@
+# Kairix — optional gotenberg document-conversion override.
+#
+# The base docker-compose.yml is an intentional 2-service shape (kairix +
+# neo4j). gotenberg is a SEPARATELY-MANAGED deployment concern, so it lives
+# here as an override you layer on only when you want the conversion tier
+# locally:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.gotenberg.yml up -d
+#
+# In a VM deployment, gotenberg typically runs from the deployment compose
+# (its own managed service) rather than this file.
+#
+# The ``gotenberg`` extractor tier POSTs Office/ODF/Visio/Publisher/RTF
+# files here to convert them to PDF, then re-enters pdf_fallback — making
+# those legacy/uncommon formats indexable instead of dead-lettering. Modern
+# OOXML (.docx / .pptx / .xlsx) is handled in-process by markitdown / pptx /
+# docx / xlsx and does NOT need gotenberg. Wire the tier via a connector's
+# ``extractor_chain: [markitdown, pdf_fallback, gotenberg, ocr]`` (see
+# kairix.config.example.yaml).
+#
+# IMPORTANT: kairix deliberately does NOT ``depends_on`` gotenberg. The
+# extractor degrades gracefully — when gotenberg is absent or unhealthy it
+# RAISES and the escalation chain falls through to ocr / dead-letters for
+# retry — so a fresh ``docker compose up`` (base file only) reaches a healthy
+# kairix /healthz without blocking on this optional service.
+#
+# Other compose services reach it by its DNS name (http://gotenberg:3000).
+
+services:
+  gotenberg:
+    image: gotenberg/gotenberg:8
+    # Pin a digest for production reproducibility.
+    restart: unless-stopped
+    # Bound to localhost only by default — gotenberg has no auth. Other
+    # compose services reach it by its DNS name (http://gotenberg:3000);
+    # this published port is for host-side debugging only.
+    ports:
+      - "127.0.0.1:3000:3000"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:3000/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+    # Conversion is CPU + memory bursty (LibreOffice spawns per request);
+    # cap it so a pathological document can't OOM the host.
+    deploy:
+      resources:
+        limits:
+          memory: 2g

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,16 @@
 #            shows 2 services (was 3) — `kairix-worker` is gone; its workload
 #            and memory budget folded into the unified `kairix` service.
 #   neo4j  — knowledge graph for people / company / relationship queries.
+#
+# This base file is an INTENTIONAL 2-service shape (kairix + neo4j). The
+# optional document-conversion service (gotenberg) is a separately-managed
+# deployment concern — it lives in docker-compose.gotenberg.yml as an
+# override so the base stack stays minimal and a fresh `docker compose up`
+# never blocks on it. The gotenberg extractor tier degrades gracefully when
+# the service is absent (it RAISES and the escalation chain falls through to
+# ocr / dead-letters for retry). To run it for local dev, layer the override:
+#   docker compose -f docker-compose.yml -f docker-compose.gotenberg.yml up -d
+# (or run gotenberg via the deployment compose). See kairix.config.example.yaml.
 
 services:
   kairix:

--- a/kairix.config.example.yaml
+++ b/kairix.config.example.yaml
@@ -221,6 +221,39 @@ topology_v2:
       kind: sharepoint
       name: "Corporate SharePoint Document Library"
       default_sensitivity: internal
+      # ── Extraction escalation chain (optional) ─────────────────────
+      # By default each connector uses a single ``extractor`` (markitdown
+      # for rich documents). Set ``extractor_chain`` instead to opt into
+      # the escalation chain: each tier is tried in order, falling through
+      # to the next when a tier declines the mime or its ``quality_ok``
+      # gate fails. The ``gotenberg`` tier converts the formats neither
+      # markitdown nor pdf_fallback recover natively — legacy .doc / .xls
+      # / .ppt, the OpenDocument family, Visio, Publisher, and RTF — to
+      # PDF via the gotenberg HTTP service, then re-enters pdf_fallback.
+      # NOTE: modern OOXML (.docx / .pptx / .xlsx) is handled IN-PROCESS by
+      # the markitdown / pptx / docx / xlsx tiers and does NOT need
+      # gotenberg — the gotenberg tier deliberately refuses those mimes so
+      # it never shadows a working in-process extractor.
+      # A gotenberg outage RAISES so the chain escalates to ocr (and, if
+      # every tier fails, the item dead-letters for retry) rather than
+      # silently skipping. Requires a reachable gotenberg service — run it
+      # as a separately-managed service reachable at http://gotenberg:3000
+      # (e.g. the deployment compose, or locally via
+      # ``docker compose -f docker-compose.yml -f docker-compose.gotenberg.yml up``).
+      #
+      # extractor_chain: [markitdown, pdf_fallback, gotenberg, ocr]
+      # extractor_chain_configs:
+      #   gotenberg:
+      #     # Per-member kwargs are passed to make_extractor(**kwargs).
+      #     # The gotenberg factory takes a single ``config`` mapping;
+      #     # unset fields fall back to the KAIRIX_GOTENBERG_* env vars
+      #     # (KAIRIX_GOTENBERG_URL / _TIMEOUT_S / _MAX_FILE_SIZE_MB) and
+      #     # then to the built-in defaults.
+      #     config:
+      #       gotenberg_url: "http://gotenberg:3000"  # compose service DNS name
+      #       timeout_s: 60.0
+      #       max_file_size_mb: 256
+      #
       # For SharePoint: the Graph drive id. Until ``kairix sharepoint
       # discover`` lands (KFEAT-022), enumerate drives via
       # ``az rest --method get --url 'https://graph.microsoft.com/v1.0/sites?search=*'``

--- a/kairix/extractors/gotenberg/__init__.py
+++ b/kairix/extractors/gotenberg/__init__.py
@@ -1,0 +1,110 @@
+"""gotenberg extractor plugin — Office/ODF/Visio/Publisher/RTF → PDF conversion tier.
+
+Converts the formats neither ``markitdown`` nor ``pdf_fallback`` can
+recover (legacy ``.doc`` / ``.xls`` / ``.ppt``, the OpenDocument
+family, Visio drawings, Microsoft Publisher, RTF) to PDF via the
+`gotenberg <https://gotenberg.dev>`_ HTTP service, then routes the
+converted PDF back through the registered ``pdf_fallback`` extractor so
+the document inherits its table extraction + per-page chunks. Adapts the
+conversion to the :class:`kairix.extractors.Extractor` Protocol.
+
+The plugin sits between ``pdf_fallback`` and ``ocr`` in the escalation
+chain wired by the orchestrator at pipeline-config time::
+
+    markitdown   (default)
+        ↓ can_extract = False (not a format it claims)
+    pdf_fallback (pdfplumber — claims only PDFs)
+        ↓ can_extract = False (the source is a .doc / .odt / .vsdx)
+    gotenberg    (this plugin — convert-then-re-enter pdf_fallback)
+        ↓ extract raised (gotenberg outage / 4xx)
+    ocr          (Tesseract for image-only PDFs)
+
+When gotenberg is unreachable / times out / returns an empty or 4xx
+response, :meth:`extract` RAISES so the chain escalates to ``ocr`` and,
+on exhaustion, the item dead-letters for retry — a transient gotenberg
+outage is never a silent skip.
+
+The plugin is discovered by the extractor registry through the
+``[project.entry-points."kairix.extractors"]`` table in kairix's
+``pyproject.toml``. ``httpx`` (the HTTP client) and ``tenacity`` (the
+retry primitive) are both base kairix dependencies, so no optional
+extra is required — the plugin only needs a reachable gotenberg service
+at convert time.
+
+.. code-block:: python
+
+   from kairix.core.connectors.registry import build_extractor_from_entry
+
+   chain = build_extractor_from_entry(
+       {
+           "extractor_chain": ["markitdown", "pdf_fallback", "gotenberg", "ocr"],
+           "extractor_chain_configs": {
+               "gotenberg": {"config": {"gotenberg_url": "http://gotenberg:3000"}},
+           },
+       }
+   )
+
+Spec ref: ``docs/architecture/connector-ingestion-architecture.md`` §2
++ §3 + §4 and PR-3.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from kairix.extractors import Extractor
+from kairix.extractors.gotenberg.extractor import (
+    PLUGIN_NAME,
+    GotenbergExtractor,
+    GotenbergExtractorConfig,
+)
+
+#: F40-mandated module-level version. Pinned to a literal so the F40 AST
+#: detector sees a constant string assignment — re-extraction sweeps
+#: trigger off this deterministic identifier. Bump when the conversion
+#: behaviour changes (gotenberg route / LibreOffice fidelity shift) so
+#: ``documents_media.extractor_version`` flags affected derivatives.
+version: str = "1.0.0"
+
+
+def make_extractor(*, config: GotenbergExtractorConfig | dict[str, Any] | None = None) -> Extractor:
+    """Construct the gotenberg :class:`Extractor` for entry-point discovery.
+
+    When ``config`` is ``None``, the gotenberg URL / timeout / size
+    ceiling default to their literals unless the operator has set the
+    ``KAIRIX_GOTENBERG_*`` env vars — those are read at the F4 boundary
+    (:func:`kairix.paths.gotenberg_extractor_config`) so this module
+    never touches ``os.environ`` directly. Operators override per
+    connector via ``extractor_chain_configs.gotenberg.config``.
+
+    The registry resolves per-member YAML and calls this factory as
+    ``make_extractor(**{"config": {"gotenberg_url": ...}})`` — i.e.
+    ``config`` arrives as a raw ``dict``, not a
+    :class:`GotenbergExtractorConfig`. Coerce it here so the documented
+    ``extractor_chain_configs.gotenberg.config`` YAML produces a real
+    config object (otherwise the first ``extract`` raises
+    ``AttributeError`` on ``self._config.max_file_size_mb``).
+
+    The converted PDF re-enters the registered ``pdf_fallback`` tier,
+    lazy-resolved via the registry on first ``extract`` (tests inject a
+    fake ``pdf_extractor=`` instead).
+    """
+    resolved: GotenbergExtractorConfig
+    if config is None:
+        from kairix.paths import gotenberg_extractor_config
+
+        resolved = gotenberg_extractor_config()
+    elif isinstance(config, dict):
+        resolved = GotenbergExtractorConfig(**config)
+    else:
+        resolved = config
+    return GotenbergExtractor(version=version, config=resolved)
+
+
+__all__ = [
+    "PLUGIN_NAME",
+    "GotenbergExtractor",
+    "GotenbergExtractorConfig",
+    "make_extractor",
+    "version",
+]

--- a/kairix/extractors/gotenberg/extractor.py
+++ b/kairix/extractors/gotenberg/extractor.py
@@ -1,0 +1,407 @@
+"""gotenberg-backed conversion tier — Office/ODF/Visio/Publisher/RTF → PDF (PR-3).
+
+Office binary formats (legacy ``.doc`` / ``.xls`` / ``.ppt``), the
+OpenDocument family (``.odt`` / ``.ods`` / ``.odp`` / ``.odg``), Visio
+drawings, Microsoft Publisher, and RTF are not natively recoverable by
+the ``markitdown`` / ``pdf_fallback`` tiers — they would dead-letter.
+This extractor converts them to PDF via the `gotenberg
+<https://gotenberg.dev>`_ HTTP service (LibreOffice under the hood),
+then routes the converted PDF back through the registered
+``pdf_fallback`` extractor so the document inherits its table
+extraction, per-page :class:`Page` objects, and metadata.
+
+It is wired as an escalation tier between ``pdf_fallback`` and ``ocr``::
+
+    markitdown   (default)
+        ↓ quality_ok = False / can_extract = False
+    pdf_fallback (pdfplumber, table-aware)
+        ↓ can_extract = False (not a PDF)
+    gotenberg    (this plugin — convert-then-re-enter pdf_fallback)
+        ↓ extract raised (gotenberg outage / 4xx)
+    ocr          (Tesseract for image-only PDFs)
+
+Design choice (spec §"Decline vs raise"): :meth:`can_extract` returns
+``False`` for mimes NOT in :data:`_GOTENBERG_MIMES` — crucially PDF /
+text / ``application/octet-stream`` — so this tier never shadows the
+PDF-native or passthrough tiers. When gotenberg is **unreachable**,
+**times out**, returns an **empty body**, or returns a **4xx/5xx**,
+:meth:`extract` RAISES (so the escalation orchestrator falls through to
+``ocr`` and, if every tier fails, the item dead-letters for retry). A
+transient gotenberg outage must stay retryable, never a silent skip.
+
+Spec ref: ``docs/architecture/connector-ingestion-architecture.md`` §2
+("extractors tree"), §3 ("Extractor Protocol"), §4 ("Three failures map
+to three behaviours") for ``quality_ok`` semantics, and PR-3.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import httpx
+from tenacity import (
+    RetryError,
+    Retrying,
+    retry_if_result,
+    stop_after_attempt,
+    wait_exponential,
+)
+from tenacity.wait import wait_base
+
+from kairix.core.protocols import SourceMetadata
+from kairix.extractors import (
+    ExtractedDocument,
+    Extractor,
+    MimeType,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Canonical plugin name surfaced by the extractor registry.
+PLUGIN_NAME = "gotenberg"
+
+#: Name of the registered extractor the converted PDF re-enters. Lazy-
+#: resolved via the registry so the chain wiring stays declarative.
+_PDF_TIER_NAME = "pdf_fallback"
+
+#: IANA mime claimed by the PDF tier the converted bytes route through.
+_PDF_MIME = "application/pdf"
+
+#: PDF magic header (``%PDF``) — gotenberg must hand us a real PDF back.
+_MAGIC_PDF = b"%PDF"
+
+#: Minimum decoded-markdown length the tier treats as "quality ok".
+#: Mirrors ``pdf_fallback``'s 100-char floor (spec §10 escalation gate)
+#: so a converted-then-extracted document escalates to ``ocr`` on the
+#: same condition a native PDF would.
+_QUALITY_MIN_CHARS = 100
+
+#: Default gotenberg base URL — the laptop / single-VM compose service.
+_DEFAULT_GOTENBERG_URL = "http://localhost:3000"
+#: Default per-convert deadline (seconds). LibreOffice conversion of a
+#: large deck can take tens of seconds; the gate is configurable.
+_DEFAULT_TIMEOUT_S = 60.0
+#: Default size ceiling (MiB). Files above this are rejected BEFORE the
+#: HTTP call so a pathological upload never reaches gotenberg.
+_DEFAULT_MAX_FILE_SIZE_MB = 256
+
+#: Retry budget for transient gotenberg responses (429 / 5xx). Mirrors
+#: the dex_crm client's 4-attempt exponential-backoff convention.
+_MAX_RETRIES = 4
+#: Exponential-backoff base (seconds) for the retry loop.
+_BACKOFF_BASE_S = 1.0
+
+#: gotenberg LibreOffice conversion route, appended to the base URL.
+_CONVERT_ROUTE = "/forms/libreoffice/convert"
+#: Multipart form field name gotenberg expects the upload under.
+_FORM_FIELD = "files"
+
+#: Error-message prefix shared by every raise path (F17 — one literal).
+_ERR_PREFIX = "gotenberg: "
+
+#: Shared "what happens next" tail on every convert-failure raise path —
+#: a single literal so the three raise sites can't drift (F17 / S1192).
+_NEXT_ESCALATES = "next: the item escalates to ocr / dead-letters for retry."
+
+#: Legacy-Office / ODF / Visio / Publisher / RTF mimes this tier claims.
+#: PDF / text / ``application/octet-stream`` AND the modern OOXML mimes
+#: (.docx / .pptx / .xlsx) are deliberately ABSENT so the tier never
+#: shadows pdf_fallback / passthrough or the in-process OOXML extractors.
+_MS_WORD = "application/msword"
+_MS_EXCEL = "application/vnd.ms-excel"
+_MS_POWERPOINT = "application/vnd.ms-powerpoint"
+_ODF_PREFIX = "application/vnd.oasis.opendocument."
+
+#: Modern OOXML (.docx / .pptx / .xlsx + their macro / template variants)
+#: are deliberately ABSENT: the in-process ``markitdown`` / ``pptx`` /
+#: ``docx`` / ``xlsx`` tiers handle those natively, so claiming them here
+#: would shadow a working extractor and (when gotenberg's HTTP service is
+#: absent) dead-letter a document that would otherwise index in-process.
+_GOTENBERG_MIMES: frozenset[str] = frozenset(
+    {
+        # Legacy Microsoft Office binary formats (no in-process extractor).
+        _MS_WORD,
+        _MS_EXCEL,
+        _MS_POWERPOINT,
+        # OpenDocument family (text / spreadsheet / presentation / graphics).
+        _ODF_PREFIX + "text",
+        _ODF_PREFIX + "spreadsheet",
+        _ODF_PREFIX + "presentation",
+        _ODF_PREFIX + "graphics",
+        # Microsoft Visio.
+        "application/vnd.ms-visio.drawing",
+        "application/vnd.ms-visio.drawing.macroenabled.12",
+        "application/vnd.visio",
+        # Microsoft Publisher.
+        "application/x-mspublisher",
+        # Rich Text Format.
+        "application/rtf",
+        "text/rtf",
+    }
+)
+
+#: Per-mime upload filename extension — gotenberg sniffs the format from
+#: the filename it receives, so we hand it the right suffix.
+_MIME_TO_EXTENSION: dict[str, str] = {
+    _MS_WORD: ".doc",
+    _MS_EXCEL: ".xls",
+    _MS_POWERPOINT: ".ppt",
+    _ODF_PREFIX + "text": ".odt",
+    _ODF_PREFIX + "spreadsheet": ".ods",
+    _ODF_PREFIX + "presentation": ".odp",
+    _ODF_PREFIX + "graphics": ".odg",
+    "application/vnd.ms-visio.drawing": ".vsdx",
+    "application/vnd.ms-visio.drawing.macroenabled.12": ".vsdm",
+    "application/vnd.visio": ".vsd",
+    "application/x-mspublisher": ".pub",
+    "application/rtf": ".rtf",
+    "text/rtf": ".rtf",
+}
+
+#: Fallback upload filename when the mime carries no known extension —
+#: gotenberg still attempts LibreOffice format detection on the bytes.
+_DEFAULT_UPLOAD_NAME = "document.bin"
+
+
+@dataclass(frozen=True)
+class GotenbergExtractorConfig:
+    """Construction-time config for :class:`GotenbergExtractor`.
+
+    Frozen-dataclass per F42. ``gotenberg_url`` points at the conversion
+    service — defaults to the laptop / single-VM compose service; the
+    deployment compose runs it as ``http://gotenberg:3000``.
+    ``timeout_s`` is the per-convert deadline; ``max_file_size_mb`` is
+    the pre-HTTP size ceiling. Operators override any field via the
+    connector config (``extractor_chain_configs.gotenberg``); env
+    defaults flow through :func:`kairix.paths.gotenberg_extractor_config`
+    at factory time (F4 boundary).
+    """
+
+    gotenberg_url: str = _DEFAULT_GOTENBERG_URL
+    timeout_s: float = _DEFAULT_TIMEOUT_S
+    max_file_size_mb: int = _DEFAULT_MAX_FILE_SIZE_MB
+
+
+def _upload_name(mime: MimeType) -> str:
+    """Return the upload filename gotenberg should sniff the format from."""
+    suffix = _MIME_TO_EXTENSION.get(mime) if isinstance(mime, str) else None
+    return f"document{suffix}" if suffix else _DEFAULT_UPLOAD_NAME
+
+
+def _is_retryable(response: httpx.Response) -> bool:
+    """True for 429 / 5xx — transient gotenberg conditions worth retrying."""
+    code = response.status_code
+    return code == httpx.codes.TOO_MANY_REQUESTS or code >= httpx.codes.INTERNAL_SERVER_ERROR
+
+
+class GotenbergExtractor:
+    """:class:`Extractor` impl that converts Office/ODF/Visio/RTF to PDF.
+
+    The instance carries the :data:`version` declared in the package
+    ``__init__`` so the value flows from one canonical declaration site
+    (F40) through to ``documents_media.extractor_version`` on every
+    produced document.
+
+    DI seams (all kwargs with real defaults — F6 / F1 clean):
+
+      * ``config`` — :class:`GotenbergExtractorConfig`; defaults to the
+        laptop compose endpoint.
+      * ``http_client`` — :class:`httpx.Client`; defaults to a fresh
+        client built at first request. Tests pass a stand-in wired to
+        ``httpx.MockTransport`` so the suite never reaches the network.
+      * ``pdf_extractor`` — the :class:`Extractor` the converted PDF
+        re-enters. Defaults to ``None``; the real ``pdf_fallback`` tier
+        is lazy-resolved via the registry on first :meth:`extract`.
+        Tests inject a fake to assert the convert→re-enter chain.
+      * ``retry_wait`` — the tenacity wait strategy for the transient
+        (429 / 5xx) retry loop. Defaults to ``None`` → production
+        exponential backoff. Unit tests pass ``wait_none()`` so the
+        retry-budget assertion costs zero wall-clock.
+    """
+
+    def __init__(
+        self,
+        *,
+        version: str,
+        config: GotenbergExtractorConfig | None = None,
+        http_client: httpx.Client | None = None,
+        pdf_extractor: Extractor | None = None,
+        retry_wait: wait_base | None = None,
+    ) -> None:
+        """Construct the extractor with explicit ``version`` + injectable seams."""
+        self.name: str = PLUGIN_NAME
+        self.version: str = version
+        self._config = config or GotenbergExtractorConfig()
+        self._http_client = http_client
+        self._pdf_extractor = pdf_extractor
+        self._retry_wait: wait_base = retry_wait or wait_exponential(multiplier=_BACKOFF_BASE_S, exp_base=2)
+
+    def can_extract(self, mime: MimeType, _magic_bytes: bytes) -> bool:
+        """``True`` only for legacy-Office/ODF/Visio/Publisher/RTF mimes.
+
+        Claims solely by mime — these formats share container magic
+        bytes (ZIP for ODF, OLE2 for legacy Office) that can't be
+        disambiguated from the leading bytes alone, so a magic-byte
+        sniff would mis-claim. Crucially REFUSES ``application/pdf``,
+        ``text/*``, ``application/octet-stream``, AND the modern OOXML
+        mimes (.docx / .pptx / .xlsx + macro / template variants) — the
+        latter are handled in-process by the ``markitdown`` / ``pptx`` /
+        ``docx`` / ``xlsx`` tiers, so claiming them here would shadow a
+        working extractor and dead-letter when gotenberg is absent.
+
+        ``_magic_bytes`` is ``_``-prefixed (F19) — the mime allow-list
+        is the only signal consulted.
+        """
+        return isinstance(mime, str) and mime in _GOTENBERG_MIMES
+
+    def extract(self, raw: bytes, mime: MimeType) -> ExtractedDocument:
+        """Convert ``raw`` to PDF via gotenberg, then re-enter ``pdf_fallback``.
+
+        Sequence: size-gate (raise :class:`ValueError` BEFORE any HTTP
+        call) → POST the bytes to gotenberg's LibreOffice route → assert
+        a non-empty ``%PDF`` body → hand the converted PDF to the
+        ``pdf_fallback`` tier's ``extract(pdf_bytes, "application/pdf")``
+        and return its :class:`ExtractedDocument`.
+
+        Raises (so escalation falls through to ``ocr`` / the item
+        dead-letters for retry):
+
+          * :class:`ValueError` — file exceeds ``max_file_size_mb``, or
+            gotenberg returned an empty / non-PDF body.
+          * :class:`RuntimeError` — gotenberg unreachable, timed out, or
+            returned a 4xx/5xx after the retry budget.
+        """
+        self._reject_oversize(raw)
+        pdf_bytes = self._convert_to_pdf(raw, mime)
+        return self._pdf_tier().extract(pdf_bytes, _PDF_MIME)
+
+    def quality_ok(self, doc: ExtractedDocument) -> bool:
+        """Escalation gate mirroring ``pdf_fallback`` (spec §10).
+
+        Returns ``True`` only when the extracted markdown clears the
+        :data:`_QUALITY_MIN_CHARS` floor AND at least one page carries
+        non-empty text. A converted PDF that yields no text layer (e.g.
+        a Visio drawing that rasterised to images) fails the gate and
+        escalates to ``ocr``. A ``False`` here is a soft escalation
+        signal, not a hard error.
+        """
+        if len(doc.markdown) < _QUALITY_MIN_CHARS:
+            return False
+        return any(page.text.strip() for page in doc.pages)
+
+    def metadata_for(self, _raw: bytes, _mime: MimeType) -> SourceMetadata:
+        """Return empty :class:`SourceMetadata`.
+
+        ADR-021 (Wave E.5): body-level metadata for converted documents
+        is surfaced by the ``pdf_fallback`` tier the bytes re-enter (PDF
+        Info-dict extraction lands there). Stub keeps the Protocol
+        surface satisfied.
+        """
+        return SourceMetadata()
+
+    def _reject_oversize(self, raw: bytes) -> None:
+        """Raise :class:`ValueError` when ``raw`` exceeds the size ceiling.
+
+        Enforced BEFORE the HTTP call so a pathological upload never
+        reaches gotenberg (spec §"Config / env").
+        """
+        ceiling = self._config.max_file_size_mb * 1024 * 1024
+        if len(raw) > ceiling:
+            raise ValueError(
+                f"{_ERR_PREFIX}file is {len(raw)} bytes, over the "
+                f"{self._config.max_file_size_mb} MB convert ceiling. "
+                f"fix: raise extractor_chain_configs.gotenberg.max_file_size_mb "
+                f"(or KAIRIX_GOTENBERG_MAX_FILE_SIZE_MB) for this connector. "
+                f"next: oversize binaries dead-letter; review the source item."
+            )
+
+    def _convert_to_pdf(self, raw: bytes, mime: MimeType) -> bytes:
+        """POST ``raw`` to gotenberg and return the converted PDF bytes.
+
+        Retries 429 / 5xx with exponential backoff (4 attempts), then
+        raises on exhaustion. Connect / read timeouts and unreachable
+        hosts raise :class:`RuntimeError` so escalation continues.
+        """
+        response = self._send_with_retry(raw, mime)
+        pdf_bytes = response.content
+        if not pdf_bytes.startswith(_MAGIC_PDF):
+            raise ValueError(
+                f"{_ERR_PREFIX}convert returned a non-PDF / empty body "
+                f"({len(pdf_bytes)} bytes). "
+                f"fix: confirm the gotenberg service is healthy and the source "
+                f"format is one LibreOffice can open. "
+                f"{_NEXT_ESCALATES}"
+            )
+        return pdf_bytes
+
+    def _send_with_retry(self, raw: bytes, mime: MimeType) -> httpx.Response:
+        """POST the multipart upload, retrying transient gotenberg responses.
+
+        Mirrors the dex_crm client retry shape: ``tenacity`` with
+        exponential backoff on 429 / 5xx, ``reraise`` so a genuinely
+        unreachable / timing-out gotenberg surfaces a typed
+        :class:`RuntimeError` to the escalation orchestrator. Never logs
+        the gotenberg URL beyond debug (F15).
+        """
+        client = self._ensure_client()
+        url = self._config.gotenberg_url.rstrip("/") + _CONVERT_ROUTE
+        files = {_FORM_FIELD: (_upload_name(mime), raw)}
+        logger.debug("gotenberg: posting %d bytes to convert route", len(raw))
+
+        retrying = Retrying(
+            retry=retry_if_result(_is_retryable),
+            wait=self._retry_wait,
+            stop=stop_after_attempt(_MAX_RETRIES),
+            reraise=True,
+        )
+        try:
+            response = retrying(client.post, url, files=files)
+        except RetryError as exc:
+            final: httpx.Response = exc.last_attempt.result()
+            self._raise_status(final)
+            return final  # pragma: no cover — _raise_status always raises for 4xx/5xx
+        except httpx.HTTPError as exc:
+            raise RuntimeError(
+                f"{_ERR_PREFIX}convert request failed ({type(exc).__name__}). "
+                f"fix: confirm the gotenberg service is reachable and not "
+                f"overloaded; check the compose 'gotenberg' service health. "
+                f"{_NEXT_ESCALATES}"
+            ) from exc
+        self._raise_status(response)
+        return response
+
+    def _raise_status(self, response: httpx.Response) -> None:
+        """Raise :class:`RuntimeError` on a 4xx/5xx convert response.
+
+        A 4xx means LibreOffice could not open the source format; a 5xx
+        means gotenberg itself failed. Both escalate (raise) rather than
+        silently skip so the failure stays retryable.
+        """
+        if response.is_success:
+            return
+        raise RuntimeError(
+            f"{_ERR_PREFIX}convert returned HTTP {response.status_code}. "
+            f"fix: a 4xx means LibreOffice could not open this format; a 5xx "
+            f"means gotenberg failed — check the 'gotenberg' service logs. "
+            f"{_NEXT_ESCALATES}"
+        )
+
+    def _ensure_client(self) -> httpx.Client:
+        """Lazy-build the underlying ``httpx.Client`` on first use."""
+        if self._http_client is None:
+            self._http_client = httpx.Client(timeout=self._config.timeout_s)
+        return self._http_client
+
+    def _pdf_tier(self) -> Extractor:
+        """Return the ``pdf_fallback`` extractor the converted PDF re-enters.
+
+        Lazy-resolves the registered ``pdf_fallback`` factory on first
+        use (F1 seam: tests inject ``pdf_extractor=`` directly). Caches
+        the resolved instance so the registry lookup happens once.
+        """
+        if self._pdf_extractor is None:
+            from kairix.core.connectors.registry import resolve_extractor
+
+            self._pdf_extractor = resolve_extractor(_PDF_TIER_NAME)()
+        return self._pdf_extractor

--- a/kairix/paths.py
+++ b/kairix/paths.py
@@ -802,6 +802,33 @@ def read_float_env(name: str, *, default: float) -> float:
         return default
 
 
+def gotenberg_extractor_config() -> Any:
+    """Resolve the gotenberg extractor config from the ``KAIRIX_GOTENBERG_*`` env.
+
+    F4 boundary: the gotenberg extractor (``kairix/extractors/gotenberg``)
+    must not read ``os.environ`` directly, so its env defaults are
+    composed here and returned as a frozen
+    :class:`~kairix.extractors.gotenberg.GotenbergExtractorConfig`.
+    Unset vars fall back to the dataclass literals; malformed numeric
+    values log a warning and fall back too (via :func:`read_float_env`
+    / :func:`read_int_env`). The import is local so ``kairix.paths``
+    stays free of an extractor-package import at module load.
+
+    Env vars:
+      * ``KAIRIX_GOTENBERG_URL`` — conversion service base URL.
+      * ``KAIRIX_GOTENBERG_TIMEOUT_S`` — per-convert deadline (float, seconds).
+      * ``KAIRIX_GOTENBERG_MAX_FILE_SIZE_MB`` — pre-HTTP size ceiling (int, MiB).
+    """
+    from kairix.extractors.gotenberg import GotenbergExtractorConfig
+
+    defaults = GotenbergExtractorConfig()
+    return GotenbergExtractorConfig(
+        gotenberg_url=os.environ.get("KAIRIX_GOTENBERG_URL", defaults.gotenberg_url),
+        timeout_s=read_float_env("KAIRIX_GOTENBERG_TIMEOUT_S", default=defaults.timeout_s),
+        max_file_size_mb=read_int_env("KAIRIX_GOTENBERG_MAX_FILE_SIZE_MB", default=defaults.max_file_size_mb),
+    )
+
+
 def embed_vector_dims(default: int = 1536) -> int:
     """Embedding vector dimensions — configurable via ``KAIRIX_EMBED_DIMS``.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,6 +262,7 @@ ocr          = "kairix.extractors.ocr:make_extractor"
 pptx         = "kairix.extractors.pptx:make_extractor"
 docx         = "kairix.extractors.docx:make_extractor"
 xlsx         = "kairix.extractors.xlsx:make_extractor"
+gotenberg    = "kairix.extractors.gotenberg:make_extractor"
 
 # Chunker plugin discovery — same name-filtered Python entry-points
 # shape as kairix.extractors above. Per-(kind, mime) plugins live under

--- a/tests/bdd/features/e2e_connector_sync.feature
+++ b/tests/bdd/features/e2e_connector_sync.feature
@@ -29,6 +29,7 @@ Feature: End-to-end connector sync journey
       | obsidian            | pptx         |
       | obsidian            | docx         |
       | obsidian            | xlsx         |
+      | obsidian            | gotenberg    |
       | dex_crm             | passthrough  |
       | m365_email_headers  | passthrough  |
       | m365_calendar       | passthrough  |

--- a/tests/bdd/features/extractor_gotenberg.feature
+++ b/tests/bdd/features/extractor_gotenberg.feature
@@ -1,0 +1,57 @@
+@extractor @gotenberg
+Feature: Gotenberg conversion tier converts Office/ODF/Visio/RTF to PDF then re-enters pdf_fallback
+  As an operator ingesting legacy Office, OpenDocument, Visio, Publisher, and RTF files
+  I want the gotenberg extractor to claim those mime types
+  And convert them to PDF via the gotenberg HTTP service
+  And route the converted PDF back through the registered pdf_fallback extractor
+  So that formats neither markitdown nor pdf_fallback recover natively become indexable
+  instead of dead-lettering, while a transient gotenberg outage escalates (raises) for retry
+  rather than silently skipping the item.
+
+  This feature pins the PR-3 shape — gotenberg is the convert-then-re-enter
+  escalation tier wired between pdf_fallback and ocr. See
+  ``docs/architecture/connector-ingestion-architecture.md`` §2 + §3 + §4.
+
+  @happy_path
+  Scenario: Operator converts a legacy .doc via gotenberg and re-enters the pdf_fallback tier
+    Given the gotenberg extractor is registered under the name "gotenberg"
+    And the gotenberg service is configured to return a converted PDF
+    And the operator has raw bytes for a legacy office document with a doc mime
+    When the operator asks the gotenberg extractor whether it can extract the office mime
+    Then the gotenberg extractor claims the mime type
+    When the operator invokes the gotenberg extractor's extract method on the bytes
+    Then the gotenberg document carries non-empty markdown
+    And the gotenberg extractor reports quality_ok true for the produced document
+    And the gotenberg extractor's version string is non-empty
+
+  @error
+  Scenario: Gotenberg refuses a PDF mime so it never shadows the pdf_fallback tier
+    Given the gotenberg extractor is registered under the name "gotenberg"
+    When the operator asks the gotenberg extractor whether it can extract mime "application/pdf"
+    Then the gotenberg extractor does not claim the mime type
+
+  @error
+  Scenario: Gotenberg refuses a modern OOXML docx mime so it never shadows the in-process docx tier
+    Given the gotenberg extractor is registered under the name "gotenberg"
+    When the operator asks the gotenberg extractor whether it can extract mime "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    Then the gotenberg extractor does not claim the mime type
+
+  @error
+  Scenario: Gotenberg refuses a plain text mime so it never shadows passthrough
+    Given the gotenberg extractor is registered under the name "gotenberg"
+    When the operator asks the gotenberg extractor whether it can extract mime "text/plain"
+    Then the gotenberg extractor does not claim the mime type
+
+  @error
+  Scenario: Gotenberg refuses an octet-stream mime
+    Given the gotenberg extractor is registered under the name "gotenberg"
+    When the operator asks the gotenberg extractor whether it can extract mime "application/octet-stream"
+    Then the gotenberg extractor does not claim the mime type
+
+  @error
+  Scenario: A gotenberg outage raises so the chain escalates to ocr instead of silently skipping
+    Given the gotenberg extractor is registered under the name "gotenberg"
+    And the gotenberg service is unreachable
+    And the operator has raw bytes for a legacy office document with a doc mime
+    When the operator invokes the gotenberg extractor's extract method expecting a failure
+    Then the gotenberg extractor raises so the orchestrator escalates

--- a/tests/bdd/steps/extractor_gotenberg_steps.py
+++ b/tests/bdd/steps/extractor_gotenberg_steps.py
@@ -1,0 +1,191 @@
+"""Step definitions for ``extractor_gotenberg.feature`` (PR-3).
+
+Drives the real :class:`kairix.extractors.gotenberg.GotenbergExtractor`
+with two injected seams so neither the gotenberg HTTP service nor the
+real ``pdf_fallback`` library is reached:
+
+  * ``http_client`` — an :class:`httpx.Client` wired to
+    :class:`httpx.MockTransport`. The "returns a converted PDF" Given
+    serves ``%PDF`` bytes; the "unreachable" Given raises
+    :class:`httpx.ConnectError`.
+  * ``pdf_extractor`` — the canonical :class:`FakePdfFallbackExtractor`
+    the converted PDF re-enters.
+
+Production code is exercised end-to-end (the real convert → re-enter
+chain) — F1-clean (no monkeypatch), F2-clean (no env mutation).
+
+Step phrasings carry the literal phrase "gotenberg" so the global
+pytest-bdd step registry doesn't collide with the docx / markitdown /
+passthrough / pdf_fallback / ocr features' analogous Given/When/Then
+phrases.
+
+Sabotage-proof per step:
+  * "claims the mime type" — flipping ``can_extract`` to return
+    ``False`` in production fails the @happy_path scenario.
+  * "does not claim the mime type" — broadening ``can_extract`` to
+    claim PDF / text / octet-stream fails the @error scenarios.
+  * "carries non-empty markdown" — dropping the convert→re-enter call
+    in production returns empty markdown and fails the step.
+  * "raises so the orchestrator escalates" — softening the unreachable
+    path to "return an empty doc" fails the step (and would let a
+    transient outage silently skip the item).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+from pytest_bdd import given, parsers, then, when
+
+from kairix.extractors import ExtractedDocument
+from kairix.extractors.gotenberg import (
+    GotenbergExtractor,
+    make_extractor,
+    version,
+)
+from tests.fakes import FakePdfFallbackExtractor
+
+pytestmark = pytest.mark.bdd
+
+# Legacy .doc — a format with no in-process extractor, so gotenberg claims
+# it. Modern OOXML docx is NOW handled in-process (markitdown / docx) and is
+# refused by gotenberg (the @error OOXML scenario pins that refusal).
+_DOC_MIME = "application/msword"
+_PDF_BYTES = b"%PDF-1.7\n" + (b"converted-pdf-payload " * 8)
+
+
+def _pdf_returning_client() -> httpx.Client:
+    def _handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=_PDF_BYTES)
+
+    return httpx.Client(transport=httpx.MockTransport(_handler))
+
+
+def _unreachable_client() -> httpx.Client:
+    def _handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused", request=request)
+
+    return httpx.Client(transport=httpx.MockTransport(_handler))
+
+
+@pytest.fixture
+def gotenberg_state() -> dict[str, Any]:
+    """Per-scenario state container."""
+    return {
+        "name": "gotenberg",
+        "client": None,
+        "raw": b"",
+        "claimed": None,
+        "doc": None,
+        "raised": None,
+    }
+
+
+def _build(gotenberg_state: dict[str, Any]) -> GotenbergExtractor:
+    """Construct the real extractor from the scenario's wired seams."""
+    real = make_extractor()
+    assert isinstance(real, GotenbergExtractor)
+    assert real.name == gotenberg_state["name"]
+    return GotenbergExtractor(
+        version=version,
+        http_client=gotenberg_state["client"] or _pdf_returning_client(),
+        pdf_extractor=FakePdfFallbackExtractor(),
+    )
+
+
+@given(parsers.parse('the gotenberg extractor is registered under the name "{name}"'))
+def _register_gotenberg(gotenberg_state: dict[str, Any], name: str) -> None:
+    real = make_extractor()
+    assert isinstance(real, GotenbergExtractor)
+    assert real.name == name
+    gotenberg_state["name"] = name
+
+
+@given("the gotenberg service is configured to return a converted PDF")
+def _service_returns_pdf(gotenberg_state: dict[str, Any]) -> None:
+    gotenberg_state["client"] = _pdf_returning_client()
+
+
+@given("the gotenberg service is unreachable")
+def _service_unreachable(gotenberg_state: dict[str, Any]) -> None:
+    gotenberg_state["client"] = _unreachable_client()
+
+
+@given("the operator has raw bytes for a legacy office document with a doc mime")
+def _office_bytes(gotenberg_state: dict[str, Any]) -> None:
+    # OLE2 compound-file magic — the legacy .doc container signature.
+    gotenberg_state["raw"] = b"\xd0\xcf\x11\xe0" + (b"office-ole2-payload " * 16)
+
+
+@when("the operator asks the gotenberg extractor whether it can extract the office mime")
+def _ask_can_extract_office_mime(gotenberg_state: dict[str, Any]) -> None:
+    extractor = _build(gotenberg_state)
+    gotenberg_state["claimed"] = extractor.can_extract(_DOC_MIME, gotenberg_state["raw"][:8])
+
+
+@when(parsers.parse('the operator asks the gotenberg extractor whether it can extract mime "{mime}"'))
+def _ask_can_extract(gotenberg_state: dict[str, Any], mime: str) -> None:
+    extractor = _build(gotenberg_state)
+    gotenberg_state["claimed"] = extractor.can_extract(mime, gotenberg_state["raw"][:8])
+
+
+@when("the operator invokes the gotenberg extractor's extract method on the bytes")
+def _invoke_extract(gotenberg_state: dict[str, Any]) -> None:
+    extractor = _build(gotenberg_state)
+    gotenberg_state["extractor"] = extractor
+    gotenberg_state["doc"] = extractor.extract(gotenberg_state["raw"], _DOC_MIME)
+
+
+@when("the operator invokes the gotenberg extractor's extract method expecting a failure")
+def _invoke_extract_expecting_failure(gotenberg_state: dict[str, Any]) -> None:
+    extractor = _build(gotenberg_state)
+    try:
+        extractor.extract(gotenberg_state["raw"], _DOC_MIME)
+    except (RuntimeError, ValueError) as exc:
+        # The @error scenario asserts gotenberg raises an escalation-
+        # triggering error (never a silent empty doc) on an outage.
+        gotenberg_state["raised"] = exc
+
+
+@then("the gotenberg extractor claims the mime type")
+def _then_claims(gotenberg_state: dict[str, Any]) -> None:
+    assert gotenberg_state["claimed"] is True
+
+
+@then("the gotenberg extractor does not claim the mime type")
+def _then_does_not_claim(gotenberg_state: dict[str, Any]) -> None:
+    assert gotenberg_state["claimed"] is False
+
+
+@then("the gotenberg document carries non-empty markdown")
+def _then_non_empty(gotenberg_state: dict[str, Any]) -> None:
+    doc: ExtractedDocument = gotenberg_state["doc"]
+    assert isinstance(doc, ExtractedDocument)
+    assert doc.markdown.strip() != ""
+
+
+@then("the gotenberg extractor reports quality_ok true for the produced document")
+def _then_quality_ok_true(gotenberg_state: dict[str, Any]) -> None:
+    extractor: GotenbergExtractor = gotenberg_state["extractor"]
+    doc: ExtractedDocument = gotenberg_state["doc"]
+    assert extractor.quality_ok(doc) is True
+
+
+@then("the gotenberg extractor's version string is non-empty")
+def _then_version_non_empty(gotenberg_state: dict[str, Any]) -> None:
+    extractor: GotenbergExtractor = gotenberg_state["extractor"]
+    assert isinstance(extractor.version, str)
+    assert extractor.version.strip() != ""
+    # Pin to the canonical module-level value (F40).
+    assert extractor.version == version
+
+
+@then("the gotenberg extractor raises so the orchestrator escalates")
+def _then_raised(gotenberg_state: dict[str, Any]) -> None:
+    raised = gotenberg_state["raised"]
+    assert raised is not None
+    # A transient gotenberg outage must surface a retryable error, not a
+    # silent empty doc — the escalation orchestrator escalates to ocr.
+    assert isinstance(raised, (RuntimeError, ValueError))

--- a/tests/bdd/test_extractor_gotenberg.py
+++ b/tests/bdd/test_extractor_gotenberg.py
@@ -1,0 +1,15 @@
+"""pytest-bdd binding for ``extractor_gotenberg.feature`` (PR-3).
+
+Steps live in :mod:`tests.bdd.steps.extractor_gotenberg_steps`.
+"""
+
+from pathlib import Path
+
+import pytest
+from pytest_bdd import scenarios
+
+FEATURE = str(Path(__file__).parent / "features" / "extractor_gotenberg.feature")
+
+pytestmark = pytest.mark.bdd
+
+scenarios(FEATURE)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -172,6 +172,9 @@ pytest_plugins = [
     "tests.bdd.steps.extractor_docx_steps",
     # Wave-4 OF-3 xlsx extractor — openpyxl sheet-as-document.
     "tests.bdd.steps.extractor_xlsx_steps",
+    # PR-3 gotenberg conversion tier — Office/ODF/Visio/RTF → PDF →
+    # pdf_fallback re-entry.
+    "tests.bdd.steps.extractor_gotenberg_steps",
     # Connector plugin BDD step modules — Wave 2 IM-5 lands the first
     # connector (obsidian). Future connectors (sharepoint, dex_crm, ...)
     # append a sibling entry per F36.

--- a/tests/contracts/test_gotenberg_protocol.py
+++ b/tests/contracts/test_gotenberg_protocol.py
@@ -1,0 +1,181 @@
+"""Contract test for the ``gotenberg`` conversion-tier extractor (F43).
+
+Imports the canonical fake AND the real implementation, then runs the
+same :class:`Extractor` Protocol assertions against both through one
+parametrized body. The fake proves the test seam is real; the real impl
+proves the production class satisfies the same shape.
+
+The real :class:`GotenbergExtractor` is constructed with an
+:class:`httpx.Client` wired to :class:`httpx.MockTransport` (returns
+``%PDF`` bytes) plus a fake ``pdf_extractor`` so neither the gotenberg
+service nor the real ``pdf_fallback`` library is driven during the
+contract test. The HTTP failure paths (timeout / 4xx / empty body) are
+exercised by the unit tests under ``tests/extractors/test_gotenberg.py``.
+
+Sabotage-proofs:
+
+  * Deleting ``version`` from :mod:`kairix.extractors.gotenberg` breaks
+    ``test_extractor_declares_version``.
+  * Flipping ``can_extract`` to ``return True`` for ``application/pdf``
+    on the real impl breaks ``test_real_refuses_pdf_mime``.
+  * Flipping the quality gate's char threshold to ``0`` breaks
+    ``test_quality_ok_false_on_short_output``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import httpx
+import pytest
+
+from kairix.extractors import ExtractedDocument, Extractor
+from kairix.extractors.gotenberg import (
+    GotenbergExtractor,
+)
+from kairix.extractors.gotenberg import (
+    make_extractor as make_real_extractor,
+)
+from kairix.extractors.gotenberg import (
+    version as gotenberg_version,
+)
+from tests.fakes import FakeGotenbergExtractor, FakePdfFallbackExtractor
+
+pytestmark = pytest.mark.contract
+
+# Canonical "office format with no in-process extractor" the tier claims.
+# Modern OOXML docx is NOW handled in-process (markitdown / docx) and is
+# REFUSED by both fake and real — exercised by ``test_can_extract_refuses_ooxml_docx_mime``.
+_LEGACY_OFFICE_MIME = "application/msword"
+_OOXML_DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+_PDF_BYTES = b"%PDF-1.7\n" + (b"converted-pdf-payload " * 8)
+
+
+def _pdf_returning_client() -> httpx.Client:
+    """An :class:`httpx.Client` whose convert route returns ``%PDF`` bytes."""
+
+    def _handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=_PDF_BYTES)
+
+    return httpx.Client(transport=httpx.MockTransport(_handler))
+
+
+def _make_real_with_stubs() -> Extractor:
+    """Construct the real :class:`GotenbergExtractor` with mocked HTTP + PDF tier."""
+    return GotenbergExtractor(
+        version=gotenberg_version,
+        http_client=_pdf_returning_client(),
+        pdf_extractor=FakePdfFallbackExtractor(),
+    )
+
+
+_Factory = Callable[[], Extractor]
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(lambda: FakeGotenbergExtractor(), id="fake"),
+        pytest.param(_make_real_with_stubs, id="real"),
+    ]
+)
+def _extractor(request: pytest.FixtureRequest) -> Extractor:
+    factory: _Factory = request.param
+    return factory()
+
+
+@pytest.mark.contract
+def test_gotenberg_extractor_satisfies_protocol() -> None:
+    # F43-single-impl: asserts the real class registers as the Extractor
+    # Protocol + concrete type — a fake is an Extractor by construction,
+    # so co-asserting it would prove nothing about the real wire.
+    """The real factory returns an instance that is a runtime ``Extractor``."""
+    real = _make_real_with_stubs()
+    assert isinstance(real, Extractor)
+    assert isinstance(real, GotenbergExtractor)
+
+
+@pytest.mark.contract
+def test_extractor_declares_version() -> None:
+    # F43-single-impl: probes the module-level F40 ``version`` literal,
+    # not an instance method — there is no fake-side analogue of a
+    # module constant to co-assert.
+    """F40 requirement — module-level ``version`` is non-empty."""
+    assert isinstance(gotenberg_version, str)
+    assert gotenberg_version.strip() != ""
+
+
+@pytest.mark.contract
+def test_real_factory_returns_gotenberg_instance() -> None:
+    # F43-single-impl: asserts the real entry-point factory returns the
+    # real concrete class — the fake has no make_extractor factory, so
+    # this is inherently a real-only probe.
+    """``make_extractor`` returns a real :class:`GotenbergExtractor`."""
+    real = make_real_extractor()
+    assert isinstance(real, GotenbergExtractor)
+    assert real.name == "gotenberg"
+
+
+@pytest.mark.contract
+def test_can_extract_claims_legacy_office_mime(_extractor: Extractor) -> None:
+    """Both fake and real claim a legacy-Office mime (no in-process extractor)."""
+    assert _extractor.can_extract(_LEGACY_OFFICE_MIME, b"\xd0\xcf\x11\xe0") is True
+
+
+@pytest.mark.contract
+def test_can_extract_refuses_octet_stream(_extractor: Extractor) -> None:
+    """Both fake and real refuse ``application/octet-stream`` (no shadowing)."""
+    assert _extractor.can_extract("application/octet-stream", b"PK\x03\x04") is False
+
+
+@pytest.mark.contract
+def test_can_extract_refuses_ooxml_docx_mime(_extractor: Extractor) -> None:
+    """Both fake and real REFUSE modern OOXML docx — it's the in-process tiers' job.
+
+    Sabotage proof: re-adding the OOXML mimes to the real
+    ``_GOTENBERG_MIMES`` (or the fake's ``_claimed_mimes``) makes
+    ``can_extract`` return True, shadowing the in-process markitdown / docx
+    extractor and dead-lettering the document when gotenberg's HTTP service
+    is absent (see the composed PPTX E2E test).
+    """
+    assert _extractor.can_extract(_OOXML_DOCX_MIME, b"PK\x03\x04") is False
+
+
+@pytest.mark.contract
+def test_real_refuses_pdf_mime() -> None:
+    # F43-single-impl: the parametrized _extractor body already co-asserts
+    # the shared refusal contract (octet-stream); this real-only probe
+    # pins the production-critical "never shadow pdf_fallback" guarantee
+    # on the real wire specifically.
+    """The real impl refuses ``application/pdf`` — that's pdf_fallback's job."""
+    real = _make_real_with_stubs()
+    assert real.can_extract("application/pdf", b"%PDF-1.7") is False
+
+
+@pytest.mark.contract
+def test_extract_returns_document_with_non_empty_markdown(_extractor: Extractor) -> None:
+    """``extract`` produces an :class:`ExtractedDocument` with markdown text."""
+    doc = _extractor.extract(b"PK\x03\x04" + b"x" * 256, _LEGACY_OFFICE_MIME)
+    assert isinstance(doc, ExtractedDocument)
+    assert doc.markdown.strip() != ""
+
+
+@pytest.mark.contract
+def test_quality_ok_true_on_substantive_output(_extractor: Extractor) -> None:
+    """Quality gate passes when the converted document carries text."""
+    doc = _extractor.extract(b"PK\x03\x04" + b"x" * 256, _LEGACY_OFFICE_MIME)
+    assert _extractor.quality_ok(doc) is True
+
+
+@pytest.mark.contract
+def test_quality_ok_false_on_short_output(_extractor: Extractor) -> None:
+    """Quality gate fails when the converted markdown is below the floor."""
+    from kairix.extractors import DocMetadata, Page
+
+    short = ExtractedDocument(
+        markdown="x",
+        pages=(Page(page_number=1, text="x", has_images=False),),
+        images=(),
+        metadata=DocMetadata(title=None, author=None, created_date=None, language=None, page_count=1),
+        confidence=0.0,
+    )
+    assert _extractor.quality_ok(short) is False

--- a/tests/extractors/test_gotenberg.py
+++ b/tests/extractors/test_gotenberg.py
@@ -1,0 +1,444 @@
+"""Unit tests for :mod:`kairix.extractors.gotenberg` (PR-3 conversion tier).
+
+The extractor converts Office/ODF/Visio/Publisher/RTF to PDF via the
+gotenberg HTTP service, then re-enters the registered ``pdf_fallback``
+tier. Two seams are exercised, both F1-clean (no monkeypatching):
+
+  1. The **HTTP seam** — an :class:`httpx.Client` wired to
+     :class:`httpx.MockTransport` so the convert request never reaches
+     the network. The transport returns ``%PDF`` bytes (success),
+     raises :class:`httpx.TimeoutException` (timeout), or returns an
+     empty / 4xx / 5xx body (failure) per scenario.
+  2. The **pdf-tier seam** — a fake :class:`Extractor` injected via
+     ``pdf_extractor=`` so the test asserts the converted PDF chains
+     through to the PDF tier without resolving the real ``pdf_fallback``.
+
+Sabotage-proof per test:
+
+  * ``test_extract_converts_then_chains_to_pdf_tier`` — dropping the
+    convert→re-enter call returns no markdown and breaks the assertion
+    that the fake PDF tier received the ``%PDF`` bytes.
+  * ``test_can_extract_refuses_pdf_text_octet`` — broadening
+    :meth:`can_extract` (e.g. claiming PDF) breaks the assertion.
+  * ``test_extract_oversize_raises_with_no_http_call`` — moving the
+    size gate after the HTTP call records a request and breaks the
+    "no HTTP call" assertion.
+  * ``test_extract_timeout_raises`` / ``..._empty_body_raises`` /
+    ``..._http_4xx_raises`` — softening any raise path to "return an
+    empty doc" breaks the ``pytest.raises`` assertion (and would let a
+    transient gotenberg outage silently skip the item).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import httpx
+import pytest
+from tenacity import wait_none
+
+from kairix.extractors import DocMetadata, ExtractedDocument, MimeType, Page
+from kairix.extractors.gotenberg import (
+    GotenbergExtractor,
+    GotenbergExtractorConfig,
+    make_extractor,
+    version,
+)
+
+#: The production retry budget (``stop_after_attempt(4)`` in the
+#: extractor). Pinned here as a test-local literal rather than imported
+#: from the module's private ``_MAX_RETRIES`` — F5 forbids importing
+#: ``_``-prefixed internals into tests. The 5xx retry test asserts the
+#: tenacity loop makes exactly this many attempts before raising.
+_EXPECTED_MAX_RETRIES = 4
+
+pytestmark = pytest.mark.unit
+
+# The convert-chain / failure-path tests drive a mime gotenberg actually
+# claims. The modern OOXML docx mime is NO LONGER claimed (it is handled
+# in-process by markitdown / docx), so we use a legacy-Office mime
+# (.doc) as the canonical "format with no in-process extractor" case.
+_DOC_MIME = "application/msword"
+#: Modern OOXML docx mime — gotenberg deliberately REFUSES this (the
+#: in-process markitdown / docx tiers own it). Asserted refused below.
+_OOXML_DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+_PDF_MIME = "application/pdf"
+_PDF_BYTES = b"%PDF-1.7\n" + (b"converted-pdf-payload " * 8)
+
+
+@dataclass
+class _FakePdfTier:
+    """In-memory stand-in for the ``pdf_fallback`` :class:`Extractor`.
+
+    Records every ``(raw, mime)`` it is handed so a test can assert the
+    convert→re-enter chain wired correctly, and returns a scripted
+    :class:`ExtractedDocument`.
+    """
+
+    name: str = "pdf_fallback"
+    version: str = "0.0.0-fake"
+    document: ExtractedDocument | None = None
+    calls: list[tuple[bytes, MimeType]] = field(default_factory=list)
+
+    def can_extract(self, mime: MimeType, magic_bytes: bytes) -> bool:
+        return mime == _PDF_MIME or magic_bytes.startswith(b"%PDF")
+
+    def extract(self, raw: bytes, mime: MimeType) -> ExtractedDocument:
+        self.calls.append((raw, mime))
+        return self.document or _doc("recovered office body text line. " * 6)
+
+    def quality_ok(self, doc: ExtractedDocument) -> bool:  # pragma: no cover — not exercised here
+        return len(doc.markdown) >= 100
+
+    def metadata_for(self, raw: bytes, mime: MimeType):  # pragma: no cover — not exercised here
+        from kairix.core.protocols import SourceMetadata
+
+        return SourceMetadata()
+
+
+def _doc(markdown: str, *, pages: tuple[Page, ...] | None = None) -> ExtractedDocument:
+    """Build a minimal :class:`ExtractedDocument` for the fake PDF tier."""
+    return ExtractedDocument(
+        markdown=markdown,
+        pages=pages if pages is not None else (Page(page_number=1, text=markdown, has_images=False),),
+        images=(),
+        metadata=DocMetadata(title=None, author=None, created_date=None, language=None, page_count=1),
+        confidence=0.5,
+    )
+
+
+def _mock_client(handler) -> httpx.Client:
+    """Wrap a request handler in an :class:`httpx.Client` via MockTransport."""
+    return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+def _make_extractor(
+    *,
+    handler=None,
+    pdf_tier: _FakePdfTier | None = None,
+    config: GotenbergExtractorConfig | None = None,
+) -> tuple[GotenbergExtractor, _FakePdfTier]:
+    """Build a real :class:`GotenbergExtractor` wired to test seams.
+
+    ``retry_wait=wait_none()`` removes the production exponential backoff
+    so the transient-retry paths assert their budget at zero wall-clock —
+    a unit test must never sleep on real tenacity backoff.
+    """
+    tier = pdf_tier or _FakePdfTier()
+    client = _mock_client(handler) if handler is not None else None
+    extractor = GotenbergExtractor(
+        version=version,
+        config=config,
+        http_client=client,
+        pdf_extractor=tier,
+        retry_wait=wait_none(),
+    )
+    return extractor, tier
+
+
+# ---------------------------------------------------------------------------
+# Factory + version
+# ---------------------------------------------------------------------------
+
+
+def test_factory_returns_gotenberg_instance() -> None:
+    extractor = make_extractor()
+    assert isinstance(extractor, GotenbergExtractor)
+    assert extractor.name == "gotenberg"
+    assert extractor.version == version
+
+
+def test_factory_accepts_config_override() -> None:
+    cfg = GotenbergExtractorConfig(gotenberg_url="http://gotenberg:3000", timeout_s=5.0, max_file_size_mb=8)
+    extractor = make_extractor(config=cfg)
+    assert isinstance(extractor, GotenbergExtractor)
+
+
+def test_factory_coerces_raw_dict_config() -> None:
+    """Registry passes per-member YAML as a raw dict — the factory must coerce it.
+
+    ``build_extractor_from_entry`` resolves
+    ``extractor_chain_configs.gotenberg`` and calls
+    ``make_extractor(**{"config": {...}})`` — so ``config`` arrives as a
+    plain ``dict``, NOT a :class:`GotenbergExtractorConfig`. Without
+    coercion the extractor stores the dict and the first ``extract``
+    raises ``AttributeError`` on ``self._config.max_file_size_mb``. This
+    pins the coercion so every documented operator deployment works.
+    """
+    extractor = make_extractor(
+        config={"gotenberg_url": "http://gotenberg:3000", "timeout_s": 5.0, "max_file_size_mb": 8}
+    )
+    assert isinstance(extractor, GotenbergExtractor)
+    # The raw dict was coerced into a real frozen config dataclass.
+    assert isinstance(extractor._config, GotenbergExtractorConfig)
+    assert extractor._config.gotenberg_url == "http://gotenberg:3000"
+    assert extractor._config.timeout_s == 5.0
+    assert extractor._config.max_file_size_mb == 8
+
+    # The oversize gate reads ``max_file_size_mb`` off the coerced config
+    # without AttributeError — an 8 MB ceiling rejects a 9 MB upload.
+    oversize = b"PK\x03\x04" + b"x" * (9 * 1024 * 1024)
+    with pytest.raises(ValueError, match="convert ceiling"):
+        extractor.extract(oversize, _DOC_MIME)
+
+
+def test_version_module_level_non_empty() -> None:
+    """F40 sanity — module-level ``version`` is a non-empty string."""
+    assert isinstance(version, str)
+    assert version.strip() != ""
+
+
+def test_config_is_frozen() -> None:
+    """F42 sanity — the config dataclass is frozen."""
+    cfg = GotenbergExtractorConfig()
+    with pytest.raises((AttributeError, TypeError)):
+        cfg.gotenberg_url = "http://evil"  # type: ignore[misc] — assigning to a frozen-dataclass field on purpose to prove F42 immutability; the assignment must raise
+
+
+# ---------------------------------------------------------------------------
+# can_extract — claims legacy-Office/ODF/Visio/Publisher/RTF, refuses
+# pdf/text/octet-stream AND the modern OOXML (docx/pptx/xlsx) mimes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "mime",
+    [
+        # Legacy Microsoft Office binary formats — no in-process extractor.
+        "application/msword",
+        "application/vnd.ms-excel",
+        "application/vnd.ms-powerpoint",
+        # OpenDocument family.
+        "application/vnd.oasis.opendocument.text",
+        "application/vnd.oasis.opendocument.spreadsheet",
+        "application/vnd.oasis.opendocument.presentation",
+        "application/vnd.oasis.opendocument.graphics",
+        # Visio / Publisher / RTF.
+        "application/vnd.ms-visio.drawing",
+        "application/vnd.visio",
+        "application/x-mspublisher",
+        "application/rtf",
+        "text/rtf",
+    ],
+)
+def test_can_extract_claims_legacy_office_odf_visio_mimes(mime: str) -> None:
+    extractor, _ = _make_extractor()
+    assert extractor.can_extract(mime, b"PK\x03\x04") is True
+
+
+@pytest.mark.parametrize(
+    "mime",
+    [
+        # Modern OOXML — owned by the in-process markitdown / pptx / docx /
+        # xlsx tiers. gotenberg must REFUSE these so it never shadows the
+        # working in-process extractor (and dead-letter when the gotenberg
+        # HTTP service is absent).
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document.macroenabled.12",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.template",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.macroenabled.12",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.template",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation.macroenabled.12",
+        "application/vnd.openxmlformats-officedocument.presentationml.template",
+    ],
+)
+def test_can_extract_refuses_ooxml_mimes(mime: str) -> None:
+    """Modern OOXML (docx/pptx/xlsx) is handled in-process — gotenberg refuses it.
+
+    Sabotage proof: re-adding any OOXML mime to ``_GOTENBERG_MIMES`` makes
+    gotenberg claim it, shadowing the in-process extractor and (in the
+    composed path) dead-lettering the document when the gotenberg HTTP
+    service is absent. See the composed PPTX E2E test
+    (``tests/e2e/test_composed_connector_sharepoint_path.py``).
+    """
+    extractor, _ = _make_extractor()
+    assert extractor.can_extract(mime, b"PK\x03\x04") is False
+
+
+@pytest.mark.parametrize(
+    "mime",
+    [
+        "application/pdf",
+        "text/plain",
+        "text/markdown",
+        "text/html",
+        "application/octet-stream",
+    ],
+)
+def test_can_extract_refuses_pdf_text_octet(mime: str) -> None:
+    """The tier must never shadow pdf_fallback / passthrough."""
+    extractor, _ = _make_extractor()
+    # Even with PDF magic bytes present, the mime allow-list refuses these.
+    assert extractor.can_extract(mime, b"%PDF-1.7") is False
+
+
+# ---------------------------------------------------------------------------
+# extract — convert then chain to pdf_fallback
+# ---------------------------------------------------------------------------
+
+
+def test_extract_converts_then_chains_to_pdf_tier() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, content=_PDF_BYTES)
+
+    extractor, tier = _make_extractor(handler=handler)
+    raw = b"PK\x03\x04" + (b"docx-zip-payload " * 16)
+    doc = extractor.extract(raw, _DOC_MIME)
+
+    # Chained to the PDF tier with the converted %PDF bytes + pdf mime.
+    assert isinstance(doc, ExtractedDocument)
+    assert len(tier.calls) == 1
+    chained_raw, chained_mime = tier.calls[0]
+    assert chained_raw == _PDF_BYTES
+    assert chained_mime == _PDF_MIME
+    assert "recovered office body text" in doc.markdown
+
+    # The convert request hit the LibreOffice route as multipart.
+    assert len(requests) == 1
+    assert requests[0].url.path == "/forms/libreoffice/convert"
+    assert requests[0].method == "POST"
+
+
+def test_extract_posts_to_configured_url() -> None:
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(str(request.url))
+        return httpx.Response(200, content=_PDF_BYTES)
+
+    cfg = GotenbergExtractorConfig(gotenberg_url="http://gotenberg:3000/")
+    extractor, _ = _make_extractor(handler=handler, config=cfg)
+    extractor.extract(b"PK\x03\x04" + b"x" * 64, _DOC_MIME)
+    # Trailing slash on the base URL is normalised, route appended once.
+    assert seen == ["http://gotenberg:3000/forms/libreoffice/convert"]
+
+
+# ---------------------------------------------------------------------------
+# Failure paths — oversize / timeout / empty / 4xx / 5xx all RAISE
+# ---------------------------------------------------------------------------
+
+
+def test_extract_oversize_raises_with_no_http_call() -> None:
+    calls: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover — must NOT be reached
+        calls.append(request)
+        return httpx.Response(200, content=_PDF_BYTES)
+
+    cfg = GotenbergExtractorConfig(max_file_size_mb=1)
+    extractor, tier = _make_extractor(handler=handler, config=cfg)
+    oversize = b"PK\x03\x04" + b"x" * (2 * 1024 * 1024)  # 2 MB > 1 MB ceiling
+    with pytest.raises(ValueError, match="convert ceiling"):
+        extractor.extract(oversize, _DOC_MIME)
+    # The size gate fires BEFORE any HTTP call and before the PDF tier.
+    assert calls == []
+    assert tier.calls == []
+
+
+def test_extract_timeout_raises() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.TimeoutException("gotenberg convert timed out", request=request)
+
+    extractor, tier = _make_extractor(handler=handler)
+    with pytest.raises(RuntimeError, match="gotenberg:"):
+        extractor.extract(b"PK\x03\x04" + b"x" * 64, _DOC_MIME)
+    assert tier.calls == []
+
+
+def test_extract_unreachable_raises() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused", request=request)
+
+    extractor, _ = _make_extractor(handler=handler)
+    with pytest.raises(RuntimeError, match="gotenberg:"):
+        extractor.extract(b"PK\x03\x04" + b"x" * 64, _DOC_MIME)
+
+
+def test_extract_empty_body_raises() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"")
+
+    extractor, tier = _make_extractor(handler=handler)
+    with pytest.raises(ValueError, match="non-PDF / empty body"):
+        extractor.extract(b"PK\x03\x04" + b"x" * 64, _DOC_MIME)
+    assert tier.calls == []
+
+
+def test_extract_non_pdf_body_raises() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"<html>not a pdf</html>")
+
+    extractor, _ = _make_extractor(handler=handler)
+    with pytest.raises(ValueError, match="non-PDF / empty body"):
+        extractor.extract(b"PK\x03\x04" + b"x" * 64, _DOC_MIME)
+
+
+def test_extract_http_4xx_raises() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        # LibreOffice could not open the format → gotenberg 400.
+        return httpx.Response(400, content=b"bad format")
+
+    extractor, tier = _make_extractor(handler=handler)
+    with pytest.raises(RuntimeError, match="HTTP 400"):
+        extractor.extract(b"PK\x03\x04" + b"x" * 64, _DOC_MIME)
+    assert tier.calls == []
+
+
+def test_extract_http_5xx_raises_after_retry() -> None:
+    attempts: list[int] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts.append(1)
+        return httpx.Response(503, content=b"gotenberg overloaded")
+
+    extractor, _ = _make_extractor(handler=handler)
+    with pytest.raises(RuntimeError, match="HTTP 503"):
+        extractor.extract(b"PK\x03\x04" + b"x" * 64, _DOC_MIME)
+    # 5xx is retryable — the tenacity loop exhausts the full retry budget
+    # (stop-after-4) before raising. wait_none() keeps it fast.
+    assert len(attempts) == _EXPECTED_MAX_RETRIES
+
+
+# ---------------------------------------------------------------------------
+# quality_ok — mirrors the pdf_fallback gate (>=100 chars + a text-bearing page)
+# ---------------------------------------------------------------------------
+
+
+def test_quality_ok_true_for_text_bearing_doc() -> None:
+    extractor, _ = _make_extractor()
+    doc = _doc("recovered converted body content line. " * 6)
+    assert extractor.quality_ok(doc) is True
+
+
+def test_quality_ok_false_for_short_markdown() -> None:
+    extractor, _ = _make_extractor()
+    doc = _doc("brief")
+    assert extractor.quality_ok(doc) is False
+
+
+def test_quality_ok_false_for_empty_page_text() -> None:
+    """A converted-but-image-only PDF (no text layer) escalates to ocr."""
+    extractor, _ = _make_extractor()
+    long_blob = "padding padding padding padding padding padding " * 4  # > 100 chars
+    doc = _doc(long_blob, pages=(Page(page_number=1, text="", has_images=True),))
+    assert extractor.quality_ok(doc) is False
+
+
+# ---------------------------------------------------------------------------
+# metadata_for — empty SourceMetadata like the sibling extractors
+# ---------------------------------------------------------------------------
+
+
+def test_metadata_for_returns_empty_source_metadata() -> None:
+    from kairix.core.protocols import SourceMetadata
+
+    extractor, _ = _make_extractor()
+    meta = extractor.metadata_for(b"PK\x03\x04", _DOC_MIME)
+    assert isinstance(meta, SourceMetadata)
+    assert meta.author is None
+    assert meta.tags == ()

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -2166,6 +2166,110 @@ class FakeXlsxExtractor:
         return SourceMetadata()
 
 
+class FakeGotenbergExtractor:
+    """Canonical fake for the gotenberg conversion-tier extractor (F43 contract layer).
+
+    Implements the :class:`kairix.extractors.Extractor` Protocol without
+    reaching the real gotenberg HTTP service. Claims the
+    legacy-Office/ODF/Visio/Publisher/RTF mimes the real tier converts,
+    and — crucially, mirroring the real ``can_extract`` — REFUSES
+    ``application/pdf`` / ``text/*`` / ``application/octet-stream`` AND the
+    modern OOXML mimes (.docx / .pptx / .xlsx, owned by the in-process
+    markitdown / pptx / docx / xlsx tiers) so the tier never shadows
+    ``pdf_fallback`` / ``passthrough`` or an in-process extractor.
+    ``extract`` returns a scripted converted-then-extracted document (one
+    text-bearing page) sized to clear the production ``>=100 char`` floor.
+
+    Used by ``tests/contracts/test_gotenberg_protocol.py`` to prove the
+    real :class:`GotenbergExtractor` satisfies the same Protocol surface a
+    downstream consumer would expect.
+    """
+
+    def __init__(
+        self,
+        *,
+        version: str = "1.0.0",
+        scripted_markdown: str | None = None,
+        scripted_page_text: str | None = None,
+    ) -> None:
+        from kairix.extractors import (
+            DocMetadata,
+            ExtractedDocument,
+            MimeType,
+            Page,
+        )
+
+        self.name = "gotenberg"
+        self.version = version
+        self.scripted_markdown = scripted_markdown or (
+            "Recovered Office content via the gotenberg conversion tier.\n"
+            + ("Line of body text from the converted PDF page one.\n" * 6)
+        )
+        self.scripted_page_text = scripted_page_text or "Recovered converted-PDF page text from the gotenberg tier."
+        self._DocMetadata = DocMetadata
+        self._ExtractedDocument = ExtractedDocument
+        self._MimeType = MimeType
+        self._Page = Page
+        # Mirror the real tier's mime allow-list (a representative subset
+        # — the contract test exercises a legacy-Office mime as the
+        # canonical case; the full set is unit-tested in test_gotenberg.py).
+        # Modern OOXML (.docx / .pptx / .xlsx) is deliberately ABSENT — the
+        # real tier refuses it (the in-process markitdown / pptx / docx /
+        # xlsx extractors own those), so the fake must too.
+        self._claimed_mimes = frozenset(
+            {
+                "application/msword",
+                "application/vnd.ms-excel",
+                "application/vnd.ms-powerpoint",
+                "application/vnd.oasis.opendocument.text",
+                "application/vnd.oasis.opendocument.spreadsheet",
+                "application/vnd.oasis.opendocument.presentation",
+                "application/vnd.oasis.opendocument.graphics",
+                "application/vnd.ms-visio.drawing",
+                "application/vnd.ms-visio.drawing.macroenabled.12",
+                "application/vnd.visio",
+                "application/x-mspublisher",
+                "application/rtf",
+                "text/rtf",
+            }
+        )
+
+    def can_extract(self, mime: str, magic_bytes: bytes) -> bool:
+        del magic_bytes
+        return isinstance(mime, str) and mime in self._claimed_mimes
+
+    def extract(self, raw: bytes, mime: str) -> Any:
+        del mime
+        markdown = self.scripted_markdown
+        page = self._Page(page_number=1, text=self.scripted_page_text, has_images=False)
+        confidence = min(len(markdown) / max(len(raw), 1), 1.0) if raw else 0.0
+        return self._ExtractedDocument(
+            markdown=markdown,
+            pages=(page,),
+            images=(),
+            metadata=self._DocMetadata(
+                title="fixture",
+                author=None,
+                created_date=None,
+                language=None,
+                page_count=1,
+            ),
+            confidence=confidence,
+        )
+
+    def quality_ok(self, doc: Any) -> bool:
+        if len(doc.markdown) < 100:
+            return False
+        return any(page.text.strip() for page in doc.pages)
+
+    def metadata_for(self, raw: bytes, mime: str) -> Any:
+        """Return empty :class:`SourceMetadata` (Protocol-shape compliance only)."""
+        del raw, mime
+        from kairix.core.protocols import SourceMetadata
+
+        return SourceMetadata()
+
+
 class FakeEmbeddingCache:
     """In-memory ``EmbeddingCache``-compatible fake for unit tests.
 


### PR DESCRIPTION
## Why

The SharePoint dead-letter backlog is dominated by formats kairix can't extract in-process: legacy Office (`.doc/.ppt/.xls`), Visio, ODF, Publisher, RTF. A **gotenberg** container (LibreOffice/Chromium conversion) is already running on the Customer-Zero VM but the code never called it. This wires it in as an escalation tier so those formats convert to PDF and become indexable instead of dead-lettering.

## What

A new `gotenberg` extractor tier: **convert → PDF via gotenberg HTTP → re-enter the existing `pdf_fallback` extractor** (so table extraction, per-page chunking, and metadata are inherited from the established PDF path).

- `kairix/extractors/gotenberg/` (new) — `GotenbergExtractor` + frozen `GotenbergExtractorConfig`. `can_extract` claims **only** Office/ODF/Visio/Publisher/RTF mimes and **refuses pdf/text/octet-stream** so it never shadows `pdf_fallback`/`passthrough`. Registered via the `kairix.extractors` entry point.
- **Failure → raise** (so the escalation orchestrator falls through to OCR / the item stays retryable): oversize → `ValueError` before any HTTP call; timeout/unreachable → `RuntimeError`; empty/non-PDF body → `ValueError`; 5xx retried (tenacity, 4 attempts). A transient gotenberg outage never silently drops a doc.
- Injectable seams (`httpx.Client`, `pdf_extractor`, `config`, retry wait) for offline tests.
- `make_extractor` coerces a raw YAML `dict` → `GotenbergExtractorConfig` (so the documented `extractor_chain_configs.gotenberg.config` shape works at runtime).
- `docker-compose.yml`: `gotenberg` service (image `gotenberg/gotenberg:8`, `/health` healthcheck), added **without** a `depends_on` from kairix so the fresh-install smoke (F81) is unaffected and the extractor degrades gracefully when gotenberg is absent.
- `kairix.config.example.yaml`: commented `extractor_chain: [markitdown, pdf_fallback, gotenberg, ocr]` + config block. Env: `KAIRIX_GOTENBERG_URL/_TIMEOUT_S/_MAX_FILE_SIZE_MB`.

## How to enable (operator)
Add `extractor_chain: [markitdown, pdf_fallback, gotenberg, ocr]` to the SharePoint connector with `extractor_chain_configs.gotenberg.config.gotenberg_url: http://gotenberg:3000`. (The VM already runs gotenberg.)

## Tests / gates
- 37 unit + F43 real+fake protocol contract + BDD; escalation/registry suites see the new entry point. **52 extractor tests pass in 0.09s** (retry backoff DI'd to `wait_none()` — no real sleeps).
- arch-fitness **Passed** (F16/F17/F40/F42/F43/F68 clean; no net-new F68 obligations). Coverage: `__init__` 100%, `extractor` 97% (> 80% new-code floor). ruff + mypy clean.