### PR TITLE
feat(sharepoint): per-drive fault isolation + 429 circuit breaker (PR#4)

### DIFF
--- a/kairix/connectors/sharepoint/connector.py
+++ b/kairix/connectors/sharepoint/connector.py
@@ -43,8 +43,10 @@ import json
 import logging
 from collections.abc import Callable, Iterator, Mapping
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, cast
+
+import httpx
 
 from kairix.connectors.sharepoint.graph_client import (
     DriveItemRef,
@@ -92,12 +94,52 @@ _HIERARCHY_ROOT_DISPLAY = "SharePoint"
 # the legacy + Wave E emission paths has one edit site.
 _META_SENSITIVITY_KEY = "sensitivity"
 
+# PR#4 429 circuit-breaker. After this many drives exhaust the graph
+# client's per-request retry budget with sustained throttling (429) in a
+# single tick, the connector backs the WHOLE tick off for one cycle so a
+# tenant-wide throttle stops thrashing the worker every
+# CONNECTOR_SYNC_INTERVAL. Threshold > 1 so a single hot drive can't trip it.
+_THROTTLE_BREAKER_THRESHOLD = 3
+_THROTTLE_BACKOFF_SECONDS = 900  # one connector tick
+
 
 def _now_iso() -> str:
     """Return a current ISO-8601 UTC timestamp matching the connector
     boundary's :class:`ChangeEvent.modified_at` format.
     """
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _timestamp_after_s(seconds: int) -> str:
+    """Return an ISO-8601 UTC timestamp ``seconds`` in the future.
+
+    Stamps the 429 breaker's backoff-expiry in the same string shape as
+    :func:`_now_iso`, so the two compare lexicographically.
+    """
+    future = datetime.now(timezone.utc) + timedelta(seconds=seconds)
+    return future.isoformat().replace("+00:00", "Z")
+
+
+def _is_throttle_exhaustion_error(exc: BaseException) -> bool:
+    """True when ``exc``'s cause chain carries a 429 the retries couldn't clear.
+
+    The graph client converts an exhausted-retry throttle into an
+    :class:`httpx.HTTPStatusError` (status 429) via ``raise_for_status``;
+    walk the ``__cause__`` / ``__context__`` chain so a wrapped 429 still
+    counts toward the breaker while a transient 403 or timeout does not.
+    """
+    seen: set[int] = set()
+    pending: list[BaseException | None] = [exc]
+    while pending:
+        current = pending.pop()
+        if current is None or id(current) in seen:
+            continue
+        seen.add(id(current))
+        if isinstance(current, httpx.HTTPStatusError) and current.response.status_code == 429:
+            return True
+        pending.append(current.__cause__)
+        pending.append(current.__context__)
+    return False
 
 
 @dataclass(frozen=True)
@@ -294,6 +336,11 @@ class SharePointConnector:
         # ``drive_id -> deltaLink`` so a single opaque string round-trips
         # through the orchestrator's cursor_store.
         self._next_cursor: str | None = None
+        # PR#4 429 breaker state: count of drives that exhausted retries with
+        # sustained throttling this tick, and the ISO timestamp until which the
+        # breaker holds the connector off (None = breaker not tripped).
+        self._throttle_hits_this_tick = 0
+        self._throttle_backoff_until: str | None = None
 
         # Probe each EXPLICIT include_path against the live drive at
         # startup so missing folders surface proactively (not silently,
@@ -503,27 +550,118 @@ class SharePointConnector:
         (possibly discovered) ``drive_id`` so it round-trips through the
         existing deltaLink map regardless of how the drive was declared.
         """
+        if self._throttle_breaker_active():
+            logger.warning(
+                "event=sharepoint_breaker_active name=%s backoff_until=%s "
+                "(sustained 429 last tick; skipping this tick so Graph recovers; "
+                "cursor unchanged, next tick will retry)",
+                self.name,
+                self._throttle_backoff_until,
+            )
+            self._next_cursor = cursor if isinstance(cursor, str) else None
+            return iter([])
         per_drive_cursor = _deserialise_cursor(cursor)
         events: list[ChangeEvent] = []
         next_links: dict[str, str] = {}
+        self._throttle_hits_this_tick = 0
         for spec in self._refresh_resolved_specs():
             drive_id = spec.drive_id
             start_url = per_drive_cursor.get(drive_id)
-            for item in self._graph.iter_drive_items(drive_id, start_url=start_url):
-                if not self._item_passes_spec_filter(item, spec=spec):
-                    continue
-                event = self._item_to_event(item, drive_id=drive_id)
-                if event is None:
-                    continue
-                self._cache[event.item_id] = item
-                events.append(event)
-            drive_delta = self._graph.last_delta_link_for_drive(drive_id)
+            try:
+                drive_delta = self._drain_drive(spec, start_url, events)
+            except Exception as exc:
+                self._record_drive_failure(drive_id, exc, start_url, next_links)
+                continue
             if drive_delta is not None:
                 next_links[drive_id] = drive_delta
             elif start_url is not None:
                 next_links[drive_id] = start_url
+        self._maybe_trip_throttle_breaker()
         self._next_cursor = _serialise_cursor(next_links) if next_links else None
         return iter(events)
+
+    def _drain_drive(
+        self,
+        spec: SharePointDriveSpec,
+        start_url: str | None,
+        events: list[ChangeEvent],
+    ) -> str | None:
+        """Drain one drive's delta into ``events`` atomically; return its deltaLink.
+
+        Changes are staged locally and only merged into ``events`` + the
+        envelope cache once the drive drains in full. A mid-iteration failure
+        (e.g. a throttle on delta page 2) therefore leaves NO partial events
+        or stale cache entries behind — :meth:`list_changes` wraps the call,
+        carries the drive's prior cursor forward, and the next tick re-drains
+        the whole drive cleanly.
+        """
+        drive_id = spec.drive_id
+        staged: list[ChangeEvent] = []
+        staged_cache: dict[str, DriveItemRef] = {}
+        for item in self._graph.iter_drive_items(drive_id, start_url=start_url):
+            if not self._item_passes_spec_filter(item, spec=spec):
+                continue
+            event = self._item_to_event(item, drive_id=drive_id)
+            if event is None:
+                continue
+            staged_cache[event.item_id] = item
+            staged.append(event)
+        self._cache.update(staged_cache)
+        events.extend(staged)
+        return self._graph.last_delta_link_for_drive(drive_id)
+
+    def _record_drive_failure(
+        self,
+        drive_id: str,
+        exc: Exception,
+        start_url: str | None,
+        next_links: dict[str, str],
+    ) -> None:
+        """Log a per-drive failure and carry its cursor forward for a retry.
+
+        A drive that raised is skipped this tick; its prior cursor (when it
+        had one) is re-persisted so the next tick resumes from the same
+        position. Counts toward the 429 breaker only when the error chain
+        carries an exhausted-retry 429.
+        """
+        if _is_throttle_exhaustion_error(exc):
+            self._throttle_hits_this_tick += 1
+        if start_url is not None:
+            next_links[drive_id] = start_url
+        logger.warning(
+            "event=sharepoint_drive_error name=%s drive=%s error=%s "
+            "(this drive skipped this tick; other drives still sync; "
+            "next tick will retry)",
+            self.name,
+            drive_id,
+            exc,
+        )
+
+    def _throttle_breaker_active(self) -> bool:
+        """Return True while the 429 breaker is holding the connector off.
+
+        Clears the breaker (and returns False) once the backoff window set by
+        :meth:`_maybe_trip_throttle_breaker` has elapsed.
+        """
+        if self._throttle_backoff_until is None:
+            return False
+        if _now_iso() >= self._throttle_backoff_until:
+            self._throttle_backoff_until = None
+            return False
+        return True
+
+    def _maybe_trip_throttle_breaker(self) -> None:
+        """Trip the 429 breaker when this tick's throttle count hit the threshold."""
+        if self._throttle_hits_this_tick < _THROTTLE_BREAKER_THRESHOLD:
+            return
+        self._throttle_backoff_until = _timestamp_after_s(_THROTTLE_BACKOFF_SECONDS)
+        logger.warning(
+            "event=sharepoint_breaker_tripped name=%s drives_throttled=%d backoff_until=%s "
+            "(connector backing off one tick to let Graph recover; cursor not advanced)",
+            self.name,
+            self._throttle_hits_this_tick,
+            self._throttle_backoff_until,
+        )
 
     def fetch(self, item_id: str) -> RawArtefact:
         """Download the binary content for ``item_id``.

--- a/tests/unit/test_sharepoint_fault_isolation.py
+++ b/tests/unit/test_sharepoint_fault_isolation.py
@@ -1,0 +1,214 @@
+"""PR#4: per-drive fault isolation + 429 circuit breaker for the SharePoint connector.
+
+F5: every behaviour is exercised through the public
+``SharePointConnector.list_changes()`` surface. The breaker is observed only
+via behaviour (which drives' cursors advance, whether a tick is skipped, how
+many Graph calls happen) and the structured WARN logs — never by reading
+private connector state.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Iterable
+
+import httpx
+import pytest
+
+from kairix.connectors.sharepoint.connector import (
+    SharePointConnector,
+    SharePointCredentials,
+    SharePointDriveSpec,
+)
+from kairix.connectors.sharepoint.graph_client import DriveItemRef
+
+pytestmark = pytest.mark.unit
+
+_CREDS = SharePointCredentials(
+    tenant_id="t",
+    client_id="c",
+    client_secret="s",  # pragma: allowlist secret — test fixture
+)
+
+
+def _http_error(status: int) -> httpx.HTTPStatusError:
+    req = httpx.Request("GET", "https://graph.microsoft.com/v1.0/drives/x/root/delta")
+    return httpx.HTTPStatusError(f"{status}", request=req, response=httpx.Response(status, request=req))
+
+
+def _raises(exc: Exception) -> Callable[[], Iterable[object]]:
+    def _behaviour() -> Iterable[object]:
+        raise exc
+
+    return _behaviour
+
+
+def _ok() -> Iterable[object]:
+    return []
+
+
+def _yields(items: list[DriveItemRef]) -> Callable[[], Iterable[object]]:
+    return lambda: list(items)
+
+
+def _yields_then_raises(items: list[DriveItemRef], exc: Exception) -> Callable[[], Iterable[object]]:
+    def _behaviour() -> Iterable[object]:
+        yield from items
+        raise exc
+
+    return _behaviour
+
+
+def _drive_item(item_id: str, drive_id: str) -> DriveItemRef:
+    return DriveItemRef(
+        item_id=item_id,
+        drive_id=drive_id,
+        name=f"{item_id}.md",
+        mime="text/markdown",
+        web_url=None,
+        size=1,
+        last_modified_at="2026-06-25T00:00:00Z",
+        removed=False,
+    )
+
+
+class _FakeGraph:
+    """Per-drive controllable Graph stub.
+
+    ``behaviours`` maps ``drive_id`` to a zero-arg callable that either returns
+    an iterable of drive-item envelopes (success) or raises (fault). A drive
+    that returned successfully reports a deltaLink; a drive that never ran (or
+    raised) reports ``None``.
+    """
+
+    def __init__(self, behaviours: dict[str, Callable[[], Iterable[object]]]) -> None:
+        self._behaviours = behaviours
+        self._delivered: set[str] = set()
+        self.drive_calls = 0
+
+    def iter_drive_items(self, drive_id: str, start_url: str | None = None):
+        self.drive_calls += 1
+        result = self._behaviours.get(drive_id, _ok)()  # may raise
+        self._delivered.add(drive_id)
+        return iter(result)
+
+    def last_delta_link_for_drive(self, drive_id: str) -> str | None:
+        return f"delta-{drive_id}" if drive_id in self._delivered else None
+
+    def path_exists(self, *args: object, **kwargs: object) -> bool:
+        return True
+
+    def list_drives(self, *args: object, **kwargs: object):
+        return iter([])
+
+    def resolve_site_by_path(self, *args: object, **kwargs: object):
+        raise NotImplementedError
+
+    def fetch_item_content(self, *args: object, **kwargs: object) -> bytes:
+        return b""
+
+
+def _connector(behaviours: dict[str, Callable[[], Iterable[object]]]) -> tuple[SharePointConnector, _FakeGraph]:
+    fake = _FakeGraph(behaviours)
+    connector = SharePointConnector(
+        drives=[SharePointDriveSpec(drive_id=d) for d in behaviours],
+        credentials=_CREDS,
+        client_builder=lambda _auth: fake,
+    )
+    return connector, fake
+
+
+def test_one_drive_error_others_still_sync(caplog):
+    """A single failing drive is skipped with a WARN; the others advance."""
+    connector, _ = _connector(
+        {"a": _raises(_http_error(403)), "b": _ok, "c": _ok},
+    )
+    with caplog.at_level("WARNING"):
+        list(connector.list_changes(cursor=None))
+    cursor = connector.next_cursor()
+    assert cursor is not None
+    advanced = json.loads(cursor)
+    assert advanced == {"b": "delta-b", "c": "delta-c"}  # a skipped, b+c advanced
+    assert "event=sharepoint_drive_error" in caplog.text
+    assert "drive=a" in caplog.text
+
+
+def test_failed_drive_keeps_prior_cursor_for_retry():
+    """A drive that raised re-persists its prior cursor so the next tick retries it."""
+    prior = json.dumps({"a": "old-cursor-a", "b": "old-cursor-b"})
+    connector, _ = _connector({"a": _raises(_http_error(500)), "b": _ok})
+    list(connector.list_changes(cursor=prior))
+    advanced = json.loads(connector.next_cursor())
+    assert advanced["a"] == "old-cursor-a"  # carried forward unchanged
+    assert advanced["b"] == "delta-b"  # b advanced to its new delta
+
+
+def test_429_breaker_trips_then_skips_next_tick(caplog):
+    """>= threshold drives exhausting 429 trips the breaker; the next tick is skipped."""
+    connector, fake = _connector({d: _raises(_http_error(429)) for d in ("a", "b", "c", "d")})
+    with caplog.at_level("WARNING"):
+        list(connector.list_changes(cursor=None))
+    assert "event=sharepoint_breaker_tripped" in caplog.text
+    calls_after_trip = fake.drive_calls
+    assert calls_after_trip == 4  # all four drives attempted this tick
+
+    caplog.clear()
+    with caplog.at_level("WARNING"):
+        events = list(connector.list_changes(cursor=None))
+    assert events == []
+    assert "event=sharepoint_breaker_active" in caplog.text
+    assert fake.drive_calls == calls_after_trip  # no Graph calls on the skipped tick
+
+
+def test_429_breaker_skip_preserves_cursor():
+    """While the breaker holds, the incoming cursor is returned unchanged."""
+    connector, _ = _connector({d: _raises(_http_error(429)) for d in ("a", "b", "c")})
+    list(connector.list_changes(cursor=None))  # trips (3 >= threshold)
+    incoming = json.dumps({"a": "keep-a"})
+    list(connector.list_changes(cursor=incoming))  # skipped tick
+    assert connector.next_cursor() == incoming
+
+
+def test_non_429_errors_do_not_trip_breaker(caplog):
+    """403 / transient errors are isolated but never trip the 429 breaker."""
+    connector, _ = _connector({d: _raises(_http_error(403)) for d in ("a", "b", "c", "d")})
+    with caplog.at_level("WARNING"):
+        list(connector.list_changes(cursor=None))
+    assert "event=sharepoint_breaker_tripped" not in caplog.text
+    # next tick proceeds (not skipped) — the drives are attempted again
+    caplog.clear()
+    with caplog.at_level("WARNING"):
+        list(connector.list_changes(cursor=None))
+    assert "event=sharepoint_breaker_active" not in caplog.text
+    assert "event=sharepoint_drive_error" in caplog.text
+
+
+def test_drive_failing_mid_iteration_commits_nothing():
+    """A drive that yields then raises commits no partial events or cache (atomic).
+
+    Guards the at-least-once contract: a throttle on delta page 2 must not leak
+    page-1 events or poison the envelope cache; the whole drive re-drains next
+    tick from its prior cursor.
+    """
+    connector, _ = _connector(
+        {
+            "a": _yields_then_raises([_drive_item("a-item", "a")], _http_error(500)),
+            "b": _yields([_drive_item("b-item", "b")]),
+        },
+    )
+    events = list(connector.list_changes(cursor=None))
+    ids = {e.item_id for e in events}
+    assert "a-item" not in ids  # drive a's partial item discarded
+    assert "b-item" in ids  # drive b committed in full
+    assert json.loads(connector.next_cursor()) == {"b": "delta-b"}
+    with pytest.raises(KeyError):
+        connector.fetch("a-item")  # never cached -> not fetchable
+
+
+def test_429_below_threshold_does_not_trip(caplog):
+    """Fewer than threshold throttled drives leaves the breaker closed."""
+    connector, _ = _connector({"a": _raises(_http_error(429)), "b": _raises(_http_error(429)), "c": _ok})
+    with caplog.at_level("WARNING"):
+        list(connector.list_changes(cursor=None))
+    assert "event=sharepoint_breaker_tripped" not in caplog.text
+    assert json.loads(connector.next_cursor()) == {"c": "delta-c"}  # c still advanced


### PR DESCRIPTION
## Problem

One bad drive sinks the whole SharePoint connector tick. `list_changes` loops every resolved drive; if `iter_drive_items` raises for **any** drive (403, transient 5xx, or a 429 that exhausts the graph client's per-request retry budget) the exception unwinds the loop — events drained so far are dropped and **no cursor advances**. A single site in maintenance/throttle deadlocks the connector every `CONNECTOR_SYNC_INTERVAL`.

The graph client already honours `Retry-After` + exponential backoff **per request**; this PR adds the missing **tick-level** policy.

## Change

1. **Per-drive fault isolation** — each drive drains inside its own `try/except` (`_drain_drive`). A drive that raises is skipped with a structured `event=sharepoint_drive_error` WARN and **re-persists its prior cursor** so the next tick retries from the same position; every other drive still syncs and advances. (Mirrors the existing per-*site* `event=sharepoint_discover_error` isolation.)

2. **429 circuit breaker** — when ≥ `_THROTTLE_BREAKER_THRESHOLD` (3) drives exhaust retries with a 429 in one tick, the breaker trips (`event=sharepoint_breaker_tripped`) and the **next tick short-circuits** (`event=sharepoint_breaker_active`) without touching Graph or the cursor, letting the tenant recover instead of thrashing. Self-clears once the backoff window (`_THROTTLE_BACKOFF_SECONDS` = one tick) elapses. Only exhausted-retry 429s count — 403/timeouts are isolated but don't trip it (`_is_throttle_exhaustion_error` walks the exception cause chain).

`list_changes` stays under the F16 complexity ceiling by extracting `_drain_drive` / `_record_drive_failure` / `_throttle_breaker_active` / `_maybe_trip_throttle_breaker`.

## Tests

F5 — all via the public `SharePointConnector.list_changes()` surface with a `client_builder`-injected fake Graph:
`one_drive_error_others_still_sync`, `failed_drive_keeps_prior_cursor_for_retry`, `429_breaker_trips_then_skips_next_tick` (asserts no Graph calls on the skipped tick), `429_breaker_skip_preserves_cursor`, `non_429_errors_do_not_trip_breaker`, `429_below_threshold_does_not_trip`.

20 existing SharePoint tests unchanged; **57 staged fitness gates green**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)