### PR TITLE
feat(silver): wire per-type chunker registry into markdown ingest, flag-gated (PR#6)

### DIFF
--- a/kairix/core/connectors/silver.py
+++ b/kairix/core/connectors/silver.py
@@ -39,7 +39,7 @@ import re
 import sqlite3
 from collections.abc import Callable, Sequence
 from datetime import datetime, timezone
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from kairix.core.protocols import (
     BronzeRef,
@@ -51,6 +51,9 @@ from kairix.core.protocols import (
     SilverOutput,
     SourceMetadata,
 )
+
+if TYPE_CHECKING:
+    from kairix.core.connectors.chunker_registry import ChunkerRegistry
 
 # Allowed values for ``documents_media.extraction_status``. ``ok`` and
 # ``failed`` mirror the legacy schema default; ``unsupported`` is new
@@ -458,9 +461,15 @@ class DefaultSilverProcessor:
         self,
         documents_media_writer: SqliteDocumentsMediaWriter | None = None,
         document_pages_writer: SqliteDocumentPagesWriter | None = None,
+        chunker_registry: ChunkerRegistry | None = None,
     ) -> None:
         self._documents_media_writer = documents_media_writer
         self._document_pages_writer = document_pages_writer
+        # PR#6: when wired (the chunker_registry_dispatch_enabled flag is ON at
+        # worker boot), passthrough markdown is routed through the per-type
+        # chunker registry; None (default) keeps the paragraph fallback so the
+        # OFF path is byte-identical to pre-cutover behaviour.
+        self._chunker_registry = chunker_registry
 
     def process(
         self,
@@ -518,6 +527,15 @@ class DefaultSilverProcessor:
                 )
                 for chunk_text, page_number in page_chunks
             )
+        elif self._chunker_registry is not None:
+            chunks = self._dispatch_markdown_chunks(
+                markdown=extracted.markdown,
+                raw=raw,
+                source_uri=source_uri,
+                chunk_modified_at=chunk_modified_at,
+                sensitivity=sensitivity,
+                merged=merged,
+            )
         else:
             chunk_texts = _chunk_markdown(extracted.markdown)
             chunks = tuple(
@@ -572,6 +590,47 @@ class DefaultSilverProcessor:
             chunker_version=_first_chunker_version(chunks),
         )
         return SilverOutput(chunks=chunks, entity_signals=signals)
+
+    def _dispatch_markdown_chunks(
+        self,
+        *,
+        markdown: str,
+        raw: BronzeRef,
+        source_uri: str,
+        chunk_modified_at: str,
+        sensitivity: Sensitivity,
+        merged: SourceMetadata,
+    ) -> tuple[Chunk, ...]:
+        """Chunk passthrough markdown via the per-type chunker registry (PR#6).
+
+        The registry resolves a chunker by ``(connector kind, source mime)`` and
+        returns minimally-shaped Chunks carrying the per-type ``chunker_version``
+        + structural metadata (e.g. ``heading_path``); Silver re-wraps each with
+        the source / sensitivity / author metadata it owns. Any unregistered
+        ``(kind, mime)`` falls through to the registry's bounded paragraph
+        fallback, so no document is left unchunked and every chunk stays within
+        the embed token budget.
+        """
+        assert self._chunker_registry is not None
+        chunker = self._chunker_registry.dispatch(kind=raw.source_name, mime=raw.mime, section_kind="text")
+        dispatched = chunker.chunk(text=markdown, section_kind="text", source_uri=source_uri)
+        return tuple(
+            Chunk(
+                text=chunk.text,
+                content_hash=chunk.content_hash,
+                source_name=raw.source_name,
+                source_uri=source_uri,
+                source_modified_at=chunk_modified_at,
+                source_page=None,
+                sensitivity=sensitivity,
+                chunker_version=chunk.chunker_version,
+                author=merged.author,
+                author_email=merged.author_email,
+                tags=merged.tags,
+                metadata={**merged.properties, **chunk.metadata} if chunk.metadata else merged.properties,
+            )
+            for chunk in dispatched
+        )
 
     def _maybe_write_documents_media(
         self,

--- a/kairix/core/features/registry.py
+++ b/kairix/core/features/registry.py
@@ -47,6 +47,7 @@ class FeatureFlag:
 # the check; these are the canonical recurring fields.
 _CONNECTOR_FRAMEWORK_OWNER = "connector-framework"
 _CONNECTOR_INGESTION_SPEC = "docs/architecture/connector-ingestion-architecture.md"
+_PER_TYPE_CHUNKING_SPEC = "docs/architecture/ADR-028-per-type-chunking-and-evaluation.md"
 _FLAG_INTRODUCED_IN_DISPATCH_WINDOW = "v2026.5.23"
 _FLAG_TARGET_RETIRE_IN = "v2026.7.23"
 # Long-window retire ceiling for connectors with slower per-customer adoption
@@ -492,6 +493,32 @@ REGISTRY: dict[str, FeatureFlag] = {
         target_retire_in="v2026.12.6",
         owner="cli-warm-mcp",
         related_spec=_FEATURE_FLAG_ARCHITECTURE_SPEC,
+    ),
+    "chunker_registry_dispatch_enabled": FeatureFlag(
+        name="chunker_registry_dispatch_enabled",
+        default=False,
+        description=(
+            "When ON, Silver routes passthrough (no-pages) content through the "
+            "per-type chunker registry (build_default_registry) instead of the "
+            "paragraph fallback — markdown_structural for obsidian / notion / "
+            "github markdown, DocxHeadingChunker for DOCX, with the bounded "
+            "paragraph fallback for any unregistered (kind, mime). Chunks carry "
+            "the per-type chunker_version + structural metadata (heading_path) so "
+            "a re-chunk sweep can identify them. OFF (default) keeps the "
+            "byte-identical silver-markdown-v1 fallback. CAVEAT: existing "
+            "documents re-chunk lazily on their next sync, but the per-document "
+            "upsert keys on source_uri#seq — a document whose chunk count SHRINKS "
+            "keeps stale tail chunks (old chunker_version) searchable until the "
+            "re-chunk sweep (forthcoming) retires them, so prefer enabling on "
+            "fresh deployments or pair the flip with a re-embed sweep. ADR-028 "
+            "markdown-first cutover; page-bearing PPTX / XLSX take the page path "
+            "(their registry entries are inert until per-page dispatch lands)."
+        ),
+        stage="introduce",
+        introduced_in="v2026.6.25",
+        target_retire_in="v2026.12.25",
+        owner=_CONNECTOR_FRAMEWORK_OWNER,
+        related_spec=_PER_TYPE_CHUNKING_SPEC,
     ),
 }
 

--- a/kairix/worker.py
+++ b/kairix/worker.py
@@ -38,6 +38,7 @@ from kairix.worker_state import WorkerPhase, WorkerState, read_state, write_stat
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from kairix.core.connectors.silver import DefaultSilverProcessor, SqliteDocumentsMediaWriter
     from kairix.core.embed.use_cases import EmbedPipelineResult
     from kairix.core.features.registry import FeatureFlag
     from kairix.core.protocols import Chunk, EntitySignal
@@ -571,7 +572,6 @@ def _run_one_connector_batch(
         ConnectorPipeline,
         CursorStore,
         DeadLetterStore,
-        DefaultSilverProcessor,
         SqliteDocumentsMediaWriter,
         resolve_connector,
     )
@@ -599,7 +599,7 @@ def _run_one_connector_batch(
     # legacy_chunk_writer remains the fallback when no cc_pair has been
     # registered for the entry.
     chunk_writer = resolve_chunk_writer_for_entry(db, name, cc_pair_id=cc_pair_id)
-    silver = DefaultSilverProcessor(documents_media_writer=SqliteDocumentsMediaWriter(db))
+    silver = _silver_with_registry(SqliteDocumentsMediaWriter(db))
     pipeline = ConnectorPipeline(
         db=db,
         bronze=bronze_store,
@@ -1174,7 +1174,7 @@ def _build_reextract_components(
     routing name. ``entry["name"]`` keys the chunk-writer collection (via
     :func:`resolve_collection_for_entry`).
     """
-    from kairix.core.connectors import DefaultSilverProcessor, SqliteDocumentsMediaWriter, resolve_connector
+    from kairix.core.connectors import SqliteDocumentsMediaWriter, resolve_connector
     from kairix.core.connectors.collection_router import legacy_chunk_writer
     from kairix.core.connectors.registry import build_extractor_from_entry
 
@@ -1186,7 +1186,7 @@ def _build_reextract_components(
     # documents_media row that the original sync would have. Without
     # this, re-extracted documents flow through but the per-doc row is
     # silently skipped, leaving F40/F70 blind to recovered docs.
-    silver = DefaultSilverProcessor(documents_media_writer=SqliteDocumentsMediaWriter(db))
+    silver = _silver_with_registry(SqliteDocumentsMediaWriter(db))
     # GH #371 — re-extract MUST tag with the same collection the sync
     # path uses. The previous ``entry.get("collection", "default")``
     # silently leaked ~1M SharePoint docs into the ``default`` collection.
@@ -1493,12 +1493,12 @@ def _default_deadletter_sweep() -> tuple[Any, ...]:
     import sqlite3
 
     from kairix.core.connectors.deadletter_drain import drain_all_source_deadletters
-    from kairix.core.connectors.silver import DefaultSilverProcessor, SqliteDocumentsMediaWriter
+    from kairix.core.connectors.silver import SqliteDocumentsMediaWriter
     from kairix.paths import db_path
 
     conn = sqlite3.connect(str(db_path()), timeout=30.0)
     try:
-        silver = DefaultSilverProcessor(documents_media_writer=SqliteDocumentsMediaWriter(conn))
+        silver = _silver_with_registry(SqliteDocumentsMediaWriter(conn))
         return drain_all_source_deadletters(conn, silver=silver)
     finally:
         conn.close()
@@ -1530,6 +1530,26 @@ def _default_flag_value(name: str) -> bool:
     from kairix.core.features import flag as _prod_flag
 
     return _prod_flag(name)
+
+
+# PR#6 — read once per Silver construction. OFF (default) -> registry None ->
+# Silver keeps its byte-identical paragraph fallback; ON -> per-type dispatch.
+_CHUNKER_REGISTRY_FLAG = "chunker_registry_dispatch_enabled"
+
+
+def _silver_with_registry(
+    writer: SqliteDocumentsMediaWriter,
+    *,
+    read_flag: Callable[[str], bool] = _default_flag_value,
+) -> DefaultSilverProcessor:
+    """Construct Silver, wiring the per-type chunker registry when
+    ``chunker_registry_dispatch_enabled`` is ON (default OFF -> paragraph fallback).
+    """
+    from kairix.core.connectors.chunker_registry import build_default_registry
+    from kairix.core.connectors.silver import DefaultSilverProcessor
+
+    registry = build_default_registry() if read_flag(_CHUNKER_REGISTRY_FLAG) else None
+    return DefaultSilverProcessor(documents_media_writer=writer, chunker_registry=registry)
 
 
 def connector_enabled(

--- a/tests/bdd/features/feature_flag_chunker_registry_dispatch_enabled.feature
+++ b/tests/bdd/features/feature_flag_chunker_registry_dispatch_enabled.feature
@@ -1,0 +1,21 @@
+@feature_flag @chunker_registry_dispatch_enabled
+Feature: chunker_registry_dispatch_enabled feature flag — both-branch parity (ADR-028 F54)
+
+  The chunker_registry_dispatch_enabled flag gates whether Silver routes
+  passthrough markdown through the per-type chunker registry. OFF (default)
+  keeps the paragraph fallback (silver-markdown-v1); ON dispatches to the
+  registered per-type chunker, stamping its per-type version.
+
+  @happy_path @flag_off
+  Scenario: flag OFF keeps the paragraph fallback chunker version
+    Given an obsidian markdown document to chunk
+    And the chunker_registry_dispatch_enabled flag is OFF
+    When the document is processed by Silver
+    Then the chunks carry the silver-markdown fallback version
+
+  @flag_on
+  Scenario: flag ON dispatches to the per-type chunker
+    Given an obsidian markdown document to chunk
+    And the chunker_registry_dispatch_enabled flag is ON
+    When the document is processed by Silver
+    Then the chunks carry a per-type chunker version

--- a/tests/bdd/steps/feature_flag_chunker_registry_dispatch_enabled_steps.py
+++ b/tests/bdd/steps/feature_flag_chunker_registry_dispatch_enabled_steps.py
@@ -1,0 +1,99 @@
+"""Step definitions for feature_flag_chunker_registry_dispatch_enabled.feature (ADR-028).
+
+OFF branch: Silver is built with ``chunker_registry=None`` -> the paragraph
+fallback stamps ``silver-markdown-v1``. ON branch: Silver is built with
+``build_default_registry()`` -> obsidian markdown dispatches to the registered
+MarkdownStructuralChunker, stamping its per-type version.
+
+F1-clean: no @patch / module-attribute substitution on kairix internals.
+F2-clean: no ``KAIRIX_*`` env-var manipulation — flag state comes from
+:class:`FakeFeatureFlagResolver`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+import pytest
+from pytest_bdd import given, then, when
+
+from kairix.core.connectors.chunker_registry import MARKDOWN_MIME, build_default_registry
+from kairix.core.connectors.silver import SILVER_MARKDOWN_CHUNKER_VERSION, DefaultSilverProcessor
+from kairix.core.protocols import BronzeRef, Chunk, DocMetadata, ExtractedDocument
+from tests.fakes import FakeFeatureFlagResolver
+
+pytestmark = pytest.mark.bdd
+
+_FLAG = "chunker_registry_dispatch_enabled"
+
+
+@dataclass
+class _State:
+    read_flag: Callable[[str], bool] | None = None
+    chunks: tuple[Chunk, ...] = field(default_factory=tuple)
+
+
+@pytest.fixture
+def chunker_dispatch_state() -> _State:
+    return _State()
+
+
+def _bronze() -> BronzeRef:
+    return BronzeRef(
+        source_name="obsidian",
+        item_id="note-1",
+        raw_path=None,
+        mime=MARKDOWN_MIME,
+        fetched_at="2026-06-25T00:00:00Z",
+    )
+
+
+def _doc() -> ExtractedDocument:
+    return ExtractedDocument(
+        markdown="# Title\n\nA passthrough markdown paragraph for chunking.",
+        pages=(),
+        images=(),
+        metadata=DocMetadata(title="Title", author=None, created_date=None, language=None, page_count=None),
+        confidence=1.0,
+    )
+
+
+@given("an obsidian markdown document to chunk")
+def _given_doc(chunker_dispatch_state: _State) -> None:
+    # Constructed per-process in the @when step; nothing to stage here.
+    assert chunker_dispatch_state.chunks == ()
+
+
+@given("the chunker_registry_dispatch_enabled flag is OFF")
+def _flag_off(chunker_dispatch_state: _State) -> None:
+    chunker_dispatch_state.read_flag = FakeFeatureFlagResolver().with_flag(_FLAG, False).get
+
+
+@given("the chunker_registry_dispatch_enabled flag is ON")
+def _flag_on(chunker_dispatch_state: _State) -> None:
+    chunker_dispatch_state.read_flag = FakeFeatureFlagResolver().with_flag(_FLAG, True).get
+
+
+@when("the document is processed by Silver")
+def _process(chunker_dispatch_state: _State) -> None:
+    assert chunker_dispatch_state.read_flag is not None
+    registry = build_default_registry() if chunker_dispatch_state.read_flag(_FLAG) else None
+    silver = DefaultSilverProcessor(chunker_registry=registry)
+    out = silver.process(_bronze(), _doc(), "src://obsidian/note-1", "2026-06-25T00:00:00Z", "internal")
+    chunker_dispatch_state.chunks = out.chunks
+
+
+@then("the chunks carry the silver-markdown fallback version")
+def _then_fallback(chunker_dispatch_state: _State) -> None:
+    assert chunker_dispatch_state.chunks
+    assert all(c.chunker_version == SILVER_MARKDOWN_CHUNKER_VERSION for c in chunker_dispatch_state.chunks)
+
+
+@then("the chunks carry a per-type chunker version")
+def _then_per_type(chunker_dispatch_state: _State) -> None:
+    assert chunker_dispatch_state.chunks
+    assert all(c.chunker_version != SILVER_MARKDOWN_CHUNKER_VERSION for c in chunker_dispatch_state.chunks)
+
+
+__all__ = ["chunker_dispatch_state"]

--- a/tests/bdd/test_feature_flag_chunker_registry_dispatch_enabled.py
+++ b/tests/bdd/test_feature_flag_chunker_registry_dispatch_enabled.py
@@ -1,0 +1,25 @@
+"""pytest-bdd binding for feature_flag_chunker_registry_dispatch_enabled.feature.
+
+Pairs the OFF + ON scenarios with the step implementations in
+``tests.bdd.steps.feature_flag_chunker_registry_dispatch_enabled_steps``
+(registered in ``tests/conftest.py:pytest_plugins``).
+"""
+
+from pathlib import Path
+
+import pytest
+from pytest_bdd import scenario
+
+FEATURE = str(Path(__file__).parent / "features" / "feature_flag_chunker_registry_dispatch_enabled.feature")
+
+pytestmark = pytest.mark.bdd
+
+
+@scenario(FEATURE, "flag OFF keeps the paragraph fallback chunker version")
+def test_flag_off_fallback() -> None:
+    """Body populated by @scenario from the .feature file."""
+
+
+@scenario(FEATURE, "flag ON dispatches to the per-type chunker")
+def test_flag_on_dispatch() -> None:
+    """Body populated by @scenario from the .feature file."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -217,6 +217,7 @@ pytest_plugins = [
     "tests.bdd.steps.document_pages_writer_steps",
     # ADR-025 Phase 1 — pipeline_status_emit flag both-branch coverage.
     "tests.bdd.steps.feature_flag_pipeline_status_emit_steps",
+    "tests.bdd.steps.feature_flag_chunker_registry_dispatch_enabled_steps",
     # F64 reference test — SharePoint Graph 429 / Retry-After handling.
     "tests.bdd.steps.sharepoint_rate_limit_steps",
     # F63 reference test — maintenance scale-bound per-tick row cap.

--- a/tests/integration/test_feature_flag_chunker_registry_dispatch_enabled.py
+++ b/tests/integration/test_feature_flag_chunker_registry_dispatch_enabled.py
@@ -1,0 +1,73 @@
+"""F54 integration parity for the chunker_registry_dispatch_enabled flag (ADR-028).
+
+Pins that the flag's two branches produce observably different chunker_version
+stamps through the same call site — OFF keeps ``silver-markdown-v1``; ON
+dispatches obsidian markdown to the per-type MarkdownStructuralChunker.
+
+Flag resolution uses :class:`FakeFeatureFlagResolver` (F1-clean: no @patch /
+module-attribute substitution). ``_build_silver`` mirrors the production call
+site (``worker._silver_with_registry``): read the flag, wire the registry or None.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+
+from kairix.core.connectors.chunker_registry import MARKDOWN_MIME, build_default_registry
+from kairix.core.connectors.silver import SILVER_MARKDOWN_CHUNKER_VERSION, DefaultSilverProcessor
+from kairix.core.protocols import BronzeRef, Chunk, DocMetadata, ExtractedDocument
+from tests.fakes import FakeFeatureFlagResolver
+
+pytestmark = pytest.mark.integration
+
+_FLAG = "chunker_registry_dispatch_enabled"
+
+
+def _build_silver(read_flag: Callable[[str], bool]) -> DefaultSilverProcessor:
+    registry = build_default_registry() if read_flag(_FLAG) else None
+    return DefaultSilverProcessor(chunker_registry=registry)
+
+
+def _bronze() -> BronzeRef:
+    return BronzeRef(
+        source_name="obsidian",
+        item_id="n",
+        raw_path=None,
+        mime=MARKDOWN_MIME,
+        fetched_at="2026-06-25T00:00:00Z",
+    )
+
+
+def _doc() -> ExtractedDocument:
+    return ExtractedDocument(
+        markdown="# Heading\n\nbody paragraph one.\n\nbody paragraph two.",
+        pages=(),
+        images=(),
+        metadata=DocMetadata(title="t", author=None, created_date=None, language=None, page_count=None),
+        confidence=1.0,
+    )
+
+
+def _process(read_flag: Callable[[str], bool]) -> tuple[Chunk, ...]:
+    return _build_silver(read_flag).process(_bronze(), _doc(), "src://x", "2026-06-25T00:00:00Z", "internal").chunks
+
+
+def test_flag_off_keeps_paragraph_fallback() -> None:
+    chunks = _process(FakeFeatureFlagResolver().with_flag("chunker_registry_dispatch_enabled", False).get)
+    assert chunks
+    assert all(c.chunker_version == SILVER_MARKDOWN_CHUNKER_VERSION for c in chunks)
+
+
+def test_flag_on_dispatches_to_per_type_chunker() -> None:
+    chunks = _process(FakeFeatureFlagResolver().with_flag("chunker_registry_dispatch_enabled", True).get)
+    assert chunks
+    assert all(c.chunker_version != SILVER_MARKDOWN_CHUNKER_VERSION for c in chunks)
+
+
+def test_off_then_on_changes_chunker_version() -> None:
+    off = _process(FakeFeatureFlagResolver().with_flag("chunker_registry_dispatch_enabled", False).get)
+    on = _process(FakeFeatureFlagResolver().with_flag("chunker_registry_dispatch_enabled", True).get)
+    assert off[0].chunker_version == SILVER_MARKDOWN_CHUNKER_VERSION
+    assert on[0].chunker_version != SILVER_MARKDOWN_CHUNKER_VERSION

--- a/tests/unit/test_silver_chunker_registry_dispatch.py
+++ b/tests/unit/test_silver_chunker_registry_dispatch.py
@@ -1,0 +1,113 @@
+"""PR#6 unit: Silver routes passthrough markdown through the chunker registry.
+
+F5: exercised through the public ``DefaultSilverProcessor(chunker_registry=...)``
+surface; a fake registry/chunker is injected via the public constructor param,
+never by patching internals.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kairix.core.connectors.silver import (
+    SILVER_MARKDOWN_CHUNKER_VERSION,
+    SILVER_PAGE_CHUNKER_VERSION,
+    DefaultSilverProcessor,
+)
+from kairix.core.protocols import BronzeRef, Chunk, DocMetadata, ExtractedDocument, Page
+
+pytestmark = pytest.mark.unit
+
+_PER_TYPE_VERSION = "fake-structural@9.9.9"
+
+
+class _FakeChunker:
+    """Returns one Chunk with a distinctive version + structural metadata."""
+
+    def chunk(self, *, text: str, section_kind: str, source_uri: str) -> tuple[Chunk, ...]:
+        return (
+            Chunk(
+                text=text,
+                content_hash="deadbeef",
+                source_name="",  # minimal — Silver re-wraps with source metadata
+                source_uri=source_uri,
+                source_modified_at="",
+                source_page=None,
+                sensitivity="internal",
+                chunker_version=_PER_TYPE_VERSION,
+                author=None,
+                author_email=None,
+                tags=(),
+                metadata={"heading_path": "Root > Section", "section_kind": section_kind},
+            ),
+        )
+
+
+class _FakeRegistry:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, str]] = []
+
+    def dispatch(self, *, kind: str, mime: str, section_kind: str) -> _FakeChunker:
+        self.calls.append((kind, mime, section_kind))
+        return _FakeChunker()
+
+
+def _bronze() -> BronzeRef:
+    return BronzeRef(
+        source_name="obsidian",
+        item_id="n",
+        raw_path=None,
+        mime="text/markdown",
+        fetched_at="2026-06-25T00:00:00Z",
+    )
+
+
+def _markdown_doc() -> ExtractedDocument:
+    return ExtractedDocument(
+        markdown="# Title\n\nbody.",
+        pages=(),
+        images=(),
+        metadata=DocMetadata(title="t", author=None, created_date=None, language=None, page_count=None),
+        confidence=1.0,
+    )
+
+
+def test_registry_dispatch_stamps_per_type_version_and_keeps_silver_metadata() -> None:
+    registry = _FakeRegistry()
+    out = DefaultSilverProcessor(chunker_registry=registry).process(
+        _bronze(), _markdown_doc(), "src://obsidian/n", "2026-06-25T00:00:00Z", "internal"
+    )
+    assert registry.calls == [("obsidian", "text/markdown", "text")]  # dispatched by (kind, mime)
+    assert out.chunks
+    chunk = out.chunks[0]
+    assert chunk.chunker_version == _PER_TYPE_VERSION  # per-type version, not the silver fallback
+    assert "heading_path" in chunk.metadata  # structural metadata preserved
+    assert chunk.source_name == "obsidian"  # Silver re-wraps with source metadata
+    assert chunk.sensitivity == "internal"
+
+
+def test_no_registry_uses_paragraph_fallback() -> None:
+    out = DefaultSilverProcessor().process(
+        _bronze(), _markdown_doc(), "src://obsidian/n", "2026-06-25T00:00:00Z", "internal"
+    )
+    assert out.chunks
+    assert all(c.chunker_version == SILVER_MARKDOWN_CHUNKER_VERSION for c in out.chunks)
+
+
+def test_paged_path_unaffected_by_registry() -> None:
+    """Page-bearing extracts keep the page chunker even when a registry is wired
+    (PR#6 is markdown-first; per-page dispatch lands separately)."""
+    registry = _FakeRegistry()
+    pages = (Page(page_number=1, text="alpha page body.", has_images=False),)
+    doc = ExtractedDocument(
+        markdown="alpha page body.",
+        pages=pages,
+        images=(),
+        metadata=DocMetadata(title="t", author=None, created_date=None, language=None, page_count=1),
+        confidence=1.0,
+    )
+    out = DefaultSilverProcessor(chunker_registry=registry).process(
+        _bronze(), doc, "src://x", "2026-06-25T00:00:00Z", "internal"
+    )
+    assert registry.calls == []  # registry NOT consulted for the page path
+    assert all(c.chunker_version == SILVER_PAGE_CHUNKER_VERSION for c in out.chunks)


### PR DESCRIPTION
## Problem

The 8-chunker registry (`build_default_registry`) and the per-type chunkers (`markdown_structural`, `slide`, `docx_heading`, …) existed but were **never wired into Silver**. `process()` hardcoded the paragraph fallback, so every chunk carried `chunker_version=silver-markdown-v1` regardless of content type, the per-type chunkers were dead code (ADR-028 "remaining scope"), and oversized chunks (projects/entity-summaries up to 926K chars) silently truncated at the 8191-token embed limit.

## Change — ADR-028 markdown-first cutover, flag-gated

- **New flag** `chunker_registry_dispatch_enabled` (default **OFF**).
- The **worker reads it once at boot** (`_silver_with_registry`) and passes `build_default_registry()` or `None` into `DefaultSilverProcessor` at the 3 Silver construction sites. OFF → registry `None` → **byte-identical** to the pre-cutover fallback (zero-risk default).
- `Silver.process()`'s passthrough-markdown branch dispatches via the registry by **`(connector kind, source mime)`** when wired (`_dispatch_markdown_chunks`), stamping the **per-type `chunker_version` + structural metadata (`heading_path`)** and re-wrapping each chunk with the source/sensitivity/author metadata Silver owns. Any unregistered `(kind, mime)` falls through to the registry's **bounded paragraph fallback**, so no document is left unchunked or oversized.
- Page-bearing extracts (PDF/PPTX/XLSX) keep the page path for now — per-page dispatch (Slide/Sheet/Docx chunkers) lands separately.

## Re-chunk cost

Lazy: a doc re-chunks on its next normal sync when the flag flips → **~$0 incremental**. A one-time `embed --force` full backfill is ~$100 if ever wanted (forecast in the program notes).

## Tests

- **F54 both-branch**: BDD feature + binding + steps + integration (`FakeFeatureFlagResolver`, OFF→`silver-markdown-v1`, ON→per-type version).
- **Silver unit**: fake-registry dispatch stamps the per-type version + `heading_path`, keeps Silver metadata, dispatches by `(kind, mime)`; no-registry → fallback; **page path unaffected** by a wired registry.

**64 staged fitness gates green**; ruff clean; 36 unit/integration/BDD + Silver/worker regression tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)