### PR TITLE
feat(eval): flag embed-truncation risk in chunk-stats + per-source baseline (PR#3)

### DIFF
--- a/docs/architecture/chunking-strategy-per-source.md
+++ b/docs/architecture/chunking-strategy-per-source.md
@@ -1,0 +1,67 @@
+# Chunking strategy + per-source quality baseline (ADR-028 measurement)
+
+This is the **measurement baseline** for ADR-028's per-type chunking work: how to
+measure chunk quality per source type, the production baseline captured before the
+cutover, and the per-type targets the registry chunkers move toward.
+
+## How to measure
+
+```sh
+kairix eval chunk-stats --db-path /var/lib/kairix/index.sqlite
+```
+
+emits, per source type, the chunk-size distribution (`mean / p50 / p95 / p99`) plus
+an **embed-truncation-risk** block (`kairix/quality/eval/chunk_stats.py`). Retrieval
+quality per source type comes from the benchmark runner, which already slices NDCG
+by source type:
+
+```sh
+kairix benchmark run --suite <suite.yaml>   # summary["per_source_type"]
+```
+
+Together these answer "are this source's chunks the right size, and does retrieval
+on it hold up?" without inspecting the index by hand.
+
+## Production baseline (2026-06, Customer-Zero VM, ~2.26M chunks)
+
+| source type        | chunks  | avg chars | max chars | assessment |
+|--------------------|---------|-----------|-----------|------------|
+| sharepoint         | ~2.17M  | 832       | 1000      | well-bounded by the Silver paragraph chunker |
+| linear (projects)  | ~1.3K   | 715       | ~1000     | well-bounded |
+| **projects**       | small   | 16,899    | **926,384** | **oversized** — whole-document chunks |
+| **entity-summaries** | small | 21,737    | **926,384** | **oversized** — whole-document chunks |
+
+**Finding.** `text-embedding-3-large` truncates silently at its 8191-token limit
+(~32K chars at the production ~4 chars/token density). The `projects` and
+`entity-summaries` collections carry chunks far above that — they embed only their
+first ~32K chars and the tail never reaches retrieval. `chunker_version` is `None`
+(no per-type chunker ever stamped them), confirming they never went through a
+bounded structural chunker. `chunk-stats` now flags this directly.
+
+## Per-type targets
+
+| source type           | chunker (registry)        | target |
+|-----------------------|---------------------------|--------|
+| markdown (obsidian/notion/github) | `MarkdownStructuralChunker` | heading-aware sections, ~512 tokens, overlap within a section |
+| DOCX                  | `DocxHeadingChunker`      | heading-aware |
+| PPTX                  | `SlideChunker`            | one chunk per slide *(page-path; per-page dispatch is a later wave)* |
+| XLSX                  | `SheetRowChunker`         | one chunk per row + header *(page-path; later wave)* |
+| Slack                 | `ThreadChunker`           | ~500 tokens / thread window |
+| email                 | `EmailThreadChunker`      | per message |
+| calendar              | `CalendarEventChunker`    | one chunk per event |
+| anything unregistered | bounded paragraph fallback | ≤ ~1000 chars |
+
+Every registry chunker is **bounded**, so routing a source through the registry
+(rather than emitting a whole document as one chunk) removes the truncation cliff.
+
+## How the cutover addresses this
+
+The per-type chunker registry exists (`build_default_registry`) and is wired into
+Silver behind the `chunker_registry_dispatch_enabled` flag (default OFF — see the
+flag description for the flip caveats). When ON, passthrough markdown / DOCX
+dispatch to the registry's bounded per-type chunkers and chunks carry the per-type
+`chunker_version`, so a re-chunk sweep can find and retire the old oversized chunks.
+
+**Reproduce after a flip:** run `kairix eval chunk-stats` again — the
+embed-truncation-risk block should empty out for the cutover sources once they have
+re-chunked + re-embedded.

--- a/kairix/quality/eval/chunk_stats.py
+++ b/kairix/quality/eval/chunk_stats.py
@@ -209,6 +209,44 @@ def render_human(stats: Iterable[ChunkStats]) -> str:
     return "\n".join(lines) + "\n"
 
 
+# text-embedding-3-large truncates silently at its 8191-token limit; at the
+# production ~4 chars/token density that is ~32K chars. A chunk above this is
+# embedded only up to the limit, so its tail never reaches retrieval — a hidden
+# quality cliff for any source type with oversized chunks (e.g. whole-document
+# "chunks" that were never split). Surfacing it tells the operator which sources
+# need the per-type chunker cutover (chunker_registry_dispatch_enabled).
+_EMBED_TOKEN_LIMIT = 8191
+_EMBED_CHAR_BUDGET = _EMBED_TOKEN_LIMIT * 4
+
+
+def truncation_risk(by_type: dict[str, list[int]], char_budget: int = _EMBED_CHAR_BUDGET) -> list[tuple[str, int]]:
+    """Return ``(source_type, max_chunk_chars)`` for types whose largest chunk
+    exceeds ``char_budget`` — i.e. it silently truncates at embed time.
+
+    Sorted by max size descending so the worst offenders surface first.
+    """
+    at_risk = [(stype, max(sizes)) for stype, sizes in by_type.items() if sizes and max(sizes) > char_budget]
+    return sorted(at_risk, key=lambda pair: pair[1], reverse=True)
+
+
+def render_truncation_warning(by_type: dict[str, list[int]], char_budget: int = _EMBED_CHAR_BUDGET) -> str:
+    """Render the embed-truncation warning block, or ``""`` when nothing is at risk."""
+    at_risk = truncation_risk(by_type, char_budget)
+    if not at_risk:
+        return ""
+    lines = [
+        "",
+        f"embed-truncation risk: source types with chunks over the {char_budget}-char "
+        f"(~{_EMBED_TOKEN_LIMIT}-token) embedding budget truncate silently at embed time:",
+    ]
+    for stype, max_chars in at_risk:
+        lines.append(f"    {stype:14} max={max_chars} chars")
+    lines.append(
+        "  fix: enable chunker_registry_dispatch_enabled (per-type bounded chunkers) and re-embed the affected sources."
+    )
+    return "\n".join(lines) + "\n"
+
+
 def emit_chunk_stats(db_path: Path, out_sink: TextIO) -> int:
     """Compute + emit per-source-type chunk-size stats. Returns exit code."""
     if not db_path.exists():
@@ -227,6 +265,7 @@ def emit_chunk_stats(db_path: Path, out_sink: TextIO) -> int:
         db.close()
     stats = compute_stats(by_type)
     out_sink.write(render_human(stats))
+    out_sink.write(render_truncation_warning(by_type))
     return 0
 
 
@@ -236,4 +275,6 @@ __all__ = [
     "compute_stats",
     "emit_chunk_stats",
     "render_human",
+    "render_truncation_warning",
+    "truncation_risk",
 ]

--- a/tests/unit/test_chunk_stats_truncation.py
+++ b/tests/unit/test_chunk_stats_truncation.py
@@ -1,0 +1,48 @@
+"""PR#3: embed-truncation-risk flagging in chunk-stats (ADR-028 measurement baseline).
+
+The chunk-size distribution already surfaces mean/p50/p95/p99, but oversized
+chunks live in the tail (a whole-document "chunk" that was never split). These
+silently truncate at the text-embedding-3-large 8191-token limit, so their tail
+never reaches retrieval. ``truncation_risk`` / ``render_truncation_warning``
+surface which source types are affected and point at the per-type chunker
+cutover that bounds them.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kairix.quality.eval.chunk_stats import render_truncation_warning, truncation_risk
+
+pytestmark = pytest.mark.unit
+
+
+def test_truncation_risk_flags_only_oversized_types_worst_first() -> None:
+    by_type = {
+        "projects": [800, 900_000],  # one whole-doc chunk far over budget
+        "entity-summaries": [400_000],
+        "sharepoint": [800, 1000],  # bounded — excluded
+    }
+    assert truncation_risk(by_type) == [("projects", 900_000), ("entity-summaries", 400_000)]
+
+
+def test_truncation_risk_empty_when_all_bounded() -> None:
+    assert truncation_risk({"sharepoint": [800, 1000], "linear": [700, 715]}) == []
+
+
+def test_render_warning_empty_when_bounded() -> None:
+    assert render_truncation_warning({"sharepoint": [800, 1000]}) == ""
+
+
+def test_render_warning_lists_offenders_and_recommends_flag() -> None:
+    out = render_truncation_warning({"projects": [900_000], "entity-summaries": [400_000]})
+    assert "projects" in out
+    assert "entity-summaries" in out
+    assert "embed-truncation risk" in out
+    assert "chunker_registry_dispatch_enabled" in out  # points at the PR#6 cutover
+
+
+def test_custom_budget_respected() -> None:
+    by_type = {"foo": [5000]}
+    assert truncation_risk(by_type, char_budget=10_000) == []  # under custom budget
+    assert truncation_risk(by_type, char_budget=4000) == [("foo", 5000)]  # over custom budget


### PR DESCRIPTION
## Why

`kairix eval chunk-stats` reported `mean/p50/p95/p99` per source type — but the chunks that hurt retrieval live in the **tail**: a whole-document "chunk" that was never split. `text-embedding-3-large` truncates silently at its 8191-token limit (~32K chars), so those chunks embed only their first ~32K chars and the tail never reaches retrieval. The production baseline shows `projects` + `entity-summaries` with **max chunk 926K chars** (vs sharepoint/linear well-bounded at ≤1000), all with `chunker_version=None` — they never went through a bounded chunker.

## Change

- **`chunk_stats.truncation_risk` / `render_truncation_warning`** — flag source types whose largest chunk exceeds the embed char budget, worst-first, with a fix pointer to the `chunker_registry_dispatch_enabled` cutover (PR#6). Wired into the existing `kairix eval chunk-stats` output (empty when nothing is at risk).
- **`docs/architecture/chunking-strategy-per-source.md`** — the measurement baseline: how to measure (chunk-stats size dist + the benchmark runner's per-source-type NDCG slice, **both already shipped**), the captured production baseline, the per-type chunker targets, and how the cutover removes the truncation cliff.

This re-scopes PR#3 to what the verified design showed was actually missing (the tooling already existed; this adds the **truncation-risk surfacing** + the baseline doc). No new CLI subcommand (extends the existing command) and no `ChunkStats` shape change (computed from the raw size lists).

## Tests

Truncation-flag unit tests (worst-first ordering, empty-when-bounded, custom budget, recommends-the-flag); **32 existing chunk-stats / eval-CLI tests unchanged**; **49 staged fitness gates green**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)