### PR TITLE
feat(sharepoint): self-discover drives from a site (site_id/site_url)

### DIFF
--- a/docs/architecture/connector-ingestion-architecture.md
+++ b/docs/architecture/connector-ingestion-architecture.md
@@ -429,8 +429,36 @@ connectors:
   - name: sharepoint
     sensitivity: client-confidential
     config:
-      tenant: <tenant-id>
-      site: <site-id>
+      # ``drives`` is a non-empty list. Each entry is ONE of:
+      #
+      #   (a) an explicit drive — a bare Graph drive-id string, or a
+      #       mapping with ``drive_id`` (+ optional ``site_id`` /
+      #       ``display_name`` / ``include_paths`` / ``exclude_paths``);
+      #       OR
+      #   (b) a SITE entry — a mapping naming ``site_id`` (and/or
+      #       ``site_url``) and NO ``drive_id`` — meaning "auto-discover
+      #       every document library on this site" (F42). The site's
+      #       ``include_paths`` / ``exclude_paths`` are inherited by every
+      #       discovered drive. Discovery runs LAZILY at sync time and
+      #       re-runs each tick, so libraries added later are picked up
+      #       automatically. A site that fails to resolve (not found /
+      #       auth / throttle / empty) is logged + skipped for that tick;
+      #       explicit drives and other sites still sync (per-site fault
+      #       isolation).
+      #
+      # The M365 tenant / client / secret triple is resolved from secrets
+      # (canonical identity ``(connector, m365, None, <leaf>)``) — it is
+      # NOT declared here. Pin drives by id (not URL) for determinism
+      # across site renames; use a site entry to let kairix self-discover.
+      drives:
+        - drive_id: <graph-drive-id>                # explicit drive
+          site_id: <hostname,site-guid,web-guid>    # optional, informational
+          include_paths: ["/Curated-Content"]       # optional folder scope
+        - site_id: <hostname,site-guid,web-guid>    # SITE entry — discover all drives
+          exclude_paths: ["/Archive"]               # inherited by every discovered drive
+        # - site_url: https://contoso.sharepoint.com/sites/marketing
+        #   # ``site_url`` is resolved to a site_id via Graph at sync time
+        #   # (an alternative to pinning the composite ``site_id``).
 
 extractors:
   default: markitdown

--- a/kairix.config.example.yaml
+++ b/kairix.config.example.yaml
@@ -254,11 +254,26 @@ topology_v2:
       #       timeout_s: 60.0
       #       max_file_size_mb: 256
       #
-      # For SharePoint: the Graph drive id. Until ``kairix sharepoint
-      # discover`` lands (KFEAT-022), enumerate drives via
-      # ``az rest --method get --url 'https://graph.microsoft.com/v1.0/sites?search=*'``
-      # then ``/sites/<site-id>/drives``. Pin by id — not by URL — so the
-      # sync stays deterministic across site renames.
+      # For SharePoint: ``drives`` is a non-empty list whose entries are
+      # EITHER an explicit drive OR a self-discovering site.
+      #
+      #  • Explicit drive — a Graph drive id (deterministic across site
+      #    renames). Pin by id, not by URL. To find drive ids manually:
+      #    ``az rest --method get --url
+      #    'https://graph.microsoft.com/v1.0/sites?search=*'`` then
+      #    ``/sites/<site-id>/drives``.
+      #
+      #  • SITE entry (self-discovery, F42 — foundation for the
+      #    ``kairix sharepoint discover`` wizard, KFEAT-022) — name a
+      #    ``site_id`` (and/or ``site_url``) and OMIT ``drive_id``: kairix
+      #    auto-discovers EVERY document library on that site and syncs
+      #    each one. Discovery runs lazily at sync time and re-runs every
+      #    tick, so libraries added later are picked up automatically. The
+      #    site's ``include_paths`` / ``exclude_paths`` are inherited by
+      #    every discovered drive. A site that fails to resolve (not found
+      #    / auth / throttle / empty) is logged + skipped for that tick —
+      #    explicit drives and other sites keep syncing (per-site fault
+      #    isolation).
       #
       # ``include_paths`` / ``exclude_paths`` (optional) scope which
       # folders within the drive get indexed. Empty = whole drive walked.
@@ -268,6 +283,7 @@ topology_v2:
       # docs/architecture/sharepoint-path-filtering.md.
       connector_specific_config:
         drives:
+          # Explicit-drive entry — pin one drive by its Graph id.
           - drive_id: "b!exampleDriveIdReplaceWithRealOne"
             site_id: "contoso.sharepoint.com,xxxx,yyyy"
             include_paths:
@@ -275,6 +291,15 @@ topology_v2:
               - "/Shared Documents"
             exclude_paths:
               - "/Curated-Content/draft"
+          # Self-discovering SITE entry — no drive_id: kairix finds and
+          # syncs every document library on this site. The exclude_paths
+          # below apply to each discovered drive.
+          - site_id: "contoso.sharepoint.com,aaaa,bbbb"
+            exclude_paths:
+              - "/Archive"
+          # Alternatively name the site by URL (resolved to a site_id via
+          # Graph at sync time) instead of the opaque composite id:
+          # - site_url: "https://contoso.sharepoint.com/sites/marketing"
 
     - id: slack-workspace-conn
       kind: slack

--- a/kairix/connectors/sharepoint/__init__.py
+++ b/kairix/connectors/sharepoint/__init__.py
@@ -44,6 +44,7 @@ from kairix.connectors.sharepoint.connector import (
     SharePointConnector,
     SharePointCredentials,
     SharePointDriveSpec,
+    SiteDiscoverySpec,
     make_connector,
 )
 from kairix.connectors.sharepoint.graph_client import (
@@ -87,6 +88,7 @@ __all__ = [
     "SharePointCredentials",
     "SharePointDriveSpec",
     "SharePointGraphClient",
+    "SiteDiscoverySpec",
     "SiteRef",
     "make_connector",
 ]

--- a/kairix/connectors/sharepoint/connector.py
+++ b/kairix/connectors/sharepoint/connector.py
@@ -48,6 +48,7 @@ from typing import Any, cast
 
 from kairix.connectors.sharepoint.graph_client import (
     DriveItemRef,
+    DriveRef,
     SharePointGraphClient,
 )
 from kairix.core.protocols import (
@@ -124,7 +125,9 @@ class SharePointDriveSpec:
     ``GET /sites?search=*`` enumeration call exposed by
     :meth:`SharePointGraphClient.list_sites`) and pins it in
     ``kairix.config.yaml``. Pinning by id (not by URL) makes the sync
-    deterministic across site renames.
+    deterministic across site renames. To avoid pinning each drive by
+    hand, name a SITE instead via :class:`SiteDiscoverySpec` and kairix
+    auto-discovers every drive on that site at sync time.
 
     ``include_paths`` and ``exclude_paths`` scope which folders within
     the drive get indexed. Empty include_paths = whole drive. See
@@ -135,6 +138,44 @@ class SharePointDriveSpec:
     drive_id: str
     site_id: str | None = None
     display_name: str | None = None
+    include_paths: tuple[str, ...] = ()
+    exclude_paths: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class SiteDiscoverySpec:
+    """One configured SITE the connector should auto-discover drives from.
+
+    Frozen per F42 (F42 — guided-config wizard / KFEAT-022 self-discovery
+    foundation). A site discovery entry names a SharePoint site instead of
+    a single drive; at SYNC time the connector enumerates every document
+    library on that site (via
+    :meth:`SharePointGraphClient.list_drives`) and syncs each one as if it
+    had been declared explicitly. This restores the self-discovery the
+    connector lost when it began requiring an explicit ``drive_id`` per
+    drive — operators can now point at a site and let kairix find its
+    libraries (including libraries added after the connector was first
+    configured, because discovery re-runs every tick).
+
+    Exactly one of ``site_id`` / ``site_url`` is required:
+
+      * ``site_id`` — the Graph composite id
+        (``<hostname>,<site-guid>,<web-guid>``). Deterministic across
+        site renames; the preferred form.
+      * ``site_url`` — a friendly site URL (e.g.
+        ``https://contoso.sharepoint.com/sites/marketing``). Resolved to a
+        ``site_id`` at sync time via
+        :meth:`SharePointGraphClient.resolve_site_by_path`. Convenient for
+        operators who don't have the composite id to hand.
+
+    ``include_paths`` / ``exclude_paths`` are inherited by EVERY drive
+    discovered under the site — the same path-filter semantics as
+    :class:`SharePointDriveSpec` (segment-boundary prefix match, exclude
+    wins, case-insensitive). Empty = whole drive.
+    """
+
+    site_id: str | None = None
+    site_url: str | None = None
     include_paths: tuple[str, ...] = ()
     exclude_paths: tuple[str, ...] = ()
 
@@ -190,21 +231,28 @@ class SharePointConnector:
         self,
         drives: list[SharePointDriveSpec],
         *,
+        site_discovery: list[SiteDiscoverySpec] | None = None,
         credentials: SharePointCredentials | None = None,
         client_builder: Callable[[OAuth2ClientCredsAuth], SharePointGraphClient] | None = None,
         auth: OAuth2ClientCredsAuth | None = None,
         default_sensitivity: Sensitivity = DEFAULT_SENSITIVITY,
         secrets: SecretsResolver | None = None,
     ) -> None:
-        if not drives:
+        site_specs = tuple(site_discovery or ())
+        if not drives and not site_specs:
             raise ValueError(
                 "sharepoint: drives list is empty. "
-                "fix: declare at least one drive_id under the sharepoint connector block. "
+                "fix: declare at least one drive_id, or a site (site_id) to "
+                "auto-discover its drives, under the sharepoint connector block. "
                 "next: see docs/architecture/connector-ingestion-architecture.md §8 "
                 "for the SharePoint connector config shape."
             )
-        self._drives: tuple[SharePointDriveSpec, ...] = tuple(drives)
-        self._spec_by_drive_id: dict[str, SharePointDriveSpec] = {spec.drive_id: spec for spec in self._drives}
+        # Explicit drive specs the operator pinned by id. Site-discovery
+        # specs are expanded LAZILY at sync time (each tick, so newly
+        # added libraries are picked up) — never here, so construction
+        # stays I/O-free and one site's transient failure can't crash init.
+        self._explicit_drives: tuple[SharePointDriveSpec, ...] = tuple(drives)
+        self._site_specs: tuple[SiteDiscoverySpec, ...] = site_specs
         self._default_sensitivity: Sensitivity = default_sensitivity
 
         self._secrets: SecretsResolver = secrets if secrets is not None else SecretsLoader()
@@ -230,34 +278,235 @@ class SharePointConnector:
         # so :meth:`fetch` can resolve drive id, web URL, and mime
         # without a second Graph call.
         self._cache: dict[str, DriveItemRef] = {}
+        # Per-TICK resolved-drive-spec cache — explicit drives + every
+        # drive discovered from configured sites, keyed by drive id.
+        # Site discovery (``GET /sites/{id}/drives``) is expensive (one
+        # Graph call per site); resolving it ONCE per tick and reusing the
+        # map keeps a deployment with N drives + M sites at M discovery
+        # calls per tick instead of NxM. ``None`` means "not yet resolved
+        # this tick" — the tick entry points (:meth:`list_changes`,
+        # :meth:`iter_containers`, :meth:`load_hierarchy`) refresh it so a
+        # newly-added library is still picked up each tick; the
+        # per-container lookups read it without re-running discovery.
+        self._resolved_spec_map: dict[str, SharePointDriveSpec] | None = None
         # Next-tick cursor — populated after :meth:`list_changes` drains
         # every configured drive. Serialised as a JSON map
         # ``drive_id -> deltaLink`` so a single opaque string round-trips
         # through the orchestrator's cursor_store.
         self._next_cursor: str | None = None
 
-        # Probe each include_path against the live drive at startup so
-        # missing folders surface proactively (not silently, the first
-        # time a tick rejects every item). One-shot per process; transient
-        # Graph errors don't kill init.
+        # Probe each EXPLICIT include_path against the live drive at
+        # startup so missing folders surface proactively (not silently,
+        # the first time a tick rejects every item). One-shot per process;
+        # transient Graph errors don't kill init. Site-discovery specs are
+        # NOT probed here — their drives aren't resolved until the first
+        # sync (lazy discovery), so probing them would force a Graph call
+        # at construction time.
         self._probe_include_paths()
+
+    # ------------------------------------------------------------------
+    # Drive-spec resolution — explicit + lazily-discovered site drives
+    # ------------------------------------------------------------------
+
+    @property
+    def _drives(self) -> tuple[SharePointDriveSpec, ...]:
+        """Explicit operator-pinned drive specs (back-compat accessor).
+
+        Site-discovery drives are intentionally NOT included here — they
+        resolve lazily at sync time via :meth:`_resolve_drive_specs`. The
+        startup probe and any code that must avoid a Graph call read this
+        property; the sync paths read the resolved set instead.
+        """
+        return self._explicit_drives
+
+    def _resolve_drive_specs(self) -> tuple[SharePointDriveSpec, ...]:
+        """Resolve explicit drives + discovered site drives ONCE per tick.
+
+        Site discovery (``GET /sites/{id}/drives``) is expensive — one
+        Graph call per configured site. This method runs discovery
+        exactly once per tick and memoises the result on
+        :attr:`_resolved_spec_map`; the per-container lookups
+        (:meth:`_spec_for_drive_id`) read that map instead of re-running
+        discovery, so a deployment with N drives + M sites makes M
+        discovery calls per tick, not NxM.
+
+        The tick entry points (:meth:`list_changes`,
+        :meth:`iter_containers`, :meth:`load_hierarchy`) call
+        :meth:`_refresh_resolved_specs` to invalidate the cache at the
+        start of each tick, so libraries added to a site after the
+        connector was configured are still picked up automatically. The
+        per-container Wave-E paths that may be entered without a fresh
+        tick boundary fall through to a lazy one-shot resolve here.
+
+        Each :class:`SiteDiscoverySpec` is expanded independently with
+        per-site fault isolation — a site that fails to resolve (not
+        found / auth / throttle / empty) is logged and skipped WITHOUT
+        affecting the explicit drives or the other sites (per-site fault
+        isolation, F42 robustness).
+        """
+        if self._resolved_spec_map is not None:
+            return tuple(self._resolved_spec_map.values())
+        return self._refresh_resolved_specs()
+
+    def _refresh_resolved_specs(self) -> tuple[SharePointDriveSpec, ...]:
+        """Re-run site discovery and rebuild the per-tick resolved-spec map.
+
+        Called at the start of each tick entry point so newly-added
+        libraries are picked up; populates :attr:`_resolved_spec_map`
+        (keyed by drive id) so the per-container lookups in the same tick
+        reuse it instead of re-running discovery (NxM → M calls/tick).
+        """
+        resolved: dict[str, SharePointDriveSpec] = {}
+        for spec in self._explicit_drives:
+            resolved.setdefault(spec.drive_id, spec)
+        for site_spec in self._site_specs:
+            for discovered in self._discover_site_drives(site_spec):
+                resolved.setdefault(discovered.drive_id, discovered)
+        self._resolved_spec_map = resolved
+        return tuple(resolved.values())
+
+    def _spec_for_drive_id(self, drive_id: str) -> SharePointDriveSpec | None:
+        """Return the resolved spec for ``drive_id`` (explicit or discovered).
+
+        Used by the per-container paths whose ``container_id`` may name a
+        drive discovered from a site, so the container inherits the
+        site's path filters. Reads the per-tick resolved-spec map (built
+        once per tick by :meth:`_resolve_drive_specs`) so a per-container
+        lookup never re-runs site discovery. Returns ``None`` when no
+        resolved spec matches (e.g. the site that produced the drive
+        failed discovery this tick) — the caller then drains the drive
+        unfiltered.
+        """
+        if self._resolved_spec_map is None:
+            self._resolve_drive_specs()
+        assert self._resolved_spec_map is not None  # populated by the resolve above
+        return self._resolved_spec_map.get(drive_id)
+
+    def _discover_site_drives(self, site_spec: SiteDiscoverySpec) -> list[SharePointDriveSpec]:
+        """Discover one site's drives, applying the site's path filters.
+
+        Robust by contract: any failure resolving the site id, listing
+        its drives, or an empty drive set is logged as a structured WARN
+        naming the site and an empty list is returned so the caller skips
+        that site this tick. Never raises — one site's outage must not
+        crash the connector or freeze unrelated cursors.
+        """
+        site_label = site_spec.site_id or site_spec.site_url or "<unknown>"
+        try:
+            site_id = self._resolve_site_id(site_spec)
+            if site_id is None:
+                return []
+            drives = [
+                self._drive_spec_from_ref(ref, site_spec=site_spec)
+                for ref in self._graph.list_drives(site_id)
+                if ref.drive_id
+            ]
+        except Exception as exc:
+            logger.warning(
+                "event=sharepoint_discover_error site=%s error=%s "
+                "(this site skipped this tick; explicit drives + other sites still sync; "
+                "next tick will retry)",
+                site_label,
+                exc,
+            )
+            return []
+        if not drives:
+            logger.warning(
+                "event=sharepoint_discover_no_drives site=%s. "
+                "fix: confirm the site has at least one document library the app can read "
+                "(Sites.Read.All + Files.Read.All), or pin explicit drive_ids instead. "
+                "next: the connector retries discovery on the next tick.",
+                site_label,
+            )
+        return drives
+
+    def _resolve_site_id(self, site_spec: SiteDiscoverySpec) -> str | None:
+        """Resolve a site spec to a Graph composite site id.
+
+        Prefers an explicit ``site_id``; otherwise resolves ``site_url``
+        via :meth:`SharePointGraphClient.resolve_site_by_path`. Returns
+        ``None`` (after a structured WARN) when neither yields a usable
+        id so the caller skips the site this tick.
+        """
+        if site_spec.site_id:
+            return site_spec.site_id
+        if site_spec.site_url:
+            return self._resolve_site_id_from_url(site_spec.site_url)
+        return None
+
+    def _resolve_site_id_from_url(self, site_url: str) -> str | None:
+        """Resolve a friendly ``site_url`` to a Graph composite site id.
+
+        Two skip-with-WARN paths, both isolated so the site is dropped
+        this tick rather than producing a bad/empty site id downstream:
+
+          * the URL has no host or server-relative path
+            (:func:`_split_site_url` returns ``(None, None)``) — WARN
+            ``sharepoint_discover_site_url_unparseable``;
+          * the URL parses but Graph resolves it to an empty/None site id
+            (deleted site, permission gap) — WARN
+            ``sharepoint_discover_site_unresolved``. Previously this empty
+            resolution was swallowed silently, leaking a falsy site id
+            into discovery.
+        """
+        hostname, server_relative_path = _split_site_url(site_url)
+        if hostname is None or server_relative_path is None:
+            logger.warning(
+                "event=sharepoint_discover_site_url_unparseable site_url=%s. "
+                "fix: use a full site URL like "
+                "'https://contoso.sharepoint.com/sites/marketing', or pin site_id directly. "
+                "next: the connector retries discovery on the next tick.",
+                site_url,
+            )
+            return None
+        resolved_site_id = self._graph.resolve_site_by_path(hostname, server_relative_path).site_id
+        if not resolved_site_id:
+            logger.warning(
+                "event=sharepoint_discover_site_unresolved site_url=%s. "
+                "fix: confirm the site URL is correct and the app can read it "
+                "(Sites.Read.All), or pin the site_id (composite id) directly. "
+                "next: the connector retries discovery on the next tick.",
+                site_url,
+            )
+            return None
+        return resolved_site_id
+
+    def _drive_spec_from_ref(self, ref: DriveRef, *, site_spec: SiteDiscoverySpec) -> SharePointDriveSpec:
+        """Map a discovered :class:`DriveRef` to a concrete drive spec.
+
+        Carries the library name from the ref as the display name (so
+        status surfaces show a real label, not a drive-id prefix) and
+        inherits the site spec's ``include_paths`` / ``exclude_paths`` so
+        the operator's site-level folder scope applies to every drive.
+        """
+        return SharePointDriveSpec(
+            drive_id=ref.drive_id,
+            site_id=ref.site_id or site_spec.site_id,
+            display_name=ref.name or None,
+            include_paths=site_spec.include_paths,
+            exclude_paths=site_spec.exclude_paths,
+        )
 
     # ------------------------------------------------------------------
     # SourceConnector Protocol surface
     # ------------------------------------------------------------------
 
     def list_changes(self, cursor: Cursor | None) -> Iterator[ChangeEvent]:
-        """Stream changes across every configured drive.
+        """Stream changes across every configured + discovered drive.
 
         ``cursor`` is the JSON map persisted on the previous tick (or
-        ``None`` for cold start). The connector walks each configured
-        drive's delta endpoint, caches envelopes on the way through, and
-        records the next-tick cursor on :attr:`_next_cursor`.
+        ``None`` for cold start). The connector resolves the live drive
+        set (explicit drives + every drive discovered from configured
+        sites), walks each drive's delta endpoint, caches envelopes on
+        the way through, and records the next-tick cursor on
+        :attr:`_next_cursor`. The per-drive cursor is keyed on the
+        (possibly discovered) ``drive_id`` so it round-trips through the
+        existing deltaLink map regardless of how the drive was declared.
         """
         per_drive_cursor = _deserialise_cursor(cursor)
         events: list[ChangeEvent] = []
         next_links: dict[str, str] = {}
-        for spec in self._drives:
+        for spec in self._refresh_resolved_specs():
             drive_id = spec.drive_id
             start_url = per_drive_cursor.get(drive_id)
             for item in self._graph.iter_drive_items(drive_id, start_url=start_url):
@@ -437,8 +686,18 @@ class SharePointConnector:
         framework's lifecycle layer (``kairix/core/connectors/cc_pair.py``)
         passes ``cc_pair_id`` so the connector can construct the
         Container without reaching back into the cc_pair store.
+
+        Site-discovery drives surface here too — each drive discovered
+        from a configured site becomes its own Container (resolved fresh
+        each call so newly-added libraries appear automatically).
+
+        This is a TICK entry point: it refreshes the per-tick
+        resolved-spec map once (one discovery call per site) so the
+        per-container :meth:`list_changes_for_container` /
+        :meth:`retrieve_all_slim_docs` calls that follow reuse it instead
+        of each re-running discovery (NxM → M discovery calls per tick).
         """
-        for spec in self._drives:
+        for spec in self._refresh_resolved_specs():
             yield Container(
                 cc_pair_id=cc_pair_id,
                 container_id=spec.drive_id,
@@ -477,6 +736,10 @@ class SharePointConnector:
 
         ``topology_v2_sharepoint`` retired post-cutover (task #132);
         the SITE + DRIVE per-drive emission is now the only behaviour.
+
+        Site-discovery drives appear as DRIVE nodes too — the drive set
+        is resolved fresh (explicit + discovered) so the hierarchy
+        reflects libraries added to a site since configuration.
         """
         yield HierarchyNode(
             cc_pair_id=cc_pair_id,
@@ -488,7 +751,7 @@ class SharePointConnector:
             external_access_json=None,
             sensitivity_hint=None,
         )
-        for spec in self._drives:
+        for spec in self._refresh_resolved_specs():
             yield HierarchyNode(
                 cc_pair_id=cc_pair_id,
                 raw_node_id=spec.drive_id,
@@ -517,7 +780,7 @@ class SharePointConnector:
         """
         drive_id = container.container_id
         start_url = container.cursor_token
-        spec = self._spec_by_drive_id.get(drive_id)
+        spec = self._spec_for_drive_id(drive_id)
         for item in self._graph.iter_drive_items(drive_id, start_url=start_url):
             if not item.item_id or item.removed:
                 continue
@@ -609,7 +872,7 @@ class SharePointConnector:
         """
         drive_id = container.container_id
         start_url = container.cursor_token
-        spec = self._spec_by_drive_id.get(drive_id)
+        spec = self._spec_for_drive_id(drive_id)
         events: list[ChangeEvent] = []
         for item in self._graph.iter_drive_items(drive_id, start_url=start_url):
             if spec is not None and not self._item_passes_spec_filter(item, spec=spec):
@@ -843,6 +1106,28 @@ def _full_item_path(item: DriveItemRef) -> str | None:
     return f"{item.parent_path}/{item.name}"
 
 
+def _split_site_url(site_url: str) -> tuple[str | None, str | None]:
+    """Split a friendly SharePoint site URL into ``(hostname, server_relative_path)``.
+
+    ``https://contoso.sharepoint.com/sites/marketing`` →
+    ``("contoso.sharepoint.com", "/sites/marketing")``. The components
+    feed :meth:`SharePointGraphClient.resolve_site_by_path`. Tolerant of
+    a missing scheme (``contoso.sharepoint.com/sites/marketing`` parses
+    too). Returns ``(None, None)`` when the URL has no host or no
+    server-relative path so the caller warns + skips that site.
+    """
+    trimmed = site_url.strip()
+    if not trimmed:
+        return None, None
+    without_scheme = trimmed.split("://", 1)[-1]
+    if "/" not in without_scheme:
+        return None, None
+    hostname, _, path = without_scheme.partition("/")
+    if not hostname or not path:
+        return None, None
+    return hostname, "/" + path.strip("/")
+
+
 def _serialise_cursor(per_drive: Mapping[str, str]) -> str:
     """Encode per-drive cursors as a deterministic JSON string."""
     return json.dumps(dict(per_drive), sort_keys=True, ensure_ascii=False)
@@ -929,8 +1214,95 @@ def _validate_no_exact_overlap(
         )
 
 
-def parse_drive_entry(entry: object) -> SharePointDriveSpec:
+def _optional_str(value: object) -> str | None:
+    """Return ``value`` when it is a non-empty string, else ``None``.
+
+    Narrows the ``object``-typed result of ``dict.get`` so the typed
+    spec dataclasses receive a clean ``str | None``.
+    """
+    return value if isinstance(value, str) and value else None
+
+
+# F17 — the include / exclude path-list field names are read by both the
+# explicit-drive and site-discovery parsers; extracting them keeps the
+# literal off the dup-string gate's radar (≥3 occurrences in a module).
+_INCLUDE_PATHS_FIELD = "include_paths"
+_EXCLUDE_PATHS_FIELD = "exclude_paths"
+
+
+def _parse_include_exclude(entry: dict[str, object], label: str) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Parse + validate an entry's include/exclude path lists.
+
+    Shared by the explicit-drive and site-discovery parsers. ``label``
+    is the drive id (explicit) or a ``site:`` synthetic label (discovery)
+    threaded into the fix-pointer error messages. Returns the
+    ``(include_paths, exclude_paths)`` tuple after the no-exact-overlap
+    validation.
+    """
+    include_paths = _parse_path_list(entry.get(_INCLUDE_PATHS_FIELD), _INCLUDE_PATHS_FIELD, label)
+    exclude_paths = _parse_path_list(entry.get(_EXCLUDE_PATHS_FIELD), _EXCLUDE_PATHS_FIELD, label)
+    _validate_no_exact_overlap(label, include_paths, exclude_paths)
+    return include_paths, exclude_paths
+
+
+def _parse_site_discovery_entry(entry: dict[str, object]) -> SiteDiscoverySpec:
+    """Parse one config dict that names a SITE (no ``drive_id``).
+
+    The caller has already established ``drive_id`` is absent and at
+    least one of ``site_id`` / ``site_url`` is present. Inherited
+    ``include_paths`` / ``exclude_paths`` apply to every discovered
+    drive; the path-list parser reuses the drive validation surface with
+    a synthetic label so the fix-pointer message still names the site.
+    """
+    site_id = _optional_str(entry.get("site_id"))
+    site_url = _optional_str(entry.get("site_url"))
+    label = f"site:{site_id or site_url}"
+    include_paths, exclude_paths = _parse_include_exclude(entry, label)
+    return SiteDiscoverySpec(
+        site_id=site_id,
+        site_url=site_url,
+        include_paths=include_paths,
+        exclude_paths=exclude_paths,
+    )
+
+
+def _parse_explicit_drive_entry(entry: dict[str, object], drive_id: str) -> SharePointDriveSpec:
+    """Parse one config dict that names an explicit ``drive_id``.
+
+    Split out of :func:`parse_drive_entry` so the entry-shape routing
+    (string / explicit-drive / site-discovery / reject) stays under
+    F16's cognitive-complexity ceiling.
+    """
+    site_id = _optional_str(entry.get("site_id"))
+    display = _optional_str(entry.get("display_name"))
+    include_paths, exclude_paths = _parse_include_exclude(entry, drive_id)
+    return SharePointDriveSpec(
+        drive_id=drive_id,
+        site_id=site_id,
+        display_name=display,
+        include_paths=include_paths,
+        exclude_paths=exclude_paths,
+    )
+
+
+def parse_drive_entry(entry: object) -> SharePointDriveSpec | SiteDiscoverySpec:
     """Parse one operator-config drive entry into a typed spec.
+
+    Three accepted shapes:
+
+      * a bare ``drive_id`` string → :class:`SharePointDriveSpec`;
+      * a mapping with ``drive_id`` (+ optional ``site_id`` /
+        ``display_name`` / ``include_paths`` / ``exclude_paths``) →
+        :class:`SharePointDriveSpec` (explicit drive, UNCHANGED
+        behaviour); or
+      * a mapping that names a SITE (``site_id`` and/or ``site_url``,
+        NO ``drive_id``, + optional ``include_paths`` / ``exclude_paths``)
+        → :class:`SiteDiscoverySpec` — "discover ALL drives in this
+        site" (F42 self-discovery). Resolution happens lazily at sync
+        time.
+
+    A mapping carrying neither ``drive_id`` nor ``site_id``/``site_url``
+    raises with an F21-style fix-pointer.
 
     Extracted from ``_drive_specs_from_config`` to keep that function
     under F16's cognitive-complexity ceiling — the per-entry isinstance
@@ -940,47 +1312,54 @@ def parse_drive_entry(entry: object) -> SharePointDriveSpec:
         return SharePointDriveSpec(drive_id=entry)
     if isinstance(entry, dict):
         drive_id = entry.get("drive_id")
-        if not isinstance(drive_id, str) or not drive_id:
-            raise ValueError(
-                "sharepoint: drive block missing 'drive_id'. "
-                "fix: every drive entry must declare drive_id as a non-empty string. "
-                "next: see docs/architecture/connector-ingestion-architecture.md §8."
-            )
-        site_id = entry.get("site_id") if isinstance(entry.get("site_id"), str) else None
-        display = entry.get("display_name") if isinstance(entry.get("display_name"), str) else None
-        include_paths = _parse_path_list(entry.get("include_paths"), "include_paths", drive_id)
-        exclude_paths = _parse_path_list(entry.get("exclude_paths"), "exclude_paths", drive_id)
-        _validate_no_exact_overlap(drive_id, include_paths, exclude_paths)
-        return SharePointDriveSpec(
-            drive_id=drive_id,
-            site_id=site_id,
-            display_name=display,
-            include_paths=include_paths,
-            exclude_paths=exclude_paths,
+        if isinstance(drive_id, str) and drive_id:
+            return _parse_explicit_drive_entry(entry, drive_id)
+        if _optional_str(entry.get("site_id")) or _optional_str(entry.get("site_url")):
+            return _parse_site_discovery_entry(entry)
+        raise ValueError(
+            "sharepoint: drive block names neither 'drive_id' nor a site. "
+            "fix: declare an explicit drive_id (non-empty string), OR name a site "
+            "via 'site_id' (and/or 'site_url') to auto-discover all of that site's drives. "
+            "next: see docs/architecture/connector-ingestion-architecture.md §8."
         )
     raise ValueError(
         f"sharepoint: drive entry {entry!r} is not a string or dict. "
-        "fix: each drive entry must be a drive_id string or a block with drive_id. "
+        "fix: each drive entry must be a drive_id string, a block with drive_id, "
+        "or a block naming a site to auto-discover. "
         "next: see docs/architecture/connector-ingestion-architecture.md §8."
     )
 
 
-def _drive_specs_from_config(raw: object) -> list[SharePointDriveSpec]:
+def _drive_specs_from_config(
+    raw: object,
+) -> tuple[tuple[SharePointDriveSpec, ...], tuple[SiteDiscoverySpec, ...]]:
     """Translate operator config drive entries to typed specs.
 
-    Accepts a list of strings (treated as ``drive_id`` only) OR a list
-    of dicts with ``drive_id`` plus optional ``site_id`` / ``display_name``
-    keys. Anything else raises with a fix pointer so misconfigured
-    operators see the contract surface loudly.
+    Accepts a non-empty list whose entries are strings (treated as
+    ``drive_id`` only), explicit-drive dicts (``drive_id`` + optional
+    keys), or site-discovery dicts (``site_id``/``site_url`` + optional
+    path filters). Returns a ``(explicit_drive_specs, site_specs)`` pair
+    so the connector can sync explicit drives directly and expand site
+    specs lazily at sync time. Anything else raises with a fix pointer so
+    misconfigured operators see the contract surface loudly.
     """
     if not isinstance(raw, list) or not raw:
         raise ValueError(
             "sharepoint: 'drives' must be a non-empty list of drive ids or drive blocks. "
-            "fix: declare at least one drive under sharepoint -> drives in kairix.config.yaml. "
+            "fix: declare at least one drive (drive_id) or site (site_id) under "
+            "sharepoint -> drives in kairix.config.yaml. "
             "next: see docs/architecture/connector-ingestion-architecture.md §8 "
             "for the SharePoint connector config shape."
         )
-    return [parse_drive_entry(entry) for entry in raw]
+    drive_specs: list[SharePointDriveSpec] = []
+    site_specs: list[SiteDiscoverySpec] = []
+    for entry in raw:
+        parsed = parse_drive_entry(entry)
+        if isinstance(parsed, SiteDiscoverySpec):
+            site_specs.append(parsed)
+        else:
+            drive_specs.append(parsed)
+    return tuple(drive_specs), tuple(site_specs)
 
 
 def make_connector(config: Mapping[str, Any]) -> SharePointConnector:
@@ -989,10 +1368,17 @@ def make_connector(config: Mapping[str, Any]) -> SharePointConnector:
     Expected keys:
 
       * ``drives`` (required) — non-empty list of drive specs. Each
-        entry is either a drive-id string or a mapping with ``drive_id``
-        plus optional ``site_id`` / ``display_name``.
+        entry is either a drive-id string, a mapping with ``drive_id``
+        plus optional ``site_id`` / ``display_name``, OR a mapping that
+        names a SITE (``site_id`` and/or ``site_url``, no ``drive_id``)
+        to auto-discover all of that site's drives at sync time (F42).
       * ``default_sensitivity`` (optional) — one of the F39 sensitivity
         literals; defaults to ``"internal"``.
+
+    This factory stays PURE — no Graph call, no credential resolution
+    at parse time. Site-discovery entries are parsed into typed specs
+    here and expanded to concrete drives LAZILY on the first sync, when
+    the connector already holds a live Graph client.
 
     Credentials resolve via :class:`kairix.secrets.loader.SecretsLoader`
     against the canonical identities ``(connector, m365, None, tenant-id)``,
@@ -1006,7 +1392,7 @@ def make_connector(config: Mapping[str, Any]) -> SharePointConnector:
     kairix's ``pyproject.toml`` so the orchestration layer can resolve
     ``sharepoint`` to this factory by name.
     """
-    drives = _drive_specs_from_config(config.get("drives"))
+    drives, site_discovery = _drive_specs_from_config(config.get("drives"))
     declared = config.get("default_sensitivity", DEFAULT_SENSITIVITY)
     if declared not in ("public", "internal", "client-confidential", "personal"):
         raise ValueError(
@@ -1016,4 +1402,8 @@ def make_connector(config: Mapping[str, Any]) -> SharePointConnector:
             "next: see kairix/core/protocols.py Sensitivity for the literal set."
         )
     sensitivity = cast(Sensitivity, declared)
-    return SharePointConnector(drives=drives, default_sensitivity=sensitivity)
+    return SharePointConnector(
+        drives=list(drives),
+        site_discovery=list(site_discovery),
+        default_sensitivity=sensitivity,
+    )

--- a/kairix/connectors/sharepoint/graph_client.py
+++ b/kairix/connectors/sharepoint/graph_client.py
@@ -240,6 +240,40 @@ class SharePointGraphClient:
                 yield _drive_from(entry, site_id=site_id)
             url = _string_or_none(body.get(_ODATA_NEXT_LINK_KEY))
 
+    def resolve_site_by_path(self, hostname: str, server_relative_path: str) -> SiteRef:
+        """Resolve a friendly SharePoint site URL to its Graph composite id.
+
+        Calls ``GET /sites/{hostname}:/{server-relative-path}`` — the
+        documented Graph shape for "look up a site by its server-relative
+        path". Unlike :meth:`list_sites` (a ``value``-array collection),
+        this endpoint returns a SINGLE site object, so the body is parsed
+        directly via :func:`_site_from` (not via :func:`_entries`).
+
+        Args:
+            hostname: The SharePoint host, e.g.
+                ``contoso.sharepoint.com``.
+            server_relative_path: The server-relative site path WITH a
+                leading slash, e.g. ``/sites/marketing``. A drive
+                discovery spec that names a ``site_url`` is split into
+                these two components before the call.
+
+        Returns:
+            The :class:`SiteRef` whose ``site_id`` is the Graph composite
+            id (``<hostname>,<site-guid>,<web-guid>``) that
+            :meth:`list_drives` consumes.
+
+        Raises:
+            httpx.HTTPStatusError: On a non-2xx response (e.g. 404 when
+                the site path does not resolve). The connector's
+                discovery loop wraps this call in a try/except so a bad
+                ``site_url`` warns + skips that site rather than crashing
+                the sync.
+        """
+        normalised = server_relative_path if server_relative_path.startswith("/") else "/" + server_relative_path
+        url = f"{self._graph_base}/sites/{hostname}:{normalised}"
+        body = self._authorised_get(url).json()
+        return _site_from(body)
+
     def initial_delta_url(self, drive_id: str) -> str:
         """Compose the seed delta URL for one drive.
 

--- a/tests/bdd/features/connector_sharepoint.feature
+++ b/tests/bdd/features/connector_sharepoint.feature
@@ -27,3 +27,10 @@ Feature: SharePoint connector pulls document library binaries via Microsoft Grap
     When the operator runs the sharepoint connector list_changes with no cursor
     Then the connector exposes a non-empty next cursor
     And the next cursor encodes a per-drive delta link map
+
+  @site_discovery
+  Scenario: A configured site auto-discovers its document libraries
+    Given a stubbed Microsoft Graph site that lists two drives each with one pdf envelope
+    When the operator runs the sharepoint connector list_changes with no cursor for the discovered site
+    Then two created change events are emitted one per discovered drive
+    And the next cursor records a delta link for each discovered drive

--- a/tests/bdd/steps/connector_sharepoint_steps.py
+++ b/tests/bdd/steps/connector_sharepoint_steps.py
@@ -31,6 +31,7 @@ from kairix.connectors.sharepoint import (
     SharePointCredentials,
     SharePointDriveSpec,
     SharePointGraphClient,
+    SiteDiscoverySpec,
 )
 from kairix.core.protocols import ChangeEvent
 from kairix.transport.auth.oauth2_client_creds import OAuth2ClientCredsAuth
@@ -191,3 +192,122 @@ def _cursor_encodes_drive_map(sharepoint_ctx: _Ctx) -> None:
     assert isinstance(parsed, dict), f"cursor must decode to dict, got {parsed!r}"
     assert _DRIVE_ID in parsed, f"cursor map missing drive {_DRIVE_ID!r}: {parsed!r}"
     assert "deltatoken" in parsed[_DRIVE_ID], f"cursor map value missing delta token: {parsed[_DRIVE_ID]!r}"
+
+
+# ---------------------------------------------------------------------------
+# Site auto-discovery scenario
+# ---------------------------------------------------------------------------
+
+_SITE_ID = "contoso.sharepoint.com,site-guid,web-guid"
+_DISCOVERED_DRIVES = ("drive-disco-a", "drive-disco-b")
+
+
+def _site_drives_listing() -> dict[str, Any]:
+    """A Graph ``/sites/{id}/drives`` response naming two document libraries."""
+    return {
+        "value": [
+            {"id": did, "name": f"Library-{did}", "webUrl": f"https://contoso.sharepoint.com/sites/team/{did}"}
+            for did in _DISCOVERED_DRIVES
+        ]
+    }
+
+
+def _delta_page_for(drive_id: str) -> dict[str, Any]:
+    """One delta page with a single PDF envelope, tagged with the drive id."""
+    return {
+        "@odata.context": f"https://graph.microsoft.com/v1.0/$metadata#drives/{drive_id}/root/delta",
+        "value": [
+            {
+                "id": f"item-{drive_id}",
+                "name": f"{drive_id}.pdf",
+                "size": 1234,
+                "lastModifiedDateTime": "2026-05-22T10:00:00Z",
+                "webUrl": f"https://contoso.sharepoint.com/sites/team/{drive_id}/doc.pdf",
+                "file": {"mimeType": "application/pdf"},
+                "parentReference": {"driveId": drive_id},
+            }
+        ],
+        "@odata.deltaLink": f"https://graph.microsoft.com/v1.0/drives/{drive_id}/root/delta?$deltatoken=tok-{drive_id}",
+    }
+
+
+def _build_connector_for_site_discovery(ctx: _Ctx) -> SharePointConnector:
+    """Real connector wired to a stub that discovers a site's drives.
+
+    The stub routes the ``/sites/{id}/drives`` enumeration to a
+    two-library listing and each ``/drives/{id}/root/delta`` to a
+    single-PDF page — so list_changes auto-discovers both libraries and
+    syncs one item from each.
+    """
+
+    def _stub_handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        if "/oauth2/v2.0/token" in url:
+            return httpx.Response(
+                200,
+                json={"access_token": "fake-bearer-token-value", "expires_in": 3600, "token_type": "Bearer"},
+            )
+        ctx.requested_urls.append(url)
+        if f"/sites/{_SITE_ID}/drives" in url:
+            return httpx.Response(200, json=_site_drives_listing())
+        for did in _DISCOVERED_DRIVES:
+            if f"/drives/{did}/" in url:
+                return httpx.Response(200, json=_delta_page_for(did))
+        return httpx.Response(200, json={"value": []})
+
+    transport = httpx.MockTransport(_stub_handler)
+    shared_client = httpx.Client(transport=transport)
+
+    auth = OAuth2ClientCredsAuth(
+        tenant_id="fake-tenant",
+        client_id="fake-client-id",
+        client_secret="fake-client-secret-value",  # pragma: allowlist secret — test fixture
+        scope="https://graph.microsoft.com/.default",
+        http_client=shared_client,
+    )
+
+    def _client_builder(resolved_auth: OAuth2ClientCredsAuth) -> SharePointGraphClient:
+        return SharePointGraphClient(auth=resolved_auth, http_client=shared_client)
+
+    return SharePointConnector(
+        drives=[],
+        site_discovery=[SiteDiscoverySpec(site_id=_SITE_ID)],
+        credentials=SharePointCredentials(
+            tenant_id="fake-tenant",
+            client_id="fake-client-id",
+            client_secret="fake-client-secret-value",  # pragma: allowlist secret — test fixture
+        ),
+        auth=auth,
+        client_builder=_client_builder,
+    )
+
+
+@given(parsers.parse("a stubbed Microsoft Graph site that lists two drives each with one pdf envelope"))
+def _given_site_with_two_drives(sharepoint_ctx: _Ctx) -> None:
+    sharepoint_ctx.connector = _build_connector_for_site_discovery(sharepoint_ctx)
+
+
+@when(parsers.parse("the operator runs the sharepoint connector list_changes with no cursor for the discovered site"))
+def _when_list_changes_discovered(sharepoint_ctx: _Ctx) -> None:
+    assert sharepoint_ctx.connector is not None, "Given step must run before When"
+    sharepoint_ctx.events = list(sharepoint_ctx.connector.list_changes(cursor=None))
+
+
+@then("two created change events are emitted one per discovered drive")
+def _two_created_events(sharepoint_ctx: _Ctx) -> None:
+    events = sharepoint_ctx.events
+    assert len(events) == 2, f"expected 2 events (one per discovered drive), got {len(events)}: {events!r}"
+    assert all(e.op == "created" for e in events), f"all events must be created: {events!r}"
+    drive_ids = {e.metadata.get("drive_id") for e in events}
+    assert drive_ids == set(_DISCOVERED_DRIVES), f"events must come from each discovered drive; got {drive_ids!r}"
+
+
+@then("the next cursor records a delta link for each discovered drive")
+def _cursor_has_each_discovered_drive(sharepoint_ctx: _Ctx) -> None:
+    assert sharepoint_ctx.connector is not None
+    cursor = sharepoint_ctx.connector.next_cursor()
+    assert cursor is not None, "discovered drives must produce a next cursor"
+    parsed = json.loads(cursor)
+    assert set(parsed.keys()) == set(_DISCOVERED_DRIVES), (
+        f"cursor map must key on each discovered drive id; got {sorted(parsed.keys())!r}"
+    )

--- a/tests/connectors/sharepoint/test_connector.py
+++ b/tests/connectors/sharepoint/test_connector.py
@@ -24,6 +24,7 @@ callable default), F8 carries ``@pytest.mark.unit``.
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from typing import Any
 
 import httpx
@@ -35,6 +36,7 @@ from kairix.connectors.sharepoint import (
     SharePointCredentials,
     SharePointDriveSpec,
     SharePointGraphClient,
+    SiteDiscoverySpec,
     make_connector,
 )
 from kairix.core.protocols import Container
@@ -370,28 +372,30 @@ def test_next_cursor_is_none_when_no_drive_completes_a_delta_sweep() -> None:
     assert connector.next_cursor() is None
 
 
-def test_make_connector_with_string_drives_list_parses_specs(tmp_path: Any) -> None:
+def test_make_connector_with_string_drives_list_parses_specs() -> None:
     """A list of drive_id strings parses into typed specs via the connector path.
 
     The legacy alias chain + XDG-fallback credential resolver was retired
     in #369. This test exercises drive parsing through the public
-    ``SharePointConnector`` surface with an explicit ``credentials=``
-    injection so the test never touches the credential resolver path —
-    the unit under test here is drive-spec parsing, not auth.
+    ``SharePointConnector`` surface — the resolved drive is observed via
+    ``iter_containers()`` (one Container per resolved drive) rather than
+    the private ``_drives`` accessor (F5: tests use the public surface
+    only). The unit under test here is drive-spec parsing, not auth.
     """
-    _ = tmp_path  # parametrised fixture kept for symmetry with sibling tests
-    connector = SharePointConnector(
-        drives=[SharePointDriveSpec(drive_id=_DRIVE_ID)],
-        credentials=SharePointCredentials(
-            tenant_id="t",
-            client_id="c",
-            client_secret="s-value",  # pragma: allowlist secret — test fixture
-        ),
-    )
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        token = _token_response(request)
+        if token is not None:
+            return token
+        return httpx.Response(200, json={"value": []})
+
+    connector = _build_connector(_handler)
     assert connector.name == "sharepoint"
     assert connector.sensitivity_for("any") == DEFAULT_SENSITIVITY
-    # Drive spec parses from a string id into a single-entry SharePointDriveSpec.
-    assert connector._drives == (SharePointDriveSpec(drive_id=_DRIVE_ID),)
+    # The single string-id drive resolves to exactly one Container whose
+    # id is the configured drive id — observable proof the spec parsed.
+    container_ids = [c.container_id for c in connector.iter_containers(cc_pair_id=1)]
+    assert container_ids == [_DRIVE_ID]
 
 
 def test_constructor_loads_secrets_via_loader() -> None:
@@ -449,34 +453,49 @@ def test_make_connector_rejects_invalid_sensitivity_tier() -> None:
         make_connector({"drives": [_DRIVE_ID], "default_sensitivity": "bogus"})
 
 
-def test_make_connector_with_dict_drive_entries_parses_specs(tmp_path: Any) -> None:
-    """A dict drive entry parses into a typed spec with drive_id + site_id + display_name.
+def test_make_connector_with_dict_drive_entries_parses_specs() -> None:
+    """A dict drive entry parses into a typed spec with drive_id + display_name.
 
     Exercises drive-spec parsing via the public ``SharePointConnector``
-    surface with an explicit ``credentials=`` injection so the test
-    never touches the credential resolver path (#369 retired the
-    legacy alias chain + XDG fallback the previous shape relied on).
+    surface — the resolved drive id is observed through
+    ``iter_containers()`` and the operator-facing label through
+    ``load_hierarchy()`` (the DRIVE node carries the configured
+    ``display_name``), rather than the private ``_drives`` accessor
+    (F5: tests use the public surface only).
     """
-    _ = tmp_path
-    connector = SharePointConnector(
-        drives=[SharePointDriveSpec(drive_id="id-1", site_id="site-1", display_name="Marketing")],
-        credentials=SharePointCredentials(
-            tenant_id="t",
-            client_id="c",
-            client_secret="s-value",  # pragma: allowlist secret — test fixture
-        ),
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        token = _token_response(request)
+        if token is not None:
+            return token
+        return httpx.Response(200, json={"value": []})
+
+    connector = _build_connector_with_spec(
+        _handler,
+        SharePointDriveSpec(drive_id="id-1", site_id="site-1", display_name="Marketing"),
     )
     assert connector.name == "sharepoint"
-    spec = connector._drives[0]
-    assert spec.drive_id == "id-1"
-    assert spec.site_id == "site-1"
-    assert spec.display_name == "Marketing"
+    # Drive id surfaces as the Container id.
+    assert [c.container_id for c in connector.iter_containers(cc_pair_id=1)] == ["id-1"]
+    # The operator-supplied display_name surfaces as the DRIVE node label.
+    drive_nodes = [n for n in connector.load_hierarchy(cc_pair_id=1) if n.node_type == "DRIVE"]
+    assert [(n.raw_node_id, n.display_name) for n in drive_nodes] == [("id-1", "Marketing")]
 
 
-def test_make_connector_rejects_dict_drive_without_drive_id() -> None:
-    """make_connector raises with the fix-pointer on a dict drive missing drive_id."""
-    with pytest.raises(ValueError, match="drive_id"):
-        make_connector({"drives": [{"site_id": "site-1"}]})
+def test_make_connector_rejects_dict_drive_with_neither_drive_id_nor_site() -> None:
+    """A dict naming neither drive_id nor a site raises with the F21-style fix-pointer.
+
+    Since F42 site auto-discovery landed, a dict with ``site_id`` (no
+    ``drive_id``) is a VALID site-discovery entry — see
+    ``test_parse_site_entry_*``. The hard reject now fires only when the
+    block names neither an explicit drive nor a site to discover.
+
+    The factory stays pure (no Graph / creds at parse), so parsing
+    happens before any credential resolution — the ValueError surfaces
+    even without M365 secrets present.
+    """
+    with pytest.raises(ValueError, match="neither 'drive_id' nor a site"):
+        make_connector({"drives": [{"display_name": "no-anchor"}]})
 
 
 def test_make_connector_rejects_non_string_non_dict_drive_entries() -> None:
@@ -743,6 +762,20 @@ def testparse_drive_entry_allows_exclude_inside_include() -> None:
 # ---------------------------------------------------------------------------
 
 
+def _drive_label(connector: SharePointConnector, drive_id: str) -> str:
+    """Observe a drive's operator-facing label via the public hierarchy.
+
+    ``load_hierarchy`` emits one DRIVE node per resolved drive carrying
+    the effective ``display_name``; reading it here keeps the display-name
+    assertions on the public surface (F5) instead of the private
+    ``_effective_display_name`` / ``_drives`` internals.
+    """
+    for node in connector.load_hierarchy(cc_pair_id=1):
+        if node.node_type == "DRIVE" and node.raw_node_id == drive_id:
+            return node.display_name
+    raise AssertionError(f"no DRIVE node emitted for {drive_id!r}")
+
+
 @pytest.mark.unit
 def test_effective_display_name_uses_explicit_value_when_set() -> None:
     """An operator-supplied display_name wins over any synthesis."""
@@ -751,18 +784,19 @@ def test_effective_display_name_uses_explicit_value_when_set() -> None:
         handler,
         SharePointDriveSpec(drive_id=_DRIVE_ID, display_name="My Custom Label", include_paths=("/Foo",)),
     )
-    assert connector._effective_display_name(connector._drives[0]) == "My Custom Label"
+    assert _drive_label(connector, _DRIVE_ID) == "My Custom Label"
 
 
 @pytest.mark.unit
 def test_effective_display_name_synthesises_from_include_path_when_unset() -> None:
     """No display_name + include_paths → '<drive-id-prefix> [<first-include>]'."""
     handler = _make_handler_returning_empty_delta()
+    drive_id = "b!a0rphFH2longopaqueidentifier"
     connector = _build_connector_with_spec(
         handler,
-        SharePointDriveSpec(drive_id="b!a0rphFH2longopaqueidentifier", include_paths=("/Curated-Content",)),
+        SharePointDriveSpec(drive_id=drive_id, include_paths=("/Curated-Content",)),
     )
-    label = connector._effective_display_name(connector._drives[0])
+    label = _drive_label(connector, drive_id)
     assert "Curated-Content" in label
     assert "b!a0rphF" in label  # short prefix preserved
 
@@ -775,7 +809,7 @@ def test_effective_display_name_falls_back_to_drive_id_when_no_filter() -> None:
         handler,
         SharePointDriveSpec(drive_id="b!short"),
     )
-    assert connector._effective_display_name(connector._drives[0]) == "b!short"
+    assert _drive_label(connector, "b!short") == "b!short"
 
 
 # ---------------------------------------------------------------------------
@@ -1032,9 +1066,9 @@ def test_iter_containers_emits_one_per_configured_drive() -> None:
     than per-connector. ``iter_containers`` is the surface the framework
     calls to enumerate the drives the connector knows about.
 
-    Sabotage-proof: change ``for spec in self._drives: yield Container(...)``
-    to yield just one Container regardless of drive count; this test
-    fails because two configured drives produce one Container instead of two.
+    Sabotage-proof: change ``iter_containers`` to yield just one Container
+    regardless of drive count; this test fails because two configured
+    drives produce one Container instead of two.
     """
 
     def _handler(request: httpx.Request) -> httpx.Response:
@@ -1133,3 +1167,754 @@ def test_list_changes_for_container_filters_by_spec_and_routes_via_scoped_path()
     events = list(connector.list_changes_for_container(container))
     item_ids = sorted(e.item_id for e in events)
     assert item_ids == ["scoped-keep"], f"include_paths filter must drop out-of-scope items; got {item_ids!r}"
+
+
+# ---------------------------------------------------------------------------
+# F42 — site-based drive auto-discovery (lazy, per-site fault isolated)
+# ---------------------------------------------------------------------------
+
+
+_SITE_ID = "contoso.sharepoint.com,site-guid,web-guid"
+
+
+def _drives_list_for_site(*drive_ids: str) -> dict[str, Any]:
+    """A Graph ``/sites/{id}/drives`` response listing the given drive ids."""
+    return {
+        "value": [
+            {
+                "id": did,
+                "name": f"Library-{did}",
+                "webUrl": f"https://contoso.sharepoint.com/sites/team/{did}",
+            }
+            for did in drive_ids
+        ]
+    }
+
+
+def _delta_for_drive(drive_id: str, items: list[dict[str, Any]]) -> dict[str, Any]:
+    """A per-drive delta page tagged with the drive id in its deltaLink."""
+    return {
+        "@odata.context": f"https://graph.microsoft.com/v1.0/$metadata#drives/{drive_id}/root/delta",
+        "value": items,
+        "@odata.deltaLink": f"https://graph.microsoft.com/v1.0/drives/{drive_id}/root/delta?$deltatoken={drive_id}",
+    }
+
+
+def _envelope_for_drive(item_id: str, drive_id: str, *, parent_path: str | None = None) -> dict[str, Any]:
+    env: dict[str, Any] = {
+        "id": item_id,
+        "name": f"{item_id}.pdf",
+        "size": 100,
+        "lastModifiedDateTime": "2026-05-22T10:00:00Z",
+        "webUrl": f"https://contoso.sharepoint.com/sites/team/{drive_id}/{item_id}.pdf",
+        "file": {"mimeType": "application/pdf"},
+        "parentReference": {"driveId": drive_id},
+    }
+    if parent_path is not None:
+        env["parentReference"]["path"] = f"/drives/{drive_id}/root:{parent_path}"
+    return env
+
+
+def _build_connector_for_discovery(
+    handler: Any,
+    *,
+    drives: list[SharePointDriveSpec] | None = None,
+    site_discovery: list[SiteDiscoverySpec] | None = None,
+) -> SharePointConnector:
+    transport = httpx.MockTransport(handler)
+    shared = httpx.Client(transport=transport)
+    auth = OAuth2ClientCredsAuth(
+        tenant_id="t",
+        client_id="c",
+        client_secret="s-value",  # pragma: allowlist secret — test fixture
+        scope="https://graph.microsoft.com/.default",
+        http_client=shared,
+    )
+    return SharePointConnector(
+        drives=drives if drives is not None else [],
+        site_discovery=site_discovery,
+        credentials=SharePointCredentials(
+            tenant_id="t",
+            client_id="c",
+            client_secret="s-value",  # pragma: allowlist secret — test fixture
+        ),
+        auth=auth,
+        client_builder=lambda a: SharePointGraphClient(auth=a, http_client=shared, sleep_fn=lambda _s: None),
+    )
+
+
+def test_parse_site_entry_returns_site_discovery_spec() -> None:
+    """A dict naming ``site_id`` (no drive_id) parses into a SiteDiscoverySpec."""
+    from kairix.connectors.sharepoint.connector import parse_drive_entry
+
+    spec = parse_drive_entry({"site_id": _SITE_ID, "exclude_paths": ["/Archive"]})
+    assert isinstance(spec, SiteDiscoverySpec)
+    assert spec.site_id == _SITE_ID
+    assert spec.exclude_paths == ("/Archive",)
+    assert spec.include_paths == ()
+
+
+def test_parse_site_url_entry_returns_site_discovery_spec() -> None:
+    """A dict naming ``site_url`` (no drive_id) parses into a SiteDiscoverySpec."""
+    from kairix.connectors.sharepoint.connector import parse_drive_entry
+
+    spec = parse_drive_entry({"site_url": "https://contoso.sharepoint.com/sites/marketing"})
+    assert isinstance(spec, SiteDiscoverySpec)
+    assert spec.site_url == "https://contoso.sharepoint.com/sites/marketing"
+    assert spec.site_id is None
+
+
+def test_make_connector_with_only_site_entry_constructs() -> None:
+    """``make_connector`` accepts a config whose only drives entry is a site.
+
+    The factory stays pure — no Graph call at construction; discovery is
+    deferred to the first sync. Observed through the public surface (F5):
+    construction issues NO Graph request (proved by counting requests at
+    the transport seam), and the held site spec only expands to its
+    drives when a sync path (``iter_containers``) runs.
+    """
+    requests_seen: list[str] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        token = _token_response(request)
+        if token is not None:
+            return token
+        requests_seen.append(str(request.url))
+        url = str(request.url)
+        if f"/sites/{_SITE_ID}/drives" in url:
+            return httpx.Response(200, json=_drives_list_for_site("drive-a"))
+        return httpx.Response(200, json={"value": []})
+
+    connector = _build_connector_for_discovery(_handler, site_discovery=[SiteDiscoverySpec(site_id=_SITE_ID)])
+    # Construction is pure — no Graph traffic until a sync path runs.
+    assert requests_seen == [], f"construction must not call Graph (lazy discovery); saw {requests_seen!r}"
+    # The held site spec expands lazily: a sync path discovers its drive.
+    container_ids = [c.container_id for c in connector.iter_containers(cc_pair_id=1)]
+    assert container_ids == ["drive-a"]
+    assert any(f"/sites/{_SITE_ID}/drives" in u for u in requests_seen)
+
+
+def test_site_entry_discovers_and_syncs_each_drive() -> None:
+    """A site entry expands to the mock's drives and emits items from each."""
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        token = _token_response(request)
+        if token is not None:
+            return token
+        url = str(request.url)
+        if f"/sites/{_SITE_ID}/drives" in url:
+            return httpx.Response(200, json=_drives_list_for_site("drive-a", "drive-b"))
+        if "/drives/drive-a/" in url:
+            return httpx.Response(200, json=_delta_for_drive("drive-a", [_envelope_for_drive("a1", "drive-a")]))
+        if "/drives/drive-b/" in url:
+            return httpx.Response(200, json=_delta_for_drive("drive-b", [_envelope_for_drive("b1", "drive-b")]))
+        return httpx.Response(200, json={"value": []})
+
+    connector = _build_connector_for_discovery(_handler, site_discovery=[SiteDiscoverySpec(site_id=_SITE_ID)])
+    events = list(connector.list_changes(cursor=None))
+    item_ids = sorted(e.item_id for e in events)
+    assert item_ids == ["a1", "b1"], f"both discovered drives must sync; got {item_ids!r}"
+    # Per-drive cursor keyed on the DISCOVERED drive ids round-trips.
+    cursor = connector.next_cursor()
+    assert cursor is not None
+    parsed = json.loads(cursor)
+    assert set(parsed.keys()) == {"drive-a", "drive-b"}
+
+
+def test_explicit_drive_still_works_alongside_site_entry() -> None:
+    """An explicit drive_id entry syncs unchanged when mixed with a site entry."""
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        token = _token_response(request)
+        if token is not None:
+            return token
+        url = str(request.url)
+        if f"/sites/{_SITE_ID}/drives" in url:
+            return httpx.Response(200, json=_drives_list_for_site("drive-discovered"))
+        if "/drives/drive-explicit/" in url:
+            return httpx.Response(
+                200, json=_delta_for_drive("drive-explicit", [_envelope_for_drive("e1", "drive-explicit")])
+            )
+        if "/drives/drive-discovered/" in url:
+            return httpx.Response(
+                200, json=_delta_for_drive("drive-discovered", [_envelope_for_drive("d1", "drive-discovered")])
+            )
+        return httpx.Response(200, json={"value": []})
+
+    connector = _build_connector_for_discovery(
+        _handler,
+        drives=[SharePointDriveSpec(drive_id="drive-explicit")],
+        site_discovery=[SiteDiscoverySpec(site_id=_SITE_ID)],
+    )
+    events = list(connector.list_changes(cursor=None))
+    assert sorted(e.item_id for e in events) == ["d1", "e1"]
+
+
+def _http_403_drives_failure(request: httpx.Request) -> httpx.Response:
+    """``list_drives`` fails with a 403 (HTTPStatusError) — the auth/perm path."""
+    return httpx.Response(403, json={"error": {"code": "accessDenied"}})
+
+
+def _network_drives_failure(_request: httpx.Request) -> httpx.Response:
+    """``list_drives`` fails with a raw transport error — the network path.
+
+    Raising :class:`httpx.ConnectError` from the mock transport models a
+    DNS/connection failure that never produces an HTTP response (so it
+    bypasses ``raise_for_status`` entirely). This proves the discovery
+    loop's ``except Exception`` catches network-level errors, not just
+    status errors — a narrower ``except httpx.HTTPStatusError`` would let
+    this one through and crash the tick.
+    """
+    raise httpx.ConnectError("simulated DNS failure")
+
+
+@pytest.mark.parametrize(
+    "drives_failure",
+    [
+        pytest.param(_http_403_drives_failure, id="http-403-status-error"),
+        pytest.param(_network_drives_failure, id="raw-connect-error"),
+    ],
+)
+def test_site_discovery_failure_is_isolated_and_explicit_drives_still_sync(
+    drives_failure: Callable[[httpx.Request], httpx.Response],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A site whose list_drives fails -> WARN + skipped; explicit drives still sync.
+
+    Parametrised over BOTH failure shapes that ``except Exception`` must
+    isolate: a 403 ``HTTPStatusError`` (auth/permission) and a raw
+    ``httpx.ConnectError`` (network/DNS, no HTTP response at all). Either
+    way the site is skipped with a structured WARN naming it, and the
+    explicit drive still syncs.
+    """
+    import logging
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        token = _token_response(request)
+        if token is not None:
+            return token
+        url = str(request.url)
+        if f"/sites/{_SITE_ID}/drives" in url:
+            return drives_failure(request)
+        if "/drives/drive-explicit/" in url:
+            return httpx.Response(
+                200, json=_delta_for_drive("drive-explicit", [_envelope_for_drive("e1", "drive-explicit")])
+            )
+        return httpx.Response(200, json={"value": []})
+
+    connector = _build_connector_for_discovery(
+        _handler,
+        drives=[SharePointDriveSpec(drive_id="drive-explicit")],
+        site_discovery=[SiteDiscoverySpec(site_id=_SITE_ID)],
+    )
+    with caplog.at_level(logging.WARNING, logger="kairix.connectors.sharepoint.connector"):
+        events = list(connector.list_changes(cursor=None))
+    # Explicit drive still synced despite the site failing discovery.
+    assert [e.item_id for e in events] == ["e1"]
+    discover_errors = [r for r in caplog.records if "sharepoint_discover_error" in r.getMessage()]
+    assert len(discover_errors) == 1, "a failing site must surface exactly one sharepoint_discover_error WARN"
+    assert _SITE_ID in discover_errors[0].getMessage()
+
+
+def test_site_discovery_runs_exactly_once_per_tick() -> None:
+    """A full Wave-E tick discovers each site's drives ONCE, not per container.
+
+    The Wave-E flow is ``iter_containers()`` followed by a per-container
+    ``list_changes_for_container()`` for every container. Each
+    per-container call resolves the container's drive spec via
+    ``_spec_for_drive_id``; without the per-tick cache that lookup
+    re-ran ``_resolve_drive_specs()`` → a fresh ``GET /sites/{id}/drives``
+    discovery call PER container (NxM for N drives + M sites). The cache
+    makes discovery (the ``/sites/{id}/drives`` GET — the public
+    wire-level signature of ``list_drives``) fire exactly once per site
+    for the whole tick, regardless of how many drives the site exposes.
+
+    Sabotage proof: revert ``_spec_for_drive_id`` to call
+    ``_resolve_drive_specs()`` per container — the discovery-call count
+    climbs to one-per-container and this assertion fails.
+    """
+    discovery_calls: list[str] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        token = _token_response(request)
+        if token is not None:
+            return token
+        url = str(request.url)
+        if f"/sites/{_SITE_ID}/drives" in url:
+            discovery_calls.append(url)
+            # Site exposes THREE libraries — the NxM regression would make
+            # discovery fire once per container as each is drained.
+            return httpx.Response(200, json=_drives_list_for_site("drive-a", "drive-b", "drive-c"))
+        for did in ("drive-a", "drive-b", "drive-c"):
+            if f"/drives/{did}/" in url:
+                return httpx.Response(200, json=_delta_for_drive(did, [_envelope_for_drive(f"{did}-x", did)]))
+        return httpx.Response(200, json={"value": []})
+
+    connector = _build_connector_for_discovery(_handler, site_discovery=[SiteDiscoverySpec(site_id=_SITE_ID)])
+
+    def _run_tick() -> list[str]:
+        # iter_containers enumerates the drives (one discovery call);
+        # each per-container drain reuses the per-tick resolved-spec map.
+        emitted: list[str] = []
+        for container in connector.iter_containers(cc_pair_id=1):
+            emitted.extend(e.item_id for e in connector.list_changes_for_container(container))
+        return sorted(emitted)
+
+    assert _run_tick() == ["drive-a-x", "drive-b-x", "drive-c-x"]
+    # The site was discovered exactly ONCE for the whole tick even though
+    # iter_containers + three per-container drains all needed the spec map.
+    assert len(discovery_calls) == 1, (
+        f"site discovery must run once per tick, not per drive/container; saw {len(discovery_calls)} calls"
+    )
+
+    # A SECOND tick re-discovers (so newly-added libraries appear) — again
+    # exactly once, proving the cache is per-tick, not per-process.
+    discovery_calls.clear()
+    assert _run_tick() == ["drive-a-x", "drive-b-x", "drive-c-x"]
+    assert len(discovery_calls) == 1, "the next tick must re-discover exactly once"
+
+
+def test_site_url_resolving_to_empty_site_id_warns_and_skips(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A ``site_url`` that Graph resolves to an empty site_id -> WARN + skip.
+
+    Previously a None/empty resolution from ``resolve_site_by_path`` was
+    swallowed silently, leaking a falsy site id into discovery. Now the
+    connector emits a ``sharepoint_discover_site_unresolved`` WARN naming
+    the site_url and skips that site (same isolation as a discovery
+    failure); the explicit drive still syncs.
+    """
+    import logging
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        token = _token_response(request)
+        if token is not None:
+            return token
+        url = str(request.url)
+        # resolve_site_by_path returns a 200 with NO id field -> empty site_id.
+        if "/sites/contoso.sharepoint.com:/sites/ghost" in url:
+            return httpx.Response(200, json={"displayName": "Ghost", "webUrl": "https://x"})
+        if "/drives/drive-explicit/" in url:
+            return httpx.Response(
+                200, json=_delta_for_drive("drive-explicit", [_envelope_for_drive("e1", "drive-explicit")])
+            )
+        return httpx.Response(200, json={"value": []})
+
+    connector = _build_connector_for_discovery(
+        _handler,
+        drives=[SharePointDriveSpec(drive_id="drive-explicit")],
+        site_discovery=[SiteDiscoverySpec(site_url="https://contoso.sharepoint.com/sites/ghost")],
+    )
+    with caplog.at_level(logging.WARNING, logger="kairix.connectors.sharepoint.connector"):
+        events = list(connector.list_changes(cursor=None))
+    # Explicit drive still synced; the unresolved site was WARNed + skipped.
+    assert [e.item_id for e in events] == ["e1"]
+    unresolved = [r for r in caplog.records if "sharepoint_discover_site_unresolved" in r.getMessage()]
+    assert len(unresolved) == 1, "an empty site-id resolution must surface exactly one WARN"
+    assert "contoso.sharepoint.com/sites/ghost" in unresolved[0].getMessage()
+
+
+def test_site_discovery_empty_drive_set_warns(caplog: pytest.LogCaptureFixture) -> None:
+    """A site that resolves to zero drives -> WARN + no specs, connector still usable."""
+    import logging
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        token = _token_response(request)
+        if token is not None:
+            return token
+        url = str(request.url)
+        if f"/sites/{_SITE_ID}/drives" in url:
+            return httpx.Response(200, json={"value": []})
+        return httpx.Response(200, json={"value": []})
+
+    connector = _build_connector_for_discovery(_handler, site_discovery=[SiteDiscoverySpec(site_id=_SITE_ID)])
+    with caplog.at_level(logging.WARNING, logger="kairix.connectors.sharepoint.connector"):
+        events = list(connector.list_changes(cursor=None))
+    assert events == []
+    no_drives = [r for r in caplog.records if "sharepoint_discover_no_drives" in r.getMessage()]
+    assert len(no_drives) == 1
+    assert _SITE_ID in no_drives[0].getMessage()
+
+
+def test_site_exclude_paths_apply_to_discovered_drives() -> None:
+    """exclude_paths from the site entry applies to every discovered drive."""
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        token = _token_response(request)
+        if token is not None:
+            return token
+        url = str(request.url)
+        if f"/sites/{_SITE_ID}/drives" in url:
+            return httpx.Response(200, json=_drives_list_for_site("drive-a"))
+        if "/drives/drive-a/" in url:
+            return httpx.Response(
+                200,
+                json=_delta_for_drive(
+                    "drive-a",
+                    [
+                        _envelope_for_drive("keep", "drive-a", parent_path="/Curated"),
+                        _envelope_for_drive("drop", "drive-a", parent_path="/Archive"),
+                    ],
+                ),
+            )
+        return httpx.Response(200, json={"value": []})
+
+    connector = _build_connector_for_discovery(
+        _handler,
+        site_discovery=[SiteDiscoverySpec(site_id=_SITE_ID, exclude_paths=("/Archive",))],
+    )
+    events = list(connector.list_changes(cursor=None))
+    assert {e.item_id for e in events} == {"keep"}, "site exclude_paths must drop archived item on discovered drive"
+
+
+def test_site_include_paths_apply_to_discovered_drives() -> None:
+    """include_paths from the site entry scopes every discovered drive."""
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        token = _token_response(request)
+        if token is not None:
+            return token
+        url = str(request.url)
+        if f"/sites/{_SITE_ID}/drives" in url:
+            return httpx.Response(200, json=_drives_list_for_site("drive-a"))
+        if "/drives/drive-a/" in url:
+            return httpx.Response(
+                200,
+                json=_delta_for_drive(
+                    "drive-a",
+                    [
+                        _envelope_for_drive("in", "drive-a", parent_path="/Curated"),
+                        _envelope_for_drive("out", "drive-a", parent_path="/Other"),
+                    ],
+                ),
+            )
+        return httpx.Response(200, json={"value": []})
+
+    connector = _build_connector_for_discovery(
+        _handler,
+        site_discovery=[SiteDiscoverySpec(site_id=_SITE_ID, include_paths=("/Curated",))],
+    )
+    events = list(connector.list_changes(cursor=None))
+    assert {e.item_id for e in events} == {"in"}
+
+
+def test_site_url_entry_resolves_then_discovers() -> None:
+    """A ``site_url`` entry resolves to a site_id via Graph, then discovers drives."""
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        token = _token_response(request)
+        if token is not None:
+            return token
+        url = str(request.url)
+        # resolve_site_by_path: GET /sites/{hostname}:/{path} -> single object
+        if "/sites/contoso.sharepoint.com:/sites/marketing" in url:
+            return httpx.Response(
+                200,
+                json={
+                    "id": _SITE_ID,
+                    "displayName": "Marketing",
+                    "webUrl": "https://contoso.sharepoint.com/sites/marketing",
+                },
+            )
+        if f"/sites/{_SITE_ID}/drives" in url:
+            return httpx.Response(200, json=_drives_list_for_site("drive-mk"))
+        if "/drives/drive-mk/" in url:
+            return httpx.Response(200, json=_delta_for_drive("drive-mk", [_envelope_for_drive("m1", "drive-mk")]))
+        return httpx.Response(200, json={"value": []})
+
+    connector = _build_connector_for_discovery(
+        _handler,
+        site_discovery=[SiteDiscoverySpec(site_url="https://contoso.sharepoint.com/sites/marketing")],
+    )
+    events = list(connector.list_changes(cursor=None))
+    assert [e.item_id for e in events] == ["m1"]
+
+
+def test_iter_containers_includes_discovered_drives() -> None:
+    """Discovered drives surface as their own Containers (v2 per-container path)."""
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        token = _token_response(request)
+        if token is not None:
+            return token
+        url = str(request.url)
+        if f"/sites/{_SITE_ID}/drives" in url:
+            return httpx.Response(200, json=_drives_list_for_site("drive-a", "drive-b"))
+        return httpx.Response(200, json={"value": []})
+
+    connector = _build_connector_for_discovery(
+        _handler,
+        drives=[SharePointDriveSpec(drive_id="drive-explicit")],
+        site_discovery=[SiteDiscoverySpec(site_id=_SITE_ID)],
+    )
+    containers = sorted(c.container_id for c in connector.iter_containers(cc_pair_id=7))
+    assert containers == ["drive-a", "drive-b", "drive-explicit"]
+
+
+def test_constructor_rejects_empty_drives_and_no_sites() -> None:
+    """Empty drives AND no site_discovery still fails fast at construction."""
+    with pytest.raises(ValueError, match="drives list is empty"):
+        SharePointConnector(drives=[], site_discovery=[])
+
+
+def test_re_discovery_picks_up_new_library_on_next_tick() -> None:
+    """Discovery re-runs each sync so a library added to the site appears."""
+    state = {"drives": ["drive-a"]}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        token = _token_response(request)
+        if token is not None:
+            return token
+        url = str(request.url)
+        if f"/sites/{_SITE_ID}/drives" in url:
+            return httpx.Response(200, json=_drives_list_for_site(*state["drives"]))
+        for did in ("drive-a", "drive-b"):
+            if f"/drives/{did}/" in url:
+                return httpx.Response(200, json=_delta_for_drive(did, [_envelope_for_drive(f"{did}-x", did)]))
+        return httpx.Response(200, json={"value": []})
+
+    connector = _build_connector_for_discovery(_handler, site_discovery=[SiteDiscoverySpec(site_id=_SITE_ID)])
+    first = sorted(e.item_id for e in connector.list_changes(cursor=None))
+    assert first == ["drive-a-x"]
+    # A new library appears on the site between ticks.
+    state["drives"] = ["drive-a", "drive-b"]
+    second = sorted(e.item_id for e in connector.list_changes(cursor=connector.next_cursor()))
+    assert second == ["drive-a-x", "drive-b-x"], "re-discovery must pick up the newly-added library"
+
+
+def test_unparseable_site_url_warns_and_skips(caplog: pytest.LogCaptureFixture) -> None:
+    """A site_url with no server-relative path -> WARN + skip (no crash)."""
+    import logging
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        token = _token_response(request)
+        if token is not None:
+            return token
+        return httpx.Response(200, json={"value": []})
+
+    connector = _build_connector_for_discovery(
+        _handler,
+        drives=[SharePointDriveSpec(drive_id="drive-explicit")],
+        site_discovery=[SiteDiscoverySpec(site_url="https://contoso.sharepoint.com")],
+    )
+    with caplog.at_level(logging.WARNING, logger="kairix.connectors.sharepoint.connector"):
+        events = list(connector.list_changes(cursor=None))
+    # Explicit drive still synced; the unparseable site_url WARNed + skipped.
+    assert {e.metadata.get("drive_id") for e in events} == {"drive-explicit"} or events == []
+    assert any("sharepoint_discover_site_url_unparseable" in r.getMessage() for r in caplog.records)
+
+
+def test_site_url_with_no_path_skips_via_public_sync(caplog: pytest.LogCaptureFixture) -> None:
+    """A ``site_url`` lacking a server-relative path is skipped through the public sync.
+
+    Exercises the ``_split_site_url`` -> (None, None) branch via the
+    public ``list_changes`` surface (F5: no private-name imports in
+    tests) — the bare-host URL can't be resolved to a site, so the site
+    is WARNed + skipped and the explicit drive still syncs.
+    """
+    import logging
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        token = _token_response(request)
+        if token is not None:
+            return token
+        url = str(request.url)
+        if "/drives/drive-explicit/" in url:
+            return httpx.Response(
+                200, json=_delta_for_drive("drive-explicit", [_envelope_for_drive("e1", "drive-explicit")])
+            )
+        return httpx.Response(200, json={"value": []})
+
+    connector = _build_connector_for_discovery(
+        _handler,
+        drives=[SharePointDriveSpec(drive_id="drive-explicit")],
+        site_discovery=[SiteDiscoverySpec(site_url="contoso.sharepoint.com")],
+    )
+    with caplog.at_level(logging.WARNING, logger="kairix.connectors.sharepoint.connector"):
+        events = list(connector.list_changes(cursor=None))
+    assert [e.item_id for e in events] == ["e1"]
+    assert any("sharepoint_discover_site_url_unparseable" in r.getMessage() for r in caplog.records)
+
+
+def test_empty_site_url_skips_via_public_sync(caplog: pytest.LogCaptureFixture) -> None:
+    """A blank ``site_url`` (whitespace only) is skipped through the public sync.
+
+    Exercises the ``_split_site_url`` empty-input branch via the public
+    surface — the connector WARNs + skips and the explicit drive still
+    syncs.
+    """
+    import logging
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        token = _token_response(request)
+        if token is not None:
+            return token
+        if "/drives/drive-explicit/" in str(request.url):
+            return httpx.Response(
+                200, json=_delta_for_drive("drive-explicit", [_envelope_for_drive("e1", "drive-explicit")])
+            )
+        return httpx.Response(200, json={"value": []})
+
+    connector = _build_connector_for_discovery(
+        _handler,
+        drives=[SharePointDriveSpec(drive_id="drive-explicit")],
+        site_discovery=[SiteDiscoverySpec(site_url="   ")],
+    )
+    with caplog.at_level(logging.WARNING, logger="kairix.connectors.sharepoint.connector"):
+        events = list(connector.list_changes(cursor=None))
+    assert [e.item_id for e in events] == ["e1"]
+    assert any("sharepoint_discover_site_url_unparseable" in r.getMessage() for r in caplog.records)
+
+
+def test_site_url_host_only_with_trailing_slash_skips() -> None:
+    """A ``site_url`` that is host + trailing slash only (no path) is skipped.
+
+    Exercises the ``_split_site_url`` no-path branch (hostname present but
+    server-relative path empty) via the public surface.
+    """
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        token = _token_response(request)
+        if token is not None:
+            return token
+        if "/drives/drive-explicit/" in str(request.url):
+            return httpx.Response(
+                200, json=_delta_for_drive("drive-explicit", [_envelope_for_drive("e1", "drive-explicit")])
+            )
+        return httpx.Response(200, json={"value": []})
+
+    connector = _build_connector_for_discovery(
+        _handler,
+        drives=[SharePointDriveSpec(drive_id="drive-explicit")],
+        site_discovery=[SiteDiscoverySpec(site_url="https://contoso.sharepoint.com/")],
+    )
+    events = list(connector.list_changes(cursor=None))
+    assert [e.item_id for e in events] == ["e1"]
+
+
+def test_list_changes_for_container_drains_discovered_drive_unfiltered() -> None:
+    """A container naming a discovered drive id drains via the per-container path.
+
+    Covers ``_spec_for_drive_id`` resolving a discovered drive: the
+    container's drive id matches a site-discovered spec, so its (empty)
+    filters apply and the items emit. Also exercises the ``None`` branch
+    when the container id matches no resolved spec — the drive drains
+    unfiltered rather than crashing.
+    """
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        token = _token_response(request)
+        if token is not None:
+            return token
+        url = str(request.url)
+        if f"/sites/{_SITE_ID}/drives" in url:
+            return httpx.Response(200, json=_drives_list_for_site("drive-a"))
+        if "/drives/drive-a/" in url:
+            return httpx.Response(200, json=_delta_for_drive("drive-a", [_envelope_for_drive("a1", "drive-a")]))
+        if "/drives/unknown-drive/" in url:
+            return httpx.Response(
+                200, json=_delta_for_drive("unknown-drive", [_envelope_for_drive("u1", "unknown-drive")])
+            )
+        return httpx.Response(200, json={"value": []})
+
+    connector = _build_connector_for_discovery(_handler, site_discovery=[SiteDiscoverySpec(site_id=_SITE_ID)])
+    # Discovered drive — resolves to a spec, drains its item.
+    discovered = Container(
+        cc_pair_id=1, container_id="drive-a", access_state="ACCESSIBLE", cursor_token=None, last_synced_at=None
+    )
+    assert [e.item_id for e in connector.list_changes_for_container(discovered)] == ["a1"]
+    # A drive id matching no resolved spec — drains unfiltered (None branch).
+    unknown = Container(
+        cc_pair_id=1, container_id="unknown-drive", access_state="ACCESSIBLE", cursor_token=None, last_synced_at=None
+    )
+    assert [e.item_id for e in connector.list_changes_for_container(unknown)] == ["u1"]
+
+
+def test_degenerate_site_spec_with_no_anchor_is_skipped() -> None:
+    """A SiteDiscoverySpec with neither site_id nor site_url resolves to nothing.
+
+    The config parser never produces this shape (it rejects a block
+    naming neither), but the frozen dataclass permits it — the resolver's
+    defensive ``return None`` path skips it cleanly without a Graph call.
+    """
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        token = _token_response(request)
+        if token is not None:
+            return token
+        return httpx.Response(200, json={"value": []})
+
+    connector = _build_connector_for_discovery(
+        _handler,
+        drives=[SharePointDriveSpec(drive_id="drive-explicit")],
+        site_discovery=[SiteDiscoverySpec()],
+    )
+    # Observed via the public per-container surface: the degenerate site
+    # contributes no drives, so only the explicit drive resolves.
+    container_ids = {c.container_id for c in connector.iter_containers(cc_pair_id=1)}
+    assert container_ids == {"drive-explicit"}
+
+
+def test_retrieve_all_slim_docs_for_discovered_drive() -> None:
+    """SlimConnector id-only enumeration works for a site-discovered drive.
+
+    The container id is a discovered drive; ``_spec_for_drive_id``
+    resolves the site-inherited filters and the prune scan yields the
+    live (non-tombstone) item ids.
+    """
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        token = _token_response(request)
+        if token is not None:
+            return token
+        url = str(request.url)
+        if f"/sites/{_SITE_ID}/drives" in url:
+            return httpx.Response(200, json=_drives_list_for_site("drive-a"))
+        if "/drives/drive-a/" in url:
+            return httpx.Response(
+                200,
+                json=_delta_for_drive(
+                    "drive-a",
+                    [
+                        _envelope_for_drive("live-1", "drive-a", parent_path="/Curated"),
+                        _envelope_for_drive("live-2", "drive-a", parent_path="/Other"),
+                    ],
+                ),
+            )
+        return httpx.Response(200, json={"value": []})
+
+    connector = _build_connector_for_discovery(
+        _handler,
+        site_discovery=[SiteDiscoverySpec(site_id=_SITE_ID, include_paths=("/Curated",))],
+    )
+    container = Container(
+        cc_pair_id=1, container_id="drive-a", access_state="ACCESSIBLE", cursor_token=None, last_synced_at=None
+    )
+    ids = sorted(connector.retrieve_all_slim_docs(container))
+    assert ids == ["live-1"], "site include_paths must scope the prune scan on the discovered drive"
+
+
+def test_load_hierarchy_includes_discovered_drives() -> None:
+    """The hierarchy emits a DRIVE node for each discovered drive under the root SITE."""
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        token = _token_response(request)
+        if token is not None:
+            return token
+        if f"/sites/{_SITE_ID}/drives" in str(request.url):
+            return httpx.Response(200, json=_drives_list_for_site("drive-a", "drive-b"))
+        return httpx.Response(200, json={"value": []})
+
+    connector = _build_connector_for_discovery(
+        _handler,
+        drives=[SharePointDriveSpec(drive_id="drive-explicit")],
+        site_discovery=[SiteDiscoverySpec(site_id=_SITE_ID)],
+    )
+    nodes = list(connector.load_hierarchy(cc_pair_id=5))
+    assert nodes[0].node_type == "SITE"
+    drive_node_ids = {n.raw_node_id for n in nodes if n.node_type == "DRIVE"}
+    assert drive_node_ids == {"drive-explicit", "drive-a", "drive-b"}
+    # Discovered drives carry the library name as their display label.
+    by_id = {n.raw_node_id: n for n in nodes if n.node_type == "DRIVE"}
+    assert by_id["drive-a"].display_name == "Library-drive-a"

--- a/tests/connectors/sharepoint/test_graph_client.py
+++ b/tests/connectors/sharepoint/test_graph_client.py
@@ -120,6 +120,55 @@ def test_list_drives_yields_drive_refs_for_site() -> None:
     assert drives[0].site_id == "site-1"
 
 
+def test_resolve_site_by_path_returns_site_ref_from_single_object() -> None:
+    """``resolve_site_by_path`` parses the SINGLE-object /sites/{host}:/{path} reply.
+
+    Unlike the ``/sites?search=*`` collection, this endpoint returns one
+    site object (no ``value`` wrapper), so the client must parse the body
+    directly — a regression that routed it through the collection parser
+    would yield no SiteRef and this test would fail.
+    """
+    seen: list[str] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        token = _token_response_for(request)
+        if token is not None:
+            return token
+        seen.append(str(request.url))
+        return httpx.Response(
+            200,
+            json={
+                "id": "contoso.sharepoint.com,site-guid,web-guid",
+                "displayName": "Marketing",
+                "webUrl": "https://contoso.sharepoint.com/sites/marketing",
+            },
+        )
+
+    _, client = _auth_and_client(_handler)
+    site = client.resolve_site_by_path("contoso.sharepoint.com", "/sites/marketing")
+    assert site.site_id == "contoso.sharepoint.com,site-guid,web-guid"
+    assert site.display_name == "Marketing"
+    assert any("/sites/contoso.sharepoint.com:/sites/marketing" in u for u in seen), (
+        f"resolve must hit the /sites/{{host}}:/{{path}} endpoint; saw {seen!r}"
+    )
+
+
+def test_resolve_site_by_path_normalises_missing_leading_slash() -> None:
+    """A server-relative path without a leading slash is normalised."""
+    seen: list[str] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        token = _token_response_for(request)
+        if token is not None:
+            return token
+        seen.append(str(request.url))
+        return httpx.Response(200, json={"id": "s", "displayName": "S", "webUrl": "https://x/s"})
+
+    _, client = _auth_and_client(_handler)
+    client.resolve_site_by_path("contoso.sharepoint.com", "sites/eng")
+    assert any("contoso.sharepoint.com:/sites/eng" in u for u in seen), f"path must be normalised; saw {seen!r}"
+
+
 def test_iter_drive_items_walks_pagination_and_records_delta_link() -> None:
     page_calls = {"n": 0}
 


### PR DESCRIPTION
## Why

The SharePoint connector required an **explicit `drive_id` per drive**. A config that names a *site* (the natural, human-friendly way to configure SharePoint) was rejected — which is exactly how Customer-Zero's SharePoint silently stalled for days after a config-schema change (`'drives' must be a non-empty list of drive ids`). This restores **self-discovery** so any user can point the connector at a **site** and have its drives discovered automatically — and it's the foundation for the guided-config wizard (KFEAT-022).

## What
- **Site config entry:** a `drives` list entry may be a mapping with `site_id` (or `site_url`, resolved via Graph) and **no `drive_id`** → the connector discovers **every drive in that site** via `graph_client.list_drives(site_id)`, inheriting the entry's `include_paths`/`exclude_paths` and the drive's display name. Explicit `{drive_id}` entries are **unchanged**.
- **Lazy + cached:** `make_connector` stays pure (no Graph at parse). Discovery runs at sync time, **exactly once per tick** (a per-tick resolved-spec cache), so the Wave-E per-container path doesn't multiply discovery calls. Discovered drive cursors round-trip with the existing per-drive deltaLink map.
- **Robust (per-site fault isolation):** a site whose discovery fails — `403`, a raw `httpx.ConnectError`, or an unresolvable `site_url` — emits a structured WARN and is **skipped**; explicit drives and other sites still sync. One site's failure never crashes the connector or freezes unrelated cursors.
- **Documented + configurable:** §8 of the connector-ingestion architecture + a commented self-discovering `kairix.config.example.yaml` block + a `@site_discovery` BDD scenario.

## Tests / gates
116 sharepoint unit + BDD tests pass (incl. once-per-tick discovery, `ConnectError` isolation, empty-site-id skip). All 90 fitness functions pass (F5/F16/F17/F42). Coverage 95.95% (connector 97.3%). ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)