### PR TITLE
feat(connectors): orphaned-source dead-letter drain sweep (CLI + periodic pass)

### DIFF
--- a/kairix/core/connectors/deadletter_drain.py
+++ b/kairix/core/connectors/deadletter_drain.py
@@ -15,6 +15,17 @@ the historical backlog). For each eligible row it writes a
 ``skipped_unsupported`` ``documents_media`` outcome (operator visibility,
 best-effort) and then :meth:`DeadLetterStore.clear`\\ s the row.
 
+The per-connector pass only ever drains CURRENTLY-ACTIVE connectors (it
+keys on the active ``connector.name``), so dead-letters left behind by a
+source whose connector was removed — an ORPHANED source — never drain.
+:func:`drain_source_deadletters` is the connector-agnostic per-source core
+(no active connector instance required), and
+:func:`drain_all_source_deadletters` sweeps EVERY distinct ``source_name``
+in ``connector_deadletter`` — orphaned sources included — so those
+backlogs auto-drain over time (periodic worker sweep) or on demand
+(``kairix dead-letter drain``). The eligibility rule is unchanged: the
+sweep reuses :func:`is_drain_eligible` verbatim.
+
 Eligibility is deliberately narrow — see :func:`is_drain_eligible`. The
 load-bearing rule: drain ONLY items that are genuinely, permanently
 unprocessable — a ``corrupt_zip`` archive, or a MIME that is positively
@@ -33,8 +44,8 @@ The pass is:
   (:meth:`DeadLetterStore.clear` returns ``False`` on the second pass);
 * **best-effort** — a failure draining one row logs and continues; the
   drain (and the surrounding sync) never aborts because of one bad row;
-* **cheap when clean** — a single ``DeadLetterStore.list`` read short-
-  circuits the whole pass when the queue holds no rows for the source.
+* **cheap when clean** — a single bounded ``connector_deadletter`` read
+  short-circuits the whole pass when the queue holds no rows for the source.
 
 The key on which dead-letter / bronze rows are queried is the connector
 KIND (``connector.name`` — a class constant like ``"sharepoint"``), NOT
@@ -49,7 +60,7 @@ import sqlite3
 from dataclasses import dataclass
 
 from kairix.core.connectors.compat import known_unsupported_mime
-from kairix.core.connectors.dead_letter import DeadLetterEntry, DeadLetterStore
+from kairix.core.connectors.dead_letter import DeadLetterStore
 from kairix.core.connectors.silver import DefaultSilverProcessor
 from kairix.core.observability.dead_letter_status import classify_error
 from kairix.core.protocols import BronzeRef
@@ -76,10 +87,11 @@ _FAILURE_CLASS_CORRUPT_ZIP = "corrupt_zip"
 # reference a single literal rather than repeating it across the module.
 _BUCKET_UNSUPPORTED_MIME = "unsupported_mime"
 
-# Per-tick cap on rows scanned. ``DeadLetterStore.list`` is unbounded
-# (operator-triage surface, F63 note); the drain runs inside the tick loop
-# so it must bound its own work. A generous ceiling — the backlog drains
-# over a few ticks rather than one giant pass that could stall a tick.
+# Per-tick cap on rows scanned. The drain runs inside the tick loop, so
+# ``_load_candidates`` pushes this ``LIMIT ?`` down into SQL (F63) rather
+# than fetching the whole backlog and slicing — the per-tick scan is
+# bounded regardless of queue depth. A generous ceiling: the backlog
+# drains over a few ticks rather than one giant pass that could stall one.
 _DEFAULT_PER_TICK_MAX_ITEMS = 500
 
 
@@ -103,15 +115,20 @@ class _DrainCandidate:
 
 @dataclass(frozen=True)
 class DrainSummary:
-    """Per-connector-per-tick drain tally, returned for logging + tests.
+    """Per-source-per-tick drain tally, returned for logging + tests.
 
-    ``left`` is the TRUE post-drain queue depth for the connector —
+    ``left`` is the TRUE post-drain queue depth for the source —
     ``SELECT COUNT(*) FROM connector_deadletter WHERE source_name = ?``
     AFTER the drain — NOT ``scanned - drained``. The scan is capped at
     ``max_items`` so a ``scanned - drained`` figure would understate the
     real backlog whenever the queue is deeper than the per-tick cap; this
     field reflects everything still queued (drainable-but-uncapped rows on
     a later tick, plus every row left for retry).
+
+    ``connector_name`` is the ``source_name`` string the row was written
+    under (a connector KIND like ``"sharepoint"``). For a ``dry_run`` pass
+    ``drained`` / ``corrupt_zip`` / ``unsupported_mime`` count what WOULD
+    drain and ``left`` is the CURRENT (unmutated) depth.
     """
 
     connector_name: str
@@ -152,6 +169,39 @@ def is_drain_eligible(mime: str | None, failure_class: str) -> bool:
     return known_unsupported_mime(mime or "")
 
 
+def _candidate_from_row(
+    db: sqlite3.Connection,
+    connector_name: str,
+    item_id: str,
+    last_error: str,
+) -> _DrainCandidate:
+    """Build one :class:`_DrainCandidate`, joining bronze for the MIME fields.
+
+    Derives ``failure_class`` from ``last_error`` via :func:`classify_error`
+    and looks up the bronze MIME / content_hash / raw_path / fetched_at by
+    ``(source_name, item_id)`` — the same key every dead-letter write used.
+    The bronze row is absent for fetch-failure dead-letters (never reach
+    the bronze write), so every joined field is ``None`` in that case.
+    """
+    bronze = db.execute(
+        "SELECT mime, content_hash, raw_path, fetched_at FROM bronze_records WHERE source_name = ? AND item_id = ?",
+        (connector_name, item_id),
+    ).fetchone()
+    mime = str(bronze[0]) if bronze is not None and bronze[0] is not None else None
+    content_hash = str(bronze[1]) if bronze is not None and bronze[1] is not None else None
+    raw_path = str(bronze[2]) if bronze is not None and bronze[2] is not None else None
+    fetched_at = str(bronze[3]) if bronze is not None and bronze[3] is not None else None
+    return _DrainCandidate(
+        item_id=item_id,
+        last_error=last_error,
+        failure_class=classify_error(last_error),
+        mime=mime,
+        content_hash=content_hash,
+        raw_path=raw_path,
+        fetched_at=fetched_at,
+    )
+
+
 def _load_candidates(
     db: sqlite3.Connection,
     connector_name: str,
@@ -161,34 +211,29 @@ def _load_candidates(
     """Enumerate dead-letter rows for ``connector_name`` joined to bronze.
 
     Keys on ``connector_name`` (the connector KIND) for BOTH the
-    dead-letter list and the bronze join — the same value every
-    dead-letter write used. Capped at ``max_items`` so the per-tick scan
-    is bounded even when ``DeadLetterStore.list`` returns a large backlog.
+    dead-letter scan and the bronze join — the same value every
+    dead-letter write used. The per-tick cap is pushed DOWN into SQL
+    (``LIMIT ?``) rather than fetched whole and sliced in Python, so the
+    scan touches at most ``max_items`` rows even when the source's backlog
+    is huge — the only unbounded path the tick loop could have hit. Order
+    matches ``DeadLetterStore.list``'s ``last_attempt ASC`` (oldest first).
     """
-    store = DeadLetterStore(db)
-    entries: tuple[DeadLetterEntry, ...] = store.list(connector_name)
-    candidates: list[_DrainCandidate] = []
-    for entry in entries[:max_items]:
-        bronze = db.execute(
-            "SELECT mime, content_hash, raw_path, fetched_at FROM bronze_records WHERE source_name = ? AND item_id = ?",
-            (connector_name, entry.item_id),
-        ).fetchone()
-        mime = str(bronze[0]) if bronze is not None and bronze[0] is not None else None
-        content_hash = str(bronze[1]) if bronze is not None and bronze[1] is not None else None
-        raw_path = str(bronze[2]) if bronze is not None and bronze[2] is not None else None
-        fetched_at = str(bronze[3]) if bronze is not None and bronze[3] is not None else None
-        candidates.append(
-            _DrainCandidate(
-                item_id=entry.item_id,
-                last_error=entry.last_error,
-                failure_class=classify_error(entry.last_error),
-                mime=mime,
-                content_hash=content_hash,
-                raw_path=raw_path,
-                fetched_at=fetched_at,
-            )
+    # F63-bounded: LIMIT ? caps the per-tick scan.
+    rows = db.execute(
+        "SELECT item_id, failure_count, last_error, last_attempt "
+        "FROM connector_deadletter WHERE source_name = ? "
+        "ORDER BY last_attempt ASC LIMIT ?",
+        (connector_name, max_items),
+    ).fetchall()
+    return tuple(
+        _candidate_from_row(
+            db,
+            connector_name,
+            str(row[0]),
+            str(row[2]) if row[2] is not None else "",
         )
-    return tuple(candidates)
+        for row in rows
+    )
 
 
 def _bucket_for(candidate: _DrainCandidate) -> str:
@@ -282,50 +327,83 @@ def _remaining_deadletter_count(db: sqlite3.Connection, connector_name: str) -> 
     return int(row[0]) if row is not None else 0
 
 
-def drain_connector_deadletters(
+def _tally_drain(
     db: sqlite3.Connection,
     *,
-    connector_name: str,
+    source_name: str,
     silver: DefaultSilverProcessor,
-    max_items: int = _DEFAULT_PER_TICK_MAX_ITEMS,
-) -> DrainSummary:
-    """Drain permanently-unprocessable dead-letters for one connector.
+    candidates: tuple[_DrainCandidate, ...],
+    dry_run: bool,
+) -> tuple[int, dict[str, int]]:
+    """Walk the candidates, draining (or counting) every eligible row.
 
-    Runs once per connector per sync tick. Enumerates the connector's
-    dead-letter backlog (keyed on ``connector_name`` — the connector
-    KIND), drains every :func:`is_drain_eligible` row (outcome-write +
-    clear + per-row commit), and leaves every other row for retry. Emits
-    a single summary log line and returns the tally.
-
-    ``DrainSummary.left`` is the TRUE post-drain queue depth (a direct
-    ``COUNT(*)``), so it stays accurate even when the backlog exceeds the
-    per-tick ``max_items`` scan cap.
-
-    Cheap-when-clean guard: an empty backlog short-circuits to a zero
-    :class:`DrainSummary` without any per-row work.
+    Returns ``(drained, bucket_tally)``. When ``dry_run`` is set the
+    eligible rows are COUNTED only — no outcome-write, no ``clear``, no
+    ``commit`` — so the pass mutates nothing. The narrow
+    :func:`is_drain_eligible` predicate is applied identically in both
+    modes, so a dry-run preview matches exactly what a live pass clears.
     """
-    candidates = _load_candidates(db, connector_name, max_items=max_items)
-    if not candidates:
-        return DrainSummary(connector_name, drained=0, corrupt_zip=0, unsupported_mime=0, left=0)
-
     dead_letter = DeadLetterStore(db)
     tally = {_FAILURE_CLASS_CORRUPT_ZIP: 0, _BUCKET_UNSUPPORTED_MIME: 0}
     drained = 0
     for candidate in candidates:
         if not is_drain_eligible(candidate.mime, candidate.failure_class):
             continue
-        if _drain_one(db, connector_name=connector_name, candidate=candidate, silver=silver, dead_letter=dead_letter):
+        if dry_run:
             drained += 1
             tally[_bucket_for(candidate)] += 1
+            continue
+        if _drain_one(db, connector_name=source_name, candidate=candidate, silver=silver, dead_letter=dead_letter):
+            drained += 1
+            tally[_bucket_for(candidate)] += 1
+    return drained, tally
 
+
+def drain_source_deadletters(
+    db: sqlite3.Connection,
+    *,
+    source_name: str,
+    silver: DefaultSilverProcessor,
+    dry_run: bool = False,
+    max_items: int = _DEFAULT_PER_TICK_MAX_ITEMS,
+) -> DrainSummary:
+    """Drain permanently-unprocessable dead-letters for ONE source.
+
+    The reusable per-source core. ``source_name`` is the value every
+    dead-letter write keyed on (a connector KIND like ``"sharepoint"``) —
+    NO active connector instance is required, so this drains an ORPHANED
+    source whose connector is no longer registered just as well as an
+    active one. Enumerates the source's backlog (capped at ``max_items``),
+    drains every :func:`is_drain_eligible` row (outcome-write + clear +
+    per-row commit), and leaves every other row for retry. Eligibility is
+    the EXISTING narrow rule (corrupt_zip OR known-unsupported MIME) — this
+    core never broadens it.
+
+    ``dry_run`` reports what WOULD drain (the ``drained`` /
+    ``corrupt_zip`` / ``unsupported_mime`` counts) WITHOUT mutating: no
+    ``clear``, no ``commit``, no outcome rows. ``DrainSummary.left`` is the
+    CURRENT depth in that case.
+
+    ``DrainSummary.left`` is otherwise the TRUE post-drain queue depth (a
+    direct ``COUNT(*)``), so it stays accurate even when the backlog
+    exceeds the per-tick ``max_items`` scan cap.
+
+    Cheap-when-clean guard: an empty backlog short-circuits to a zero
+    :class:`DrainSummary` without any per-row work.
+    """
+    candidates = _load_candidates(db, source_name, max_items=max_items)
+    if not candidates:
+        return DrainSummary(source_name, drained=0, corrupt_zip=0, unsupported_mime=0, left=0)
+
+    drained, tally = _tally_drain(db, source_name=source_name, silver=silver, candidates=candidates, dry_run=dry_run)
     summary = DrainSummary(
-        connector_name=connector_name,
+        connector_name=source_name,
         drained=drained,
         corrupt_zip=tally[_FAILURE_CLASS_CORRUPT_ZIP],
         unsupported_mime=tally[_BUCKET_UNSUPPORTED_MIME],
-        left=_remaining_deadletter_count(db, connector_name),
+        left=_remaining_deadletter_count(db, source_name),
     )
-    if drained:
+    if drained and not dry_run:
         logger.info(
             "auto-drain: connector=%s drained=%d (corrupt_zip=%d, unsupported_mime=%d) left_total=%d",
             summary.connector_name,
@@ -335,3 +413,89 @@ def drain_connector_deadletters(
             summary.left,
         )
     return summary
+
+
+def drain_connector_deadletters(
+    db: sqlite3.Connection,
+    *,
+    connector_name: str,
+    silver: DefaultSilverProcessor,
+    max_items: int = _DEFAULT_PER_TICK_MAX_ITEMS,
+) -> DrainSummary:
+    """Drain permanently-unprocessable dead-letters for one ACTIVE connector.
+
+    Thin alias over :func:`drain_source_deadletters` keyed on the active
+    ``connector_name`` (the connector KIND). The per-active-connector
+    auto-drain at ``kairix.worker._run_one_connector_batch`` calls THIS;
+    behaviour is byte-for-byte unchanged from the pre-sweep core (the
+    sweep simply renamed the body to ``drain_source_deadletters`` and
+    threaded a ``dry_run`` flag that defaults False here).
+    """
+    return drain_source_deadletters(db, source_name=connector_name, silver=silver, max_items=max_items)
+
+
+def distinct_deadletter_sources(db: sqlite3.Connection) -> tuple[str, ...]:
+    """Every distinct ``source_name`` present in ``connector_deadletter``.
+
+    The canonical enumeration shared with the operator triage surface
+    (:mod:`kairix.core.observability.dead_letter_status`). Source-name
+    cardinality is tiny — one per registered (or formerly-registered)
+    connector — so the ``LIMIT 1000`` is an F63 safety bound, never a real
+    truncation. Crucially this includes ORPHANED sources whose connector
+    is no longer active: those rows still carry their original
+    ``source_name`` and surface here so the sweep can drain them.
+    """
+    rows = db.execute(
+        "SELECT source_name FROM connector_deadletter GROUP BY source_name ORDER BY source_name ASC LIMIT 1000"
+    ).fetchall()
+    return tuple(str(r[0]) for r in rows)
+
+
+def drain_all_source_deadletters(
+    db: sqlite3.Connection,
+    *,
+    silver: DefaultSilverProcessor,
+    skip_sources: frozenset[str] = frozenset(),
+    dry_run: bool = False,
+    max_items: int = _DEFAULT_PER_TICK_MAX_ITEMS,
+) -> tuple[DrainSummary, ...]:
+    """Drain (or preview) EVERY distinct source's dead-letter backlog.
+
+    Enumerates :func:`distinct_deadletter_sources` and runs the per-source
+    :func:`drain_source_deadletters` core against each — including ORPHANED
+    sources whose connector is no longer active (the gap the
+    per-active-connector auto-drain leaves open). ``skip_sources`` lets a
+    caller (e.g. a sync pass that already drained the active connectors
+    this tick) avoid the redundant re-scan; the per-source drain is
+    idempotent anyway, so a skip is an optimisation, not a correctness
+    requirement.
+
+    Best-effort per source: one source raising is logged and the sweep
+    continues to the next, so a single wedged source never starves the
+    rest. Cheap-when-clean: an empty table enumerates to zero sources and
+    the whole sweep is a single ``GROUP BY`` read.
+
+    Returns one :class:`DrainSummary` per source actually processed (the
+    skipped ones are absent). ``dry_run`` previews without mutating.
+    """
+    summaries: list[DrainSummary] = []
+    drained_total = 0
+    for source_name in distinct_deadletter_sources(db):
+        if source_name in skip_sources:
+            continue
+        try:
+            summary = drain_source_deadletters(
+                db, source_name=source_name, silver=silver, dry_run=dry_run, max_items=max_items
+            )
+        except Exception as exc:  # one source must not starve the sweep
+            logger.warning("deadletter-sweep: source=%s failed — %s", source_name, exc)
+            continue
+        summaries.append(summary)
+        drained_total += summary.drained
+    logger.info(
+        "deadletter-sweep: sources=%d drained=%d dry_run=%s",
+        len(summaries),
+        drained_total,
+        dry_run,
+    )
+    return tuple(summaries)

--- a/kairix/dead_letter_cli.py
+++ b/kairix/dead_letter_cli.py
@@ -9,10 +9,17 @@ This CLI surfaces the same breakdown via a single command:
   for scripts + the MCP tool parity.
 * ``kairix dead-letter status --source-name <name>`` — slice to one
   connector.
+* ``kairix dead-letter drain [SOURCE]`` — clear the permanently-
+  unprocessable backlog for ONE source (named), or EVERY distinct
+  source (no name). Works for an ORPHANED source whose connector is no
+  longer active — the gap the per-connector auto-drain leaves open.
+* ``kairix dead-letter drain --dry-run`` — report what WOULD drain
+  (counts per source + per failure class) WITHOUT mutating.
 
 Thin adapter — analysis + rendering lives in
-:mod:`kairix.core.observability.dead_letter_status`. ``main()`` only
-parses argv, opens the connection, and writes the rendered result.
+:mod:`kairix.core.observability.dead_letter_status`; the drain core lives
+in :mod:`kairix.core.connectors.deadletter_drain`. ``main()`` only parses
+argv, opens the connection, and writes the rendered result.
 
 The ``--db-path`` flag is the F30 subprocess seam (matches
 ``--state-path`` / ``--flag-path`` on ``kairix worker``). The
@@ -29,15 +36,29 @@ import sys
 from collections.abc import Callable
 from contextlib import closing
 from pathlib import Path
-from typing import TextIO
+from typing import TYPE_CHECKING, Any, TextIO
 
+from kairix.core.connectors.deadletter_drain import _DEFAULT_PER_TICK_MAX_ITEMS
 from kairix.core.observability.dead_letter_status import (
     build_status,
     render_human,
     render_json,
 )
 
+if TYPE_CHECKING:
+    from kairix.core.connectors.deadletter_drain import DrainSummary
+
 _STORE_TRUE = "store_true"
+
+# The argparse dest for the source-name argument — held once (F17) so the
+# ``add_argument`` registration and every ``getattr(args, ...)`` read of it
+# reference a single literal rather than repeating the string.
+_ARG_SOURCE_NAME = "source_name"
+
+# Default per-source scan cap for the ``drain`` verb — re-exported from the
+# drain core so the CLI flag default and the core stay in lock-step (F17:
+# the magic number lives in one place).
+_DEFAULT_MAX_ITEMS = _DEFAULT_PER_TICK_MAX_ITEMS
 
 
 def default_db_provider(db_path: Path | None) -> sqlite3.Connection:
@@ -116,18 +137,117 @@ def status(
     return 0
 
 
+_DRAIN_HEADER = "kairix dead-letter drain"
+
+
+def _render_drain_summary(summary: DrainSummary, *, dry_run: bool) -> str:
+    """One human-readable line per drained (or previewed) source."""
+    verb = "would drain" if dry_run else "drained"
+    return (
+        f"  {summary.connector_name}: {verb} {summary.drained} "
+        f"(corrupt_zip={summary.corrupt_zip}, unsupported_mime={summary.unsupported_mime}) "
+        f"left={summary.left}\n"
+    )
+
+
+def _write_drain_report(summaries: tuple[DrainSummary, ...], *, dry_run: bool, out: TextIO) -> None:
+    """Print the per-source summary block + a totals footer."""
+    mode = " (dry-run — nothing was mutated)" if dry_run else ""
+    out.write(f"{_DRAIN_HEADER}{mode}\n")
+    if not summaries:
+        out.write("  no drainable dead-letter state found.\n")
+        return
+    total = 0
+    for summary in summaries:
+        out.write(_render_drain_summary(summary, dry_run=dry_run))
+        total += summary.drained
+    verb = "would drain" if dry_run else "drained"
+    out.write(f"  total: {verb} {total} across {len(summaries)} source(s).\n")
+
+
+def _run_drain(conn: sqlite3.Connection, *, source_name: str | None, dry_run: bool, max_items: int) -> tuple:
+    """Dispatch one or all sources through the drain core.
+
+    Builds the silver processor on the SAME connection the core commits
+    on. When ``source_name`` is given, drains just that source (works for
+    orphaned/inactive sources); otherwise sweeps every distinct source.
+    Always returns a tuple of :class:`DrainSummary` so the renderer is
+    uniform.
+    """
+    from kairix.core.connectors.deadletter_drain import (
+        drain_all_source_deadletters,
+        drain_source_deadletters,
+    )
+    from kairix.core.connectors.silver import DefaultSilverProcessor, SqliteDocumentsMediaWriter
+
+    silver = DefaultSilverProcessor(documents_media_writer=SqliteDocumentsMediaWriter(conn))
+    if source_name is not None:
+        one = drain_source_deadletters(
+            conn, source_name=source_name, silver=silver, dry_run=dry_run, max_items=max_items
+        )
+        return (one,)
+    return drain_all_source_deadletters(conn, silver=silver, dry_run=dry_run, max_items=max_items)
+
+
+def drain(
+    *,
+    db_path: Path | None = None,
+    source_name: str | None = None,
+    dry_run: bool = False,
+    max_items: int = _DEFAULT_MAX_ITEMS,
+    out: TextIO | None = None,
+    err: TextIO | None = None,
+    db_provider: DbProvider = default_db_provider,
+) -> int:
+    """``kairix dead-letter drain [SOURCE]`` — clear the poisoned backlog.
+
+    Mutating one-shot for the orphaned-source backlog the periodic worker
+    sweep also covers. With ``source_name`` drains that one source (an
+    inactive/orphaned source drains just as well as an active one); without
+    it, drains EVERY distinct ``source_name`` in ``connector_deadletter``.
+    Eligibility is the EXISTING narrow rule — corrupt_zip OR a
+    known-unsupported MIME — never broadened here. ``dry_run`` reports what
+    WOULD drain without mutating.
+
+    Exits 0 on success (an empty backlog is a happy path); exits 1 only
+    when the DB cannot be opened. ``db_provider`` is the in-process DI
+    seam mirroring :func:`status`.
+    """
+    out = out if out is not None else sys.stdout
+    err = err if err is not None else sys.stderr
+    try:
+        conn = db_provider(db_path)
+    except sqlite3.Error as exc:
+        err.write(
+            "kairix dead-letter drain: could not open SQLite db. "
+            "fix: check the --db-path argument or KAIRIX_DB_PATH config. "
+            "next: confirm the db exists and is readable. "
+            f"run: ls -l {db_path or '<configured-default>'}\n"
+            f"underlying error: {type(exc).__name__}: {exc}\n"
+        )
+        return 1
+
+    with closing(conn):
+        summaries = _run_drain(conn, source_name=source_name, dry_run=dry_run, max_items=max_items)
+    _write_drain_report(summaries, dry_run=dry_run, out=out)
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
-    """Argparse for ``kairix dead-letter [status]``."""
+    """Argparse for ``kairix dead-letter [status|drain]``."""
     parser = argparse.ArgumentParser(
         prog="kairix dead-letter",
         description="Operator triage view over the connector_deadletter table.",
     )
     sub = parser.add_subparsers(dest="cmd")
-    status_p = sub.add_parser(
-        "status",
-        help="Show per-source dead-letter breakdown (failure_count, class, MIME, oldest).",
-    )
-    status_p.add_argument(
+    _add_status_parser(sub)
+    _add_drain_parser(sub)
+    return parser
+
+
+def _add_db_path_arg(subparser: argparse.ArgumentParser) -> None:
+    """Attach the shared ``--db-path`` F30 subprocess seam to a subparser."""
+    subparser.add_argument(
         "--db-path",
         default=None,
         help=(
@@ -137,6 +257,15 @@ def build_parser() -> argparse.ArgumentParser:
             "monkeypatch.setenv (F2-clean)."
         ),
     )
+
+
+def _add_status_parser(sub: Any) -> None:
+    """Register the ``status`` subcommand."""
+    status_p = sub.add_parser(
+        "status",
+        help="Show per-source dead-letter breakdown (failure_count, class, MIME, oldest).",
+    )
+    _add_db_path_arg(status_p)
     status_p.add_argument(
         "--source-name",
         default=None,
@@ -148,7 +277,34 @@ def build_parser() -> argparse.ArgumentParser:
         action=_STORE_TRUE,
         help="Emit the full report as JSON on stdout (machine-readable, parity with the MCP tool).",
     )
-    return parser
+
+
+def _add_drain_parser(sub: Any) -> None:
+    """Register the ``drain`` subcommand."""
+    drain_p = sub.add_parser(
+        "drain",
+        help="Clear permanently-unprocessable dead-letters for one source (or every source).",
+    )
+    _add_db_path_arg(drain_p)
+    drain_p.add_argument(
+        _ARG_SOURCE_NAME,
+        nargs="?",
+        default=None,
+        help="Drain just this source (e.g. sharepoint); omit to drain every distinct source.",
+    )
+    drain_p.add_argument(
+        "--dry-run",
+        dest="dry_run",
+        action=_STORE_TRUE,
+        help="Report what WOULD drain (per source + per failure class) WITHOUT mutating.",
+    )
+    drain_p.add_argument(
+        "--max",
+        dest="max_items",
+        type=int,
+        default=_DEFAULT_MAX_ITEMS,
+        help=f"Per-source scan cap (default {_DEFAULT_MAX_ITEMS}); a deeper backlog drains over multiple runs.",
+    )
 
 
 def _resolve_db_path_arg(arg: str | None, injected: Path | None) -> Path | None:
@@ -164,25 +320,33 @@ def main(
     db_path: Path | None = None,
     db_provider: DbProvider = default_db_provider,
 ) -> int | None:
-    """CLI entry point. Routes to the ``status`` subcommand.
+    """CLI entry point. Routes to the ``status`` or ``drain`` subcommand.
 
     ``db_path`` is the in-process seam; the CLI flag is the subprocess
     seam. ``db_provider`` is the in-process DI seam for the underlying
     connection — leaving it at the default routes through
     :func:`kairix.paths.db_path`. Default subcommand is ``status`` —
-    typing ``kairix dead-letter`` without an action runs status because
-    that's the only action today.
+    typing ``kairix dead-letter`` without an action runs the read-only
+    triage view rather than the mutating drain.
     """
     parser = build_parser()
     args = parser.parse_args(argv)
 
     cmd = args.cmd or "status"
+    resolved_db = _resolve_db_path_arg(getattr(args, "db_path", None), db_path)
     if cmd == "status":
-        resolved_db = _resolve_db_path_arg(getattr(args, "db_path", None), db_path)
         return status(
             db_path=resolved_db,
-            source_name=getattr(args, "source_name", None),
+            source_name=getattr(args, _ARG_SOURCE_NAME, None),
             as_json=getattr(args, "as_json", False),
+            db_provider=db_provider,
+        )
+    if cmd == "drain":
+        return drain(
+            db_path=resolved_db,
+            source_name=getattr(args, _ARG_SOURCE_NAME, None),
+            dry_run=getattr(args, "dry_run", False),
+            max_items=getattr(args, "max_items", _DEFAULT_MAX_ITEMS),
             db_provider=db_provider,
         )
 

--- a/kairix/worker.py
+++ b/kairix/worker.py
@@ -124,6 +124,17 @@ NEO4J_DRAIN_INTERVAL = 600  # 10 minutes
 # so both DB-maintenance ticks share the same operational rhythm.
 WAL_CHECKPOINT_INTERVAL = 600  # 10 minutes
 
+# PR-5 — orphaned-source dead-letter sweep cadence. The per-connector
+# auto-drain (run after each connector batch) only drains CURRENTLY-ACTIVE
+# connectors; dead-letters from a source whose connector was removed never
+# drain through that path. This periodic sweep walks EVERY distinct
+# source_name in connector_deadletter and drains the orphaned backlog over
+# time. 3600s (1 hour) is deliberately slower than CONNECTOR_SYNC_INTERVAL
+# (900s) so the per-connector drain almost always runs first; the sweep is
+# the cheap, idempotent backstop for the orphaned remainder. Cheap when
+# clean — an empty table is a single GROUP BY read.
+DEADLETTER_SWEEP_INTERVAL = 3600  # 1 hour
+
 # Idle backoff (#224): when embed runs find no work to do, the next-embed
 # wait extends exponentially. Cap at 4 hours so we don't go totally silent
 # on a long-idle vault but also don't churn CPU/IO every hour for nothing.
@@ -1298,6 +1309,38 @@ def _default_wal_checkpoint() -> dict[str, int]:
     return {"busy": busy, "log_pages": log_pages, "checkpointed": checkpointed}
 
 
+def _default_deadletter_sweep() -> tuple[Any, ...]:
+    """Worker-loop dispatch slot for the orphaned-source dead-letter sweep (PR-5).
+
+    Opens the kairix index DB and runs
+    :func:`kairix.core.connectors.deadletter_drain.drain_all_source_deadletters`
+    over EVERY distinct ``source_name`` — including ORPHANED sources whose
+    connector is no longer active, which the per-connector auto-drain never
+    reaches. Returns the per-source :class:`DrainSummary` tuple so the
+    worker can log a structured outcome.
+
+    Reuses the EXISTING narrow eligibility (corrupt_zip OR known-unsupported
+    MIME) and the per-source best-effort / idempotent core verbatim — this
+    slot adds reach across sources, never broadened eligibility. Cheap when
+    clean: an empty table enumerates to zero sources.
+
+    Tests inject a substitute via ``WorkerDeps(deadletter_sweep_fn=fake)``;
+    production omits and gets this default.
+    """
+    import sqlite3
+
+    from kairix.core.connectors.deadletter_drain import drain_all_source_deadletters
+    from kairix.core.connectors.silver import DefaultSilverProcessor, SqliteDocumentsMediaWriter
+    from kairix.paths import db_path
+
+    conn = sqlite3.connect(str(db_path()), timeout=30.0)
+    try:
+        silver = DefaultSilverProcessor(documents_media_writer=SqliteDocumentsMediaWriter(conn))
+        return drain_all_source_deadletters(conn, silver=silver)
+    finally:
+        conn.close()
+
+
 def _default_connector_sync() -> ConnectorSyncResult:
     """Worker-loop dispatch slot for the connector-sync maintenance task.
 
@@ -1662,6 +1705,14 @@ class WorkerDeps:
     # production omits and gets ``_default_wal_checkpoint`` which opens
     # the kairix index DB and runs PRAGMA wal_checkpoint(TRUNCATE).
     wal_checkpoint_fn: Callable[[], Any] = field(default_factory=lambda: _default_wal_checkpoint)
+    # PR-5 — orphaned-source dead-letter sweep dispatch slot. Same F6-clean
+    # default_factory shape as ``wal_checkpoint_fn``. Tests pass a Fake;
+    # production omits and gets ``_default_deadletter_sweep`` which opens
+    # the kairix index DB and drains every distinct source's permanently-
+    # unprocessable backlog — orphaned (no-longer-active) sources included.
+    # Returns the per-source DrainSummary tuple (typed Any so the import
+    # stays in the function body, keeping worker boot lazy).
+    deadletter_sweep_fn: Callable[[], Any] = field(default_factory=lambda: _default_deadletter_sweep)
     sleep: Callable[[float], None] = field(default_factory=lambda: time.sleep)
     # #224 phase 4-5 combined — observable state + pause flag.
     # ``state`` is the in-memory dataclass the loop mutates on phase changes.
@@ -2012,6 +2063,36 @@ def run_wal_checkpoint(deps: WorkerDeps | None = None) -> None:
         logger.warning("worker: wal checkpoint raised — %s", exc)
 
 
+def run_deadletter_sweep(deps: WorkerDeps | None = None) -> None:
+    """PR-5 — drive one orphaned-source dead-letter sweep tick.
+
+    Invokes ``deps.deadletter_sweep_fn`` (default
+    :func:`_default_deadletter_sweep`) which drains the permanently-
+    unprocessable backlog for EVERY distinct source — including ORPHANED
+    sources whose connector is no longer active, the gap the
+    per-connector auto-drain leaves open. Logs an aggregate
+    sources/drained line from the returned :class:`DrainSummary` tuple.
+
+    Mirrors the ``(Exception, SystemExit)`` discipline of every other
+    worker maintenance helper — a sweep failure must never bring the
+    worker process down. The per-source core is itself best-effort +
+    idempotent, so a re-run is always safe.
+
+    Tests construct ``WorkerDeps(deadletter_sweep_fn=fake)``; production
+    omits the kwarg and the default factory wires
+    :func:`_default_deadletter_sweep`.
+    """
+    deps = deps if deps is not None else WorkerDeps()
+    try:
+        summaries = deps.deadletter_sweep_fn()
+        rows = tuple(summaries) if summaries is not None else ()
+        drained = sum(int(getattr(s, "drained", 0)) for s in rows)
+        if drained:
+            logger.info("worker: deadletter sweep complete — sources=%d drained=%d", len(rows), drained)
+    except (Exception, SystemExit) as exc:
+        logger.warning("worker: deadletter sweep raised — %s", exc)
+
+
 @dataclass
 class _Schedule:
     """Worker task interval config — bundles the cadence ints.
@@ -2030,6 +2111,7 @@ class _Schedule:
     connector_sync: int
     neo4j_drain: int
     wal_checkpoint: int
+    deadletter_sweep: int
 
 
 def _resolve_schedule(
@@ -2040,6 +2122,7 @@ def _resolve_schedule(
     connector_sync_interval: int | None,
     neo4j_drain_interval: int | None = None,
     wal_checkpoint_interval: int | None = None,
+    deadletter_sweep_interval: int | None = None,
 ) -> _Schedule:
     """Fold kwargs + module defaults into a single ``_Schedule``."""
     return _Schedule(
@@ -2050,6 +2133,9 @@ def _resolve_schedule(
         connector_sync=connector_sync_interval if connector_sync_interval is not None else CONNECTOR_SYNC_INTERVAL,
         neo4j_drain=neo4j_drain_interval if neo4j_drain_interval is not None else NEO4J_DRAIN_INTERVAL,
         wal_checkpoint=(wal_checkpoint_interval if wal_checkpoint_interval is not None else WAL_CHECKPOINT_INTERVAL),
+        deadletter_sweep=(
+            deadletter_sweep_interval if deadletter_sweep_interval is not None else DEADLETTER_SWEEP_INTERVAL
+        ),
     )
 
 
@@ -2460,8 +2546,9 @@ def _maybe_run_maintenance_cycle(
     last_connector_sync: float,
     last_neo4j_drain: float,
     last_wal_checkpoint: float,
+    last_deadletter_sweep: float,
     schedule: _Schedule,
-) -> tuple[float, float, float, float, float, float]:
+) -> tuple[float, float, float, float, float, float, float]:
     """Run any maintenance task whose interval has elapsed; return updated timestamps.
 
     Two buckets (#312):
@@ -2471,11 +2558,13 @@ def _maybe_run_maintenance_cycle(
       enough to set the embed-noop streak above the threshold, none of
       these have anything to do and the maintenance scan is wasted work.
 
-    * **External-source-discovery** (connector_sync) AND **Curator
-      coupling boundary** (neo4j_drain, GH #334) — ALWAYS run on their
-      intervals regardless of ``maintenance_active``. A quiet local
-      vault does NOT imply quiet upstream sources or a drained
-      ``entity_signals`` queue.
+    * **External-source-discovery** (connector_sync), **Curator coupling
+      boundary** (neo4j_drain, GH #334), **DB maintenance**
+      (wal_checkpoint) AND the **orphaned-source dead-letter sweep**
+      (deadletter_sweep, PR-5) — ALWAYS run on their intervals regardless
+      of ``maintenance_active``. A quiet local vault does NOT imply quiet
+      upstream sources, a drained ``entity_signals`` queue, or a drained
+      orphaned-source dead-letter backlog.
     """
     new_entity, new_health, new_wikilinks = last_entity, last_health, last_wikilinks
     if maintenance_active:
@@ -2510,6 +2599,11 @@ def _maybe_run_maintenance_cycle(
         _run_maintenance_task(deps, transition, run_wal_checkpoint)
         new_wal_checkpoint = now
 
+    new_deadletter_sweep = last_deadletter_sweep
+    if now - last_deadletter_sweep >= schedule.deadletter_sweep:
+        _run_maintenance_task(deps, transition, run_deadletter_sweep)
+        new_deadletter_sweep = now
+
     return (
         new_entity,
         new_health,
@@ -2517,6 +2611,7 @@ def _maybe_run_maintenance_cycle(
         new_connector_sync,
         new_neo4j_drain,
         new_wal_checkpoint,
+        new_deadletter_sweep,
     )
 
 
@@ -2529,6 +2624,7 @@ def main(
     wikilinks_interval: int | None = None,
     connector_sync_interval: int | None = None,
     neo4j_drain_interval: int | None = None,
+    deadletter_sweep_interval: int | None = None,
 ) -> None:
     """Run the worker loop.
 
@@ -2559,6 +2655,7 @@ def main(
         wikilinks_interval,
         connector_sync_interval,
         neo4j_drain_interval,
+        deadletter_sweep_interval=deadletter_sweep_interval,
     )
 
     logger.info(
@@ -2634,6 +2731,10 @@ def main(
     # first post-boot iteration truncates the WAL immediately (catches
     # any inherited bloat from before the previous shutdown).
     last_wal_checkpoint = 0.0
+    # PR-5 — last orphaned-source dead-letter sweep. Same 0.0 bootstrap so
+    # the first post-boot iteration sweeps immediately, clearing any
+    # orphaned backlog inherited from before the previous shutdown.
+    last_deadletter_sweep = 0.0
     # KFEAT-021 — last maintenance tick. Carried in WorkerState across
     # restarts so the cadence survives a container bounce; mirror it
     # into a local for the in-loop is_tick_due comparison.
@@ -2710,6 +2811,7 @@ def main(
             last_connector_sync,
             last_neo4j_drain,
             last_wal_checkpoint,
+            last_deadletter_sweep,
         ) = _maybe_run_maintenance_cycle(
             deps=deps,
             transition=_transition,
@@ -2721,6 +2823,7 @@ def main(
             last_connector_sync=last_connector_sync,
             last_neo4j_drain=last_neo4j_drain,
             last_wal_checkpoint=last_wal_checkpoint,
+            last_deadletter_sweep=last_deadletter_sweep,
             schedule=schedule,
         )
 

--- a/tests/bdd/features/cli_dead_letter_drain.feature
+++ b/tests/bdd/features/cli_dead_letter_drain.feature
@@ -1,0 +1,27 @@
+Feature: kairix dead-letter drain — clear the orphaned-source backlog
+  As a kairix operator who removed a connector but still sees its poisoned
+  dead-letters piling up in connector_deadletter
+  I want a single command that drains the permanently-unprocessable backlog
+  So that an orphaned source's noise stops inflating the failed counter
+  even though no active connector will ever drain it
+
+  Scenario: Drain one orphaned source — its permanently-unprocessable row clears
+    Given a kairix database with a drainable dead-letter for an orphaned source
+    When the operator runs the kairix dead-letter drain command for that source
+    Then the drain stdout reports one row drained for that source
+    And the orphaned source has no remaining dead-letter rows
+    And the drain command exits with code 0
+
+  Scenario: Drain every source — all distinct sources are swept
+    Given a kairix database with drainable dead-letters for two orphaned sources
+    When the operator runs the kairix dead-letter drain command for all sources
+    Then the drain stdout reports a total across two sources
+    And both orphaned sources have no remaining dead-letter rows
+    And the drain command exits with code 0
+
+  Scenario: Dry-run reports what would drain without mutating
+    Given a kairix database with a drainable dead-letter for an orphaned source
+    When the operator runs the kairix dead-letter drain command in dry-run mode
+    Then the drain stdout reports what would drain in dry-run mode
+    And the orphaned source still has its dead-letter row
+    And the drain command exits with code 0

--- a/tests/bdd/steps/cli_dead_letter_drain_steps.py
+++ b/tests/bdd/steps/cli_dead_letter_drain_steps.py
@@ -1,0 +1,152 @@
+"""Step definitions for cli_dead_letter_drain.feature (PR-5).
+
+Drives the ``kairix dead-letter drain`` verb through its public adapter
+``kairix.dead_letter_cli.main`` with the ``db_path=`` kwarg seam — no
+monkeypatching of paths.py or env vars.
+
+F1-clean: no @patch on kairix internals. F2-clean: no env-var
+manipulation. F4-clean: paths.py owns env-var reads. F46-compliant:
+the step impls invoke the CLI ``main`` entry point.
+"""
+
+from __future__ import annotations
+
+import io
+import sqlite3
+from contextlib import redirect_stdout
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pytest_bdd import given, then, when
+
+from kairix.core.db.schema import create_schema
+from kairix.dead_letter_cli import main as dead_letter_main
+
+pytestmark = pytest.mark.bdd
+
+# A permanently-unprocessable last_error + a known-unsupported MIME so the
+# drain core's narrow eligibility fires for the seeded rows.
+_ERR_DRAINABLE = "some other connector error"
+_MIME_UNSUPPORTED = "application/msword"
+_ORPHAN_A = "removed-sharepoint"
+_ORPHAN_B = "removed-gdrive"
+
+
+def _seed_orphan(db: sqlite3.Connection, source_name: str) -> None:
+    """One drainable dead-letter + its unsupported-MIME bronze row."""
+    db.execute(
+        "INSERT INTO connector_deadletter "
+        "(source_name, item_id, failure_count, last_error, last_attempt) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (source_name, "poison-1", 3, _ERR_DRAINABLE, "2026-05-26T05:58:00Z"),
+    )
+    db.execute(
+        "INSERT INTO bronze_records "
+        "(source_name, item_id, raw_path, mime, fetched_at, content_hash) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (source_name, "poison-1", "/bronze/poison-1", _MIME_UNSUPPORTED, "2026-05-26T05:50:00Z", f"h-{source_name}"),
+    )
+
+
+def _seed_db(tmp_path: Path, sources: tuple[str, ...]) -> Path:
+    db_path = tmp_path / "kairix.sqlite"
+    db = sqlite3.connect(str(db_path))
+    create_schema(db)
+    for src in sources:
+        _seed_orphan(db, src)
+    db.commit()
+    db.close()
+    return db_path
+
+
+def _remaining(db_path: Path, source_name: str) -> int:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return int(
+            conn.execute(
+                "SELECT COUNT(*) FROM connector_deadletter WHERE source_name = ?",
+                (source_name,),
+            ).fetchone()[0]
+        )
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def _drain_state(tmp_path: Path) -> dict[str, Any]:
+    return {"tmp_path": tmp_path, "db_path": None, "stdout": "", "exit_code": -1}
+
+
+@given("a kairix database with a drainable dead-letter for an orphaned source")
+def _one_orphan(_drain_state: dict[str, Any]) -> None:
+    _drain_state["db_path"] = _seed_db(_drain_state["tmp_path"], (_ORPHAN_A,))
+
+
+@given("a kairix database with drainable dead-letters for two orphaned sources")
+def _two_orphans(_drain_state: dict[str, Any]) -> None:
+    _drain_state["db_path"] = _seed_db(_drain_state["tmp_path"], (_ORPHAN_A, _ORPHAN_B))
+
+
+def _run(state: dict[str, Any], argv: list[str]) -> None:
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        exit_code = dead_letter_main(argv, db_path=state["db_path"])
+    state["stdout"] = buf.getvalue()
+    state["exit_code"] = exit_code if exit_code is not None else 0
+
+
+@when("the operator runs the kairix dead-letter drain command for that source")
+def _run_drain_one(_drain_state: dict[str, Any]) -> None:
+    _run(_drain_state, ["drain", _ORPHAN_A])
+
+
+@when("the operator runs the kairix dead-letter drain command for all sources")
+def _run_drain_all(_drain_state: dict[str, Any]) -> None:
+    _run(_drain_state, ["drain"])
+
+
+@when("the operator runs the kairix dead-letter drain command in dry-run mode")
+def _run_drain_dry(_drain_state: dict[str, Any]) -> None:
+    _run(_drain_state, ["drain", _ORPHAN_A, "--dry-run"])
+
+
+@then("the drain stdout reports one row drained for that source")
+def _reports_one_drained(_drain_state: dict[str, Any]) -> None:
+    out = _drain_state["stdout"]
+    assert _ORPHAN_A in out, f"expected source name in output; got: {out!r}"
+    assert "drained 1" in out, f"expected 'drained 1'; got: {out!r}"
+
+
+@then("the drain stdout reports a total across two sources")
+def _reports_two_total(_drain_state: dict[str, Any]) -> None:
+    out = _drain_state["stdout"]
+    assert "across 2 source(s)" in out, f"expected two-source total; got: {out!r}"
+
+
+@then("the drain stdout reports what would drain in dry-run mode")
+def _reports_dry_run(_drain_state: dict[str, Any]) -> None:
+    out = _drain_state["stdout"]
+    assert "dry-run" in out, f"expected dry-run marker; got: {out!r}"
+    assert "would drain 1" in out, f"expected 'would drain 1'; got: {out!r}"
+
+
+@then("the orphaned source has no remaining dead-letter rows")
+def _orphan_drained(_drain_state: dict[str, Any]) -> None:
+    assert _remaining(_drain_state["db_path"], _ORPHAN_A) == 0
+
+
+@then("both orphaned sources have no remaining dead-letter rows")
+def _both_drained(_drain_state: dict[str, Any]) -> None:
+    assert _remaining(_drain_state["db_path"], _ORPHAN_A) == 0
+    assert _remaining(_drain_state["db_path"], _ORPHAN_B) == 0
+
+
+@then("the orphaned source still has its dead-letter row")
+def _orphan_untouched(_drain_state: dict[str, Any]) -> None:
+    assert _remaining(_drain_state["db_path"], _ORPHAN_A) == 1
+
+
+@then("the drain command exits with code 0")
+def _exits_zero(_drain_state: dict[str, Any]) -> None:
+    assert _drain_state["exit_code"] == 0, f"expected exit 0; got {_drain_state['exit_code']}"

--- a/tests/bdd/test_cli_dead_letter_drain.py
+++ b/tests/bdd/test_cli_dead_letter_drain.py
@@ -1,0 +1,25 @@
+"""pytest-bdd test module for cli_dead_letter_drain.feature (PR-5)."""
+
+from pathlib import Path
+
+import pytest
+from pytest_bdd import scenario
+
+FEATURE = str(Path(__file__).parent / "features" / "cli_dead_letter_drain.feature")
+
+pytestmark = pytest.mark.bdd
+
+
+@scenario(FEATURE, "Drain one orphaned source — its permanently-unprocessable row clears")
+def test_drain_one_orphaned_source() -> None:
+    """Body populated by @scenario from the .feature file."""
+
+
+@scenario(FEATURE, "Drain every source — all distinct sources are swept")
+def test_drain_every_source() -> None:
+    """Body populated by @scenario from the .feature file."""
+
+
+@scenario(FEATURE, "Dry-run reports what would drain without mutating")
+def test_drain_dry_run() -> None:
+    """Body populated by @scenario from the .feature file."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -199,6 +199,8 @@ pytest_plugins = [
     # Dead-letter triage surface (kairix dead-letter status CLI +
     # tool_dead_letter_status MCP). See GH #337 / #351.
     "tests.bdd.steps.cli_dead_letter_steps",
+    # PR-5 — orphaned-source dead-letter drain verb (kairix dead-letter drain).
+    "tests.bdd.steps.cli_dead_letter_drain_steps",
     "tests.bdd.steps.mcp_dead_letter_status_steps",
     # Wave 5 KP-1 — Dex CRM connector flag at introduce stage. F54.
     "tests.bdd.steps.feature_flag_connector_dex_crm_steps",

--- a/tests/integration/test_outcome_cli_dead_letter_drain.py
+++ b/tests/integration/test_outcome_cli_dead_letter_drain.py
@@ -1,0 +1,131 @@
+"""F30 outcome test — ``kairix dead-letter drain`` subprocess surface (PR-5).
+
+Per F30: every CLI subcommand in ``kairix/cli.py:COMMANDS`` ships with an
+outcome test that (a) invokes via
+``subprocess.run([python, -m, kairix.cli, dead-letter, drain, ...])`` with
+a ``--db-path`` flag (no ``KAIRIX_*`` env vars per F2), and (b) asserts on
+``.stdout`` / ``.stderr`` content (not on returncode alone).
+
+The drain verb closes the orphaned-source gap: dead-letters from a source
+whose connector is no longer active never drain through the per-connector
+auto-drain. This file covers the operator one-shot:
+
+* named single-source drain clears that ORPHANED source's backlog;
+* no-source drain sweeps EVERY distinct source;
+* ``--dry-run`` reports what WOULD drain WITHOUT mutating.
+
+Sabotage proof executed before commit (mutate → run → fail → restore →
+pass): the ``--dry-run`` test is the load-bearing one — making
+``_run_drain`` ignore the ``dry_run`` flag clears the row and the
+``COUNT(*) == 1`` post-condition fails.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from kairix.core.db.schema import create_schema
+
+pytestmark = pytest.mark.integration
+
+# A permanently-unprocessable last_error + a known-unsupported MIME so the
+# drain core's narrow eligibility (corrupt_zip OR known-unsupported MIME)
+# fires for the seeded rows.
+_ERR_DRAINABLE = "some other connector error"
+_MIME_UNSUPPORTED = "application/msword"
+
+
+def _bootstrap_db(tmp_path: Path) -> Path:
+    db_path = tmp_path / "kairix.sqlite"
+    db = sqlite3.connect(str(db_path))
+    create_schema(db)
+    db.commit()
+    db.close()
+    return db_path
+
+
+def _seed_orphan(db_path: Path, source_name: str) -> None:
+    """One drainable dead-letter + its unsupported-MIME bronze row."""
+    db = sqlite3.connect(str(db_path))
+    try:
+        db.execute(
+            "INSERT INTO connector_deadletter "
+            "(source_name, item_id, failure_count, last_error, last_attempt) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (source_name, "poison-1", 3, _ERR_DRAINABLE, "2026-05-26T05:58:00Z"),
+        )
+        db.execute(
+            "INSERT INTO bronze_records "
+            "(source_name, item_id, raw_path, mime, fetched_at, content_hash) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (source_name, "poison-1", "/bronze/p1", _MIME_UNSUPPORTED, "2026-05-26T05:50:00Z", f"h-{source_name}"),
+        )
+        db.commit()
+    finally:
+        db.close()
+
+
+def _remaining(db_path: Path, source_name: str) -> int:
+    db = sqlite3.connect(str(db_path))
+    try:
+        return int(
+            db.execute(
+                "SELECT COUNT(*) FROM connector_deadletter WHERE source_name = ?",
+                (source_name,),
+            ).fetchone()[0]
+        )
+    finally:
+        db.close()
+
+
+def _run_drain(db_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "kairix.cli", "dead-letter", "drain", "--db-path", str(db_path), *args],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def test_drain_named_orphaned_source_clears_backlog(tmp_path: Path) -> None:
+    """``dead-letter drain SOURCE`` clears an ORPHANED source's drainable row."""
+    db_path = _bootstrap_db(tmp_path)
+    _seed_orphan(db_path, "removed-sharepoint")
+    proc = _run_drain(db_path, "removed-sharepoint")
+    assert proc.returncode == 0, f"unexpected exit {proc.returncode}: {proc.stderr}"
+    assert "removed-sharepoint" in proc.stdout
+    assert "drained 1" in proc.stdout, f"expected 'drained 1'; got: {proc.stdout!r}"
+    assert _remaining(db_path, "removed-sharepoint") == 0
+
+
+def test_drain_all_sources_sweeps_every_source(tmp_path: Path) -> None:
+    """``dead-letter drain`` with no source sweeps every distinct source."""
+    db_path = _bootstrap_db(tmp_path)
+    _seed_orphan(db_path, "removed-sharepoint")
+    _seed_orphan(db_path, "removed-gdrive")
+    proc = _run_drain(db_path)
+    assert proc.returncode == 0, f"unexpected exit {proc.returncode}: {proc.stderr}"
+    assert "across 2 source(s)" in proc.stdout, f"expected two-source total; got: {proc.stdout!r}"
+    assert _remaining(db_path, "removed-sharepoint") == 0
+    assert _remaining(db_path, "removed-gdrive") == 0
+
+
+def test_drain_dry_run_mutates_nothing(tmp_path: Path) -> None:
+    """``dead-letter drain SOURCE --dry-run`` reports but leaves the row.
+
+    Sabotage: make ``_run_drain`` ignore ``dry_run`` → the row clears and
+    the ``_remaining == 1`` post-condition fails.
+    """
+    db_path = _bootstrap_db(tmp_path)
+    _seed_orphan(db_path, "removed-sharepoint")
+    proc = _run_drain(db_path, "removed-sharepoint", "--dry-run")
+    assert proc.returncode == 0, f"unexpected exit {proc.returncode}: {proc.stderr}"
+    assert "dry-run" in proc.stdout, f"expected dry-run marker; got: {proc.stdout!r}"
+    assert "would drain 1" in proc.stdout
+    # Nothing was mutated — the row survives.
+    assert _remaining(db_path, "removed-sharepoint") == 1

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1883,6 +1883,159 @@ def test_run_wal_checkpoint_handles_non_dict_return() -> None:
 
 
 # ---------------------------------------------------------------------------
+# run_deadletter_sweep() tests (PR-5)
+# ---------------------------------------------------------------------------
+
+
+def test_run_deadletter_sweep_invokes_fn_and_logs() -> None:
+    """run_deadletter_sweep delegates to deps.deadletter_sweep_fn."""
+    from kairix.core.connectors.deadletter_drain import DrainSummary
+    from kairix.worker import run_deadletter_sweep
+
+    calls: list[bool] = []
+
+    def _fake_sweep() -> tuple[DrainSummary, ...]:
+        calls.append(True)
+        return (DrainSummary("removed-sharepoint", drained=2, corrupt_zip=1, unsupported_mime=1, left=0),)
+
+    run_deadletter_sweep(deps=WorkerDeps(deadletter_sweep_fn=_fake_sweep))
+    assert calls == [True], "deadletter_sweep_fn must be invoked once"
+
+
+def test_run_deadletter_sweep_catches_exceptions() -> None:
+    """A raised sweep must not crash the worker loop."""
+    import sqlite3
+
+    from kairix.worker import run_deadletter_sweep
+
+    def _raising_sweep() -> tuple:
+        raise sqlite3.OperationalError("database is locked")
+
+    # Must not raise — the (Exception, SystemExit) catch keeps the worker alive.
+    run_deadletter_sweep(deps=WorkerDeps(deadletter_sweep_fn=_raising_sweep))
+
+
+def test_run_deadletter_sweep_handles_none_return() -> None:
+    """A misbehaving fn returning None must not crash the aggregate log."""
+    from kairix.worker import run_deadletter_sweep
+
+    def _returns_none() -> None:
+        return None
+
+    # A () -> None callable is assignable to the Callable[[], Any] slot; this
+    # pins the run_deadletter_sweep aggregate-log tolerance for an empty/None return.
+    run_deadletter_sweep(deps=WorkerDeps(deadletter_sweep_fn=_returns_none))
+
+
+@pytest.mark.unit
+def test_main_loop_calls_deadletter_sweep_at_interval(tmp_path: Path) -> None:
+    """When ``deadletter_sweep_interval`` has elapsed, ``main()`` drives the
+    injected ``deadletter_sweep_fn`` from the dispatch loop — the periodic
+    orphaned-source sweep is actually wired into the worker tick.
+
+    Sabotage proof: remove the ``deadletter_sweep`` dispatch block in
+    ``_maybe_run_maintenance_cycle`` → ``sweep_calls['n'] == 0`` and this
+    assertion fails. Restored, it passes — proving the slot is live.
+    """
+    import os
+
+    from kairix.core.connectors.deadletter_drain import DrainSummary
+
+    embed_calls = {"n": 0}
+    sweep_calls = {"n": 0}
+
+    def _embed_then_shutdown() -> None:
+        embed_calls["n"] += 1
+        if embed_calls["n"] >= 2:
+            os.kill(os.getpid(), signal.SIGTERM)  # NOSONAR — self-signal to terminate loop in test.
+
+    def _sweep() -> tuple[DrainSummary, ...]:
+        sweep_calls["n"] += 1
+        return ()
+
+    main(
+        deps=WorkerDeps(
+            embed=_embed_then_shutdown,
+            entity_seed=lambda: None,
+            health_check=lambda: [],
+            wikilinks=lambda: None,
+            connector_sync_fn=lambda: ConnectorSyncResult(),
+            deadletter_sweep_fn=_sweep,
+            sleep=lambda _s: None,
+            state_path=tmp_path / "worker-state.json",
+            write_state_fn=lambda *_: None,
+        ),
+        embed_interval=0,
+        entity_seed_interval=999999,
+        health_check_interval=999999,
+        wikilinks_interval=999999,
+        connector_sync_interval=999999,
+        deadletter_sweep_interval=0,
+    )
+
+    assert sweep_calls["n"] >= 1, (
+        f"expected deadletter_sweep to fire at least once on interval=0; got {sweep_calls['n']}"
+    )
+
+
+@pytest.mark.unit
+def test_main_loop_runs_deadletter_sweep_above_maintenance_threshold(tmp_path: Path) -> None:
+    """The sweep MUST run regardless of the embed-noop streak.
+
+    A quiet local vault does not imply a drained orphaned-source
+    dead-letter backlog — the sweep is in the always-run bucket alongside
+    connector_sync / neo4j_drain.
+
+    Sabotage proof: move the sweep dispatch inside the
+    ``if maintenance_active:`` block → with the high streak ``sweep_calls``
+    drops to 0 and this fails.
+    """
+    import os
+
+    from kairix.core.connectors.deadletter_drain import DrainSummary
+    from kairix.worker import MAINTENANCE_SKIP_NOOP_THRESHOLD
+
+    embed_calls = {"n": 0}
+    sweep_calls = {"n": 0}
+
+    def _embed_noop_then_shutdown() -> None:
+        embed_calls["n"] += 1
+        if embed_calls["n"] >= 2:
+            os.kill(os.getpid(), signal.SIGTERM)  # NOSONAR — self-signal so the loop exits.
+
+    def _sweep() -> tuple[DrainSummary, ...]:
+        sweep_calls["n"] += 1
+        return ()
+
+    seed_streak = MAINTENANCE_SKIP_NOOP_THRESHOLD + 1
+    main(
+        deps=WorkerDeps(
+            embed=_embed_noop_then_shutdown,
+            entity_seed=lambda: None,
+            health_check=lambda: [],
+            wikilinks=lambda: None,
+            connector_sync_fn=lambda: ConnectorSyncResult(),
+            deadletter_sweep_fn=_sweep,
+            sleep=lambda _s: None,
+            state=WorkerState(consecutive_embed_noops=seed_streak),
+            state_path=tmp_path / "worker-state.json",
+            write_state_fn=lambda *_: None,
+        ),
+        embed_interval=0,
+        entity_seed_interval=0,
+        health_check_interval=0,
+        wikilinks_interval=0,
+        connector_sync_interval=999999,
+        deadletter_sweep_interval=0,
+    )
+
+    assert sweep_calls["n"] >= 1, (
+        f"deadletter sweep MUST still run even when streak ({seed_streak}+) >= threshold "
+        f"({MAINTENANCE_SKIP_NOOP_THRESHOLD}); got {sweep_calls['n']} call(s)"
+    )
+
+
+# ---------------------------------------------------------------------------
 # connector_enabled() — same-module behaviour-pin (mutation parity).
 #
 # The full predicate matrix lives in

--- a/tests/unit/test_connector_deadletter_sweep.py
+++ b/tests/unit/test_connector_deadletter_sweep.py
@@ -1,0 +1,402 @@
+"""Unit tests for PR-5 — the orphaned-source dead-letter drain sweep.
+
+Covers the connector-agnostic per-source core + the all-source sweep in
+:mod:`kairix.core.connectors.deadletter_drain` added so dead-letters from
+a source whose connector is NO LONGER ACTIVE (the gap the per-connector
+auto-drain leaves open) still drain:
+
+* :func:`drain_source_deadletters` — drains an ORPHANED source (no active
+  connector instance required): eligible (corrupt_zip / known-unsupported
+  MIME) rows clear, ineligible (transient / recoverable) rows are LEFT;
+* :func:`drain_all_source_deadletters` — sweeps EVERY distinct source,
+  honours ``skip_sources``, is best-effort across sources, idempotent;
+* ``dry_run=True`` mutates NOTHING (no clear, no commit, no outcome rows)
+  while still reporting the correct per-source / per-class counts;
+* :func:`distinct_deadletter_sources` enumerates orphaned sources too.
+
+Eligibility itself (the narrow corrupt_zip OR known-unsupported-MIME rule)
+is pinned by ``test_connector_deadletter_drain.py`` — this file pins REACH
+across sources, not the predicate. Everything runs against the REAL
+``connector_deadletter`` / ``bronze_records`` / ``documents_media`` tables
+via ``create_schema`` + the REAL silver processor (F5: public surface only,
+no private-name imports).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from kairix.core.connectors.dead_letter import DeadLetterStore
+from kairix.core.connectors.deadletter_drain import (
+    DrainSummary,
+    distinct_deadletter_sources,
+    drain_all_source_deadletters,
+    drain_source_deadletters,
+)
+from kairix.core.connectors.silver import DefaultSilverProcessor, SqliteDocumentsMediaWriter
+from kairix.core.db.schema import create_schema
+
+pytestmark = pytest.mark.unit
+
+# An ORPHANED source — its connector is NOT registered / active anywhere.
+_ORPHAN = "removed-sharepoint"
+_OTHER_ORPHAN = "removed-gdrive"
+
+_ERR_CORRUPT_ZIP = "zipfile.BadZipFile: File is not a zip file"
+_ERR_OTHER = "some other weird connector error"
+_ERR_TIMEOUT = "Request timed out after 30s"
+_ERR_DECODE = "'utf-8' codec can't decode byte 0x80 in position 0"
+
+_MIME_MSWORD = "application/msword"  # KNOWN_UNSUPPORTED → drainable
+_MIME_TEXT = "text/plain"  # recoverable → left
+_MIME_PNG = "image/png"  # supported binary → left under transient/decode
+_STATUS_SKIPPED = "skipped_unsupported"
+
+
+def _open_db(tmp_path: Path) -> sqlite3.Connection:
+    db = sqlite3.connect(str(tmp_path / "kairix.sqlite"))
+    create_schema(db)
+    return db
+
+
+def _seed_dead_letter(db: sqlite3.Connection, source_name: str, item_id: str, last_error: str) -> None:
+    db.execute(
+        "INSERT INTO connector_deadletter "
+        "(source_name, item_id, failure_count, last_error, last_attempt) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (source_name, item_id, 3, last_error, "2026-06-20T00:00:00Z"),
+    )
+
+
+def _seed_bronze(
+    db: sqlite3.Connection,
+    source_name: str,
+    item_id: str,
+    mime: str,
+    *,
+    content_hash: str | None = "hash-x",
+) -> None:
+    db.execute(
+        "INSERT INTO bronze_records "
+        "(source_name, item_id, raw_path, mime, fetched_at, content_hash) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (source_name, item_id, f"/bronze/{item_id}", mime, "2026-06-19T00:00:00Z", content_hash),
+    )
+
+
+def _silver(db: sqlite3.Connection) -> DefaultSilverProcessor:
+    return DefaultSilverProcessor(documents_media_writer=SqliteDocumentsMediaWriter(db))
+
+
+def _remaining(db: sqlite3.Connection, source_name: str) -> set[str]:
+    return {e.item_id for e in DeadLetterStore(db).list(source_name)}
+
+
+def _documents_media_count(db: sqlite3.Connection) -> int:
+    return int(db.execute("SELECT COUNT(*) FROM documents_media").fetchone()[0])
+
+
+# --------------------------------------------------------------------------
+# drain_source_deadletters — the orphaned-source case (NO active connector)
+# --------------------------------------------------------------------------
+
+
+def test_orphaned_source_drains_eligible_and_leaves_ineligible(tmp_path: Path) -> None:
+    """An ORPHANED source's eligible rows drain; ineligible rows are LEFT.
+
+    No active connector instance is constructed anywhere — the core keys on
+    the ``source_name`` string alone, so a removed connector's backlog
+    drains exactly like an active one's. This is the whole point of PR-5.
+
+    Sabotage: gate the drain on an active-connector lookup → the orphaned
+    rows never clear and the ``drained == 2`` / remaining-set assertions
+    fail.
+    """
+    db = _open_db(tmp_path)
+    try:
+        _seed_dead_letter(db, _ORPHAN, "zip-item", _ERR_CORRUPT_ZIP)
+        _seed_bronze(db, _ORPHAN, "zip-item", _MIME_MSWORD, content_hash="h-zip")
+        _seed_dead_letter(db, _ORPHAN, "doc-item", _ERR_OTHER)
+        _seed_bronze(db, _ORPHAN, "doc-item", _MIME_MSWORD, content_hash="h-doc")
+        # recoverable transient on text → must be LEFT.
+        _seed_dead_letter(db, _ORPHAN, "txt-item", _ERR_TIMEOUT)
+        _seed_bronze(db, _ORPHAN, "txt-item", _MIME_TEXT, content_hash="h-txt")
+        db.commit()
+
+        summary = drain_source_deadletters(db, source_name=_ORPHAN, silver=_silver(db))
+
+        assert summary.drained == 2
+        assert summary.corrupt_zip == 1
+        assert summary.unsupported_mime == 1
+        assert summary.left == 1
+        assert _remaining(db, _ORPHAN) == {"txt-item"}
+    finally:
+        db.close()
+
+
+def test_orphaned_source_dry_run_mutates_nothing(tmp_path: Path) -> None:
+    """``dry_run`` reports what WOULD drain but clears / commits NOTHING.
+
+    Sabotage: drop the ``dry_run`` short-circuit in ``_tally_drain`` (let it
+    fall through to ``_drain_one``) → the rows clear and the
+    ``_remaining == {...}`` / ``documents_media == 0`` assertions fail.
+    """
+    db = _open_db(tmp_path)
+    try:
+        _seed_dead_letter(db, _ORPHAN, "zip-item", _ERR_CORRUPT_ZIP)
+        _seed_bronze(db, _ORPHAN, "zip-item", _MIME_MSWORD, content_hash="h-zip")
+        _seed_dead_letter(db, _ORPHAN, "doc-item", _ERR_OTHER)
+        _seed_bronze(db, _ORPHAN, "doc-item", _MIME_MSWORD, content_hash="h-doc")
+        db.commit()
+
+        summary = drain_source_deadletters(db, source_name=_ORPHAN, silver=_silver(db), dry_run=True)
+
+        # counts reflect what WOULD drain ...
+        assert summary.drained == 2
+        assert summary.corrupt_zip == 1
+        assert summary.unsupported_mime == 1
+        # ... left is the CURRENT (unmutated) depth ...
+        assert summary.left == 2
+        # ... and the table is untouched: rows survive, zero outcome rows.
+        assert _remaining(db, _ORPHAN) == {"zip-item", "doc-item"}
+        assert _documents_media_count(db) == 0
+    finally:
+        db.close()
+
+
+# --------------------------------------------------------------------------
+# distinct_deadletter_sources
+# --------------------------------------------------------------------------
+
+
+def test_distinct_sources_includes_orphans(tmp_path: Path) -> None:
+    """Every distinct source_name — orphaned ones included — is enumerated."""
+    db = _open_db(tmp_path)
+    try:
+        _seed_dead_letter(db, _ORPHAN, "a", _ERR_OTHER)
+        _seed_dead_letter(db, _OTHER_ORPHAN, "b", _ERR_OTHER)
+        _seed_dead_letter(db, _ORPHAN, "c", _ERR_OTHER)  # duplicate source
+        db.commit()
+        assert distinct_deadletter_sources(db) == (_OTHER_ORPHAN, _ORPHAN)
+    finally:
+        db.close()
+
+
+def test_distinct_sources_empty_table_is_empty_tuple(tmp_path: Path) -> None:
+    """A clean table enumerates to zero sources (cheap-when-clean)."""
+    db = _open_db(tmp_path)
+    try:
+        assert distinct_deadletter_sources(db) == ()
+    finally:
+        db.close()
+
+
+# --------------------------------------------------------------------------
+# drain_all_source_deadletters — multi-source reach
+# --------------------------------------------------------------------------
+
+
+def test_all_source_sweep_covers_multiple_sources(tmp_path: Path) -> None:
+    """The sweep drains eligible rows across SEVERAL distinct sources.
+
+    Sabotage: make ``drain_all_source_deadletters`` only process the first
+    enumerated source → the second source's row survives and the
+    ``_remaining(_ORPHAN) == set()`` assertion fails.
+    """
+    db = _open_db(tmp_path)
+    try:
+        _seed_dead_letter(db, _OTHER_ORPHAN, "g-doc", _ERR_OTHER)
+        _seed_bronze(db, _OTHER_ORPHAN, "g-doc", _MIME_MSWORD, content_hash="h-g")
+        _seed_dead_letter(db, _ORPHAN, "s-zip", _ERR_CORRUPT_ZIP)
+        _seed_bronze(db, _ORPHAN, "s-zip", _MIME_MSWORD, content_hash="h-s")
+        # one recoverable row left behind in a third logical source.
+        _seed_dead_letter(db, _ORPHAN, "s-txt", _ERR_DECODE)
+        _seed_bronze(db, _ORPHAN, "s-txt", _MIME_PNG, content_hash="h-png")
+        db.commit()
+
+        summaries = drain_all_source_deadletters(db, silver=_silver(db))
+
+        by_source = {s.connector_name: s for s in summaries}
+        assert set(by_source) == {_ORPHAN, _OTHER_ORPHAN}
+        assert by_source[_OTHER_ORPHAN].drained == 1
+        assert by_source[_ORPHAN].drained == 1
+        assert by_source[_ORPHAN].left == 1  # the recoverable png row stays
+        assert _remaining(db, _OTHER_ORPHAN) == set()
+        assert _remaining(db, _ORPHAN) == {"s-txt"}
+    finally:
+        db.close()
+
+
+def test_all_source_sweep_skips_named_sources(tmp_path: Path) -> None:
+    """``skip_sources`` excludes already-drained sources from the sweep.
+
+    Models the double-drain-avoidance hook: a source the active-connector
+    pass already handled this tick is skipped — no summary, no re-scan.
+
+    Sabotage: ignore ``skip_sources`` in the loop → the skipped source's
+    eligible row drains and ``_remaining`` becomes empty, failing the
+    'still there' assertion; the skipped source also wrongly appears in the
+    returned summaries.
+    """
+    db = _open_db(tmp_path)
+    try:
+        _seed_dead_letter(db, _ORPHAN, "s-doc", _ERR_OTHER)
+        _seed_bronze(db, _ORPHAN, "s-doc", _MIME_MSWORD, content_hash="h-s")
+        _seed_dead_letter(db, _OTHER_ORPHAN, "g-doc", _ERR_OTHER)
+        _seed_bronze(db, _OTHER_ORPHAN, "g-doc", _MIME_MSWORD, content_hash="h-g")
+        db.commit()
+
+        summaries = drain_all_source_deadletters(db, silver=_silver(db), skip_sources=frozenset({_ORPHAN}))
+
+        names = {s.connector_name for s in summaries}
+        assert names == {_OTHER_ORPHAN}
+        # the skipped source is untouched ...
+        assert _remaining(db, _ORPHAN) == {"s-doc"}
+        # ... the swept one drained.
+        assert _remaining(db, _OTHER_ORPHAN) == set()
+    finally:
+        db.close()
+
+
+def test_all_source_sweep_is_idempotent(tmp_path: Path) -> None:
+    """A second sweep over the same DB drains nothing more.
+
+    Sabotage: make ``DeadLetterStore.clear`` raise on a missing row → the
+    second sweep raises instead of returning zero-drained summaries.
+    """
+    db = _open_db(tmp_path)
+    try:
+        _seed_dead_letter(db, _ORPHAN, "s-doc", _ERR_OTHER)
+        _seed_bronze(db, _ORPHAN, "s-doc", _MIME_MSWORD, content_hash="h-s")
+        db.commit()
+
+        first = drain_all_source_deadletters(db, silver=_silver(db))
+        second = drain_all_source_deadletters(db, silver=_silver(db))
+
+        assert sum(s.drained for s in first) == 1
+        # second pass: the source is gone from the table → zero summaries.
+        assert second == ()
+        assert _remaining(db, _ORPHAN) == set()
+    finally:
+        db.close()
+
+
+def test_all_source_sweep_empty_table_is_cheap_noop(tmp_path: Path) -> None:
+    """No dead-letter rows → zero summaries, no per-source work."""
+    db = _open_db(tmp_path)
+    try:
+        assert drain_all_source_deadletters(db, silver=_silver(db)) == ()
+    finally:
+        db.close()
+
+
+def test_all_source_sweep_dry_run_mutates_nothing(tmp_path: Path) -> None:
+    """``dry_run`` across all sources previews counts but clears nothing."""
+    db = _open_db(tmp_path)
+    try:
+        _seed_dead_letter(db, _ORPHAN, "s-doc", _ERR_OTHER)
+        _seed_bronze(db, _ORPHAN, "s-doc", _MIME_MSWORD, content_hash="h-s")
+        _seed_dead_letter(db, _OTHER_ORPHAN, "g-zip", _ERR_CORRUPT_ZIP)
+        _seed_bronze(db, _OTHER_ORPHAN, "g-zip", _MIME_TEXT, content_hash="h-g")
+        db.commit()
+
+        summaries = drain_all_source_deadletters(db, silver=_silver(db), dry_run=True)
+
+        assert sum(s.drained for s in summaries) == 2
+        # nothing mutated.
+        assert _remaining(db, _ORPHAN) == {"s-doc"}
+        assert _remaining(db, _OTHER_ORPHAN) == {"g-zip"}
+        assert _documents_media_count(db) == 0
+    finally:
+        db.close()
+
+
+class _EnumFailsForSource:
+    """Duck-typed connection whose ``execute`` raises enumerating ONE source.
+
+    Forwards every call to a real connection EXCEPT the dead-letter
+    enumeration ``SELECT ... FROM connector_deadletter`` whose params name
+    the wedged source — that one raises, simulating a catastrophic
+    per-source failure mid-sweep (the failure mode the sweep's per-source
+    ``try/except`` exists for; per-ROW clear failures are already absorbed
+    one level down by ``_drain_one``). Driven through the public ``db``
+    seam (F5 — no kairix internals patched).
+    """
+
+    def __init__(self, real: sqlite3.Connection, wedged_source: str) -> None:
+        self._real = real
+        self._wedged = wedged_source
+
+    def execute(self, sql: str, *args: Any, **kwargs: Any) -> Any:
+        params = args[0] if args else ()
+        sql_l = sql.lower()
+        names = tuple(params) if isinstance(params, list | tuple) else ()
+        if "from connector_deadletter" in sql_l and "group by" not in sql_l and self._wedged in names:
+            raise sqlite3.OperationalError("simulated per-source enumeration failure")
+        return self._real.execute(sql, *args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._real, name)
+
+
+def test_all_source_sweep_one_source_failure_continues(tmp_path: Path) -> None:
+    """One source raising is logged + skipped; sibling sources still drain.
+
+    The wedged source's enumeration ``SELECT`` raises (through the public
+    ``db`` seam); ``drain_source_deadletters`` bubbles that up, the sweep's
+    per-source ``try/except`` swallows it, and the OTHER source drains
+    normally — best-effort across sources.
+
+    Sabotage: remove the per-source ``try/except`` in
+    ``drain_all_source_deadletters`` → the OperationalError propagates and
+    the whole sweep aborts; ``_remaining(_OTHER_ORPHAN)`` is never drained
+    and the call itself raises.
+    """
+    from typing import cast
+
+    db = _open_db(tmp_path)
+    try:
+        # _OTHER_ORPHAN sorts first (g < r), so it drains BEFORE the wedge.
+        _seed_dead_letter(db, _OTHER_ORPHAN, "g-doc", _ERR_OTHER)
+        _seed_bronze(db, _OTHER_ORPHAN, "g-doc", _MIME_MSWORD, content_hash="h-g")
+        _seed_dead_letter(db, _ORPHAN, "s-doc", _ERR_OTHER)
+        _seed_bronze(db, _ORPHAN, "s-doc", _MIME_MSWORD, content_hash="h-s")
+        db.commit()
+
+        wrapped = cast("sqlite3.Connection", _EnumFailsForSource(db, _ORPHAN))
+        summaries = drain_all_source_deadletters(wrapped, silver=_silver(wrapped))
+
+        names = {s.connector_name for s in summaries}
+        assert names == {_OTHER_ORPHAN}, "only the healthy source produced a summary"
+        assert _remaining(db, _OTHER_ORPHAN) == set(), "the healthy source still drained"
+        assert _remaining(db, _ORPHAN) == {"s-doc"}, "the wedged source's row was left behind"
+    finally:
+        db.close()
+
+
+def test_drain_connector_alias_matches_source_core(tmp_path: Path) -> None:
+    """The active-connector alias is a thin pass-through to the source core.
+
+    Pins that ``drain_connector_deadletters`` (the per-active-connector
+    seam at ``worker._run_one_connector_batch``) and
+    ``drain_source_deadletters`` produce the same outcome — the refactor is
+    behaviour-preserving for the active path.
+    """
+    from kairix.core.connectors.deadletter_drain import drain_connector_deadletters
+
+    db = _open_db(tmp_path)
+    try:
+        _seed_dead_letter(db, _ORPHAN, "doc-item", _ERR_OTHER)
+        _seed_bronze(db, _ORPHAN, "doc-item", _MIME_MSWORD, content_hash="h-doc")
+        db.commit()
+
+        summary = drain_connector_deadletters(db, connector_name=_ORPHAN, silver=_silver(db))
+
+        assert summary == DrainSummary(_ORPHAN, drained=1, corrupt_zip=0, unsupported_mime=1, left=0)
+        assert _remaining(db, _ORPHAN) == set()
+    finally:
+        db.close()

--- a/tests/unit/test_dead_letter_cli_units.py
+++ b/tests/unit/test_dead_letter_cli_units.py
@@ -25,10 +25,18 @@ import pytest
 
 from kairix.core.db.schema import create_schema
 from kairix.dead_letter_cli import default_db_provider
+from kairix.dead_letter_cli import drain as dl_drain
 from kairix.dead_letter_cli import main as dl_main
 from kairix.dead_letter_cli import status as dl_status
 
 pytestmark = pytest.mark.unit
+
+# A permanently-unprocessable last_error string + an unsupported MIME so
+# the drain core's narrow eligibility (corrupt_zip OR known-unsupported
+# MIME) fires deterministically.
+_ERR_DRAINABLE = "some other connector error"
+_MIME_UNSUPPORTED = "application/msword"
+_ORPHAN_SOURCE = "removed-sharepoint"
 
 
 def _seed_db(tmp_path: Path, *, rows: bool = False) -> Path:
@@ -45,6 +53,41 @@ def _seed_db(tmp_path: Path, *, rows: bool = False) -> Path:
     db.commit()
     db.close()
     return db_path
+
+
+def _seed_drainable(tmp_path: Path, *, source_name: str = _ORPHAN_SOURCE) -> Path:
+    """A DB with one permanently-unprocessable (drainable) row for ``source_name``."""
+    db_path = tmp_path / "kairix.sqlite"
+    db = sqlite3.connect(str(db_path))
+    create_schema(db)
+    db.execute(
+        "INSERT INTO connector_deadletter "
+        "(source_name, item_id, failure_count, last_error, last_attempt) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (source_name, "poison-1", 3, _ERR_DRAINABLE, "2026-05-26T05:58:00Z"),
+    )
+    db.execute(
+        "INSERT INTO bronze_records "
+        "(source_name, item_id, raw_path, mime, fetched_at, content_hash) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (source_name, "poison-1", "/bronze/poison-1", _MIME_UNSUPPORTED, "2026-05-26T05:50:00Z", "h-poison"),
+    )
+    db.commit()
+    db.close()
+    return db_path
+
+
+def _deadletter_rows(db_path: Path, source_name: str) -> int:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return int(
+            conn.execute(
+                "SELECT COUNT(*) FROM connector_deadletter WHERE source_name = ?",
+                (source_name,),
+            ).fetchone()[0]
+        )
+    finally:
+        conn.close()
 
 
 def _provider(db_path: Path) -> Any:
@@ -188,6 +231,132 @@ def test_main_in_process_db_path_kwarg_wins_over_arg(
     assert rc == 0
     captured = capsys.readouterr()
     assert "connector-alpha" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# drain verb (PR-5) — single source, all sources, dry-run, orphaned source
+# ---------------------------------------------------------------------------
+
+
+def test_drain_named_source_clears_orphaned_backlog(tmp_path: Path) -> None:
+    """``drain SOURCE`` clears an ORPHANED source's drainable row + reports it.
+
+    The source has no active connector — drain works on the source_name
+    string alone. Sabotage: skip the ``source_name`` branch in ``_run_drain``
+    → nothing drains and the row-count / 'drained 1' assertions fail.
+    """
+    db_path = _seed_drainable(tmp_path)
+    out_buf = io.StringIO()
+    rc = dl_drain(source_name=_ORPHAN_SOURCE, out=out_buf, db_provider=_provider(db_path))
+    assert rc == 0
+    assert _deadletter_rows(db_path, _ORPHAN_SOURCE) == 0
+    out = out_buf.getvalue()
+    assert _ORPHAN_SOURCE in out
+    assert "drained 1" in out
+    assert "total:" in out
+
+
+def test_drain_all_sources_clears_every_distinct_source(tmp_path: Path) -> None:
+    """``drain`` with NO source drains every distinct source_name."""
+    db_path = tmp_path / "kairix.sqlite"
+    db = sqlite3.connect(str(db_path))
+    create_schema(db)
+    for src in ("removed-a", "removed-b"):
+        db.execute(
+            "INSERT INTO connector_deadletter "
+            "(source_name, item_id, failure_count, last_error, last_attempt) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (src, "p", 3, _ERR_DRAINABLE, "2026-05-26T05:58:00Z"),
+        )
+        db.execute(
+            "INSERT INTO bronze_records "
+            "(source_name, item_id, raw_path, mime, fetched_at, content_hash) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (src, "p", "/b/p", _MIME_UNSUPPORTED, "2026-05-26T05:50:00Z", f"h-{src}"),
+        )
+    db.commit()
+    db.close()
+
+    out_buf = io.StringIO()
+    rc = dl_drain(out=out_buf, db_provider=_provider(db_path))
+    assert rc == 0
+    assert _deadletter_rows(db_path, "removed-a") == 0
+    assert _deadletter_rows(db_path, "removed-b") == 0
+    out = out_buf.getvalue()
+    assert "removed-a" in out
+    assert "removed-b" in out
+    assert "across 2 source(s)" in out
+
+
+def test_drain_dry_run_mutates_nothing(tmp_path: Path) -> None:
+    """``--dry-run`` reports what WOULD drain but leaves the row in place.
+
+    Sabotage: ignore ``dry_run`` in ``_run_drain`` → the row clears and the
+    'row still there' / 'dry-run' header assertions fail.
+    """
+    db_path = _seed_drainable(tmp_path)
+    out_buf = io.StringIO()
+    rc = dl_drain(source_name=_ORPHAN_SOURCE, dry_run=True, out=out_buf, db_provider=_provider(db_path))
+    assert rc == 0
+    # row survives — nothing mutated.
+    assert _deadletter_rows(db_path, _ORPHAN_SOURCE) == 1
+    out = out_buf.getvalue()
+    assert "dry-run" in out
+    assert "would drain 1" in out
+
+
+def test_drain_empty_table_reports_friendly_line(tmp_path: Path) -> None:
+    """A clean table drains nothing and prints the friendly empty line."""
+    db_path = _seed_db(tmp_path, rows=False)
+    out_buf = io.StringIO()
+    rc = dl_drain(out=out_buf, db_provider=_provider(db_path))
+    assert rc == 0
+    assert "no drainable dead-letter state" in out_buf.getvalue()
+
+
+def test_drain_connect_failure_writes_affordance(tmp_path: Path) -> None:
+    """A provider raising sqlite3.Error → exit 1 + an F21-shaped affordance."""
+
+    def _bad_provider(_db_path: Path | None) -> sqlite3.Connection:
+        raise sqlite3.OperationalError("simulated connect failure")
+
+    out_buf, err_buf = io.StringIO(), io.StringIO()
+    rc = dl_drain(out=out_buf, err=err_buf, db_provider=_bad_provider)
+    assert rc == 1
+    err = err_buf.getvalue()
+    assert "fix:" in err
+    assert "next:" in err
+    assert "run:" in err
+
+
+def test_main_routes_drain_subcommand(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """``kairix dead-letter drain SOURCE`` routes through ``main`` to ``drain``.
+
+    Sabotage: remove the ``elif cmd == 'drain'`` route in ``main`` → argv
+    parses but no drain runs; the row survives and this fails.
+    """
+    db_path = _seed_drainable(tmp_path)
+    rc = dl_main(["drain", _ORPHAN_SOURCE], db_provider=_provider(db_path))
+    assert rc == 0
+    assert _deadletter_rows(db_path, _ORPHAN_SOURCE) == 0
+    assert "drained 1" in capsys.readouterr().out
+
+
+def test_main_routes_drain_dry_run_and_max_flags(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """``main`` threads ``--dry-run`` + ``--max`` through to ``drain``."""
+    db_path = _seed_drainable(tmp_path)
+    rc = dl_main(["drain", _ORPHAN_SOURCE, "--dry-run", "--max", "10"], db_provider=_provider(db_path))
+    assert rc == 0
+    assert _deadletter_rows(db_path, _ORPHAN_SOURCE) == 1  # dry-run: untouched
+    assert "dry-run" in capsys.readouterr().out
+
+
+def test_main_drain_default_out_streams_to_stdio(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """``drain`` with no ``out`` defaults to ``sys.stdout``."""
+    db_path = _seed_db(tmp_path, rows=False)
+    rc = dl_drain(db_provider=_provider(db_path))
+    assert rc == 0
+    assert "no drainable dead-letter state" in capsys.readouterr().out
 
 
 def test_main_runs_via_module_main_guard(


### PR DESCRIPTION
## Why

The auto-drain (#615) only clears dead-letters for **currently-active** connectors (keyed on the active `connector.name`). Dead-letters from a source whose connector is no longer syncing — e.g. the Customer-Zero SharePoint backlog (455 items, stalled connector) — never drain. This closes that gap **without changing the (deliberately narrow) eligibility**.

## What

- **Reusable core** — refactors the per-source drain (`drain_connector_deadletters`) so it can be invoked for any `source_name`, active or not. The active-connector auto-drain calls it unchanged.
- **`drain_all_source_deadletters`** — enumerates every distinct `source_name` in `connector_deadletter` (bounded) and drains each, with a `skip_sources` set so it never double-drains a source the live sync already handled this tick.
- **CLI `kairix dead-letter drain [SOURCE] [--dry-run] [--max N]`** — operator one-shot for an orphaned/stalled source (or all sources). `--dry-run` reports what *would* drain without mutating.
- **Periodic worker sweep** — a conservative scheduled pass drains all sources' eligible dead-letters over time, so orphaned backlogs self-clean.
- **Eligibility is identical** to #615: drain **iff** `corrupt_zip` **or** `known_unsupported_mime` — recoverable items (decode-on-supported, octet-stream, text, transient classes) are never drained, for any source.

## Bounded (F63)
`_load_candidates` pushes `LIMIT ?` into SQL (was a Python-level slice after an unbounded `fetchall`), so the per-tick cap holds even for deep backlogs — important now that the sweep runs per-source.

## Tests / gates
- 158 tests pass (sweep units, CLI units, BDD feature for the new verb, F30 subprocess outcome, worker periodic-sweep, plus the unchanged active-connector drain suite). arch-fitness Passed (F16/F17/F5/F63). New-code coverage 100%. ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)