### PR TITLE
perf(worker): batch entity-signal staging inserts (PR#5, re-scoped)

### DIFF
--- a/kairix/worker.py
+++ b/kairix/worker.py
@@ -440,17 +440,27 @@ class _SqliteEntityGraphSink:
         self._db = db
 
     def buffer(self, signals: Sequence[EntitySignal]) -> int:
-        """Write entity signals to the ``entity_signals`` staging table."""
-        staged = 0
-        for sig in signals:
-            self._db.execute(
-                "INSERT INTO entity_signals "
-                "(kind, value, source_uri, modified_at, confidence, sensitivity, pushed_to_neo4j) "
-                "VALUES (?, ?, ?, ?, ?, ?, 0)",
-                (sig.kind, sig.value, sig.source_uri, sig.modified_at, sig.confidence, sig.sensitivity),
-            )
-            staged += 1
-        return staged
+        """Write entity signals to the ``entity_signals`` staging table.
+
+        Batches every signal into a single ``executemany`` rather than N
+        single-row ``execute`` calls — one prepared statement, one C-level
+        bind loop — so a fast connector emitting thousands of signals per
+        batch doesn't pay per-row Python/SQLite dispatch overhead. Behaviour
+        is identical (same rows, same order). Does NOT commit — the caller's
+        per-batch transaction owns the commit.
+        """
+        rows = [
+            (sig.kind, sig.value, sig.source_uri, sig.modified_at, sig.confidence, sig.sensitivity) for sig in signals
+        ]
+        if not rows:
+            return 0
+        self._db.executemany(
+            "INSERT INTO entity_signals "
+            "(kind, value, source_uri, modified_at, confidence, sensitivity, pushed_to_neo4j) "
+            "VALUES (?, ?, ?, ?, ?, ?, 0)",
+            rows,
+        )
+        return len(rows)
 
 
 def _topology_entry_for_cc_pair(connector: Any, cc_pair: Any) -> dict[str, Any]:


### PR DESCRIPTION
## Re-scope note

PR#5 as originally framed (per-item error absorption + compat guard + sink backpressure) was found **largely redundant or infeasible** under the design review:
- poison-skip already happens before fetch (cursor advances) and the compat skip-gate already records `skipped_unsupported` without dead-lettering;
- the proposed pre-fetch compat *peek* can't run — `classify_compat` needs the full bytes for ZIP central-directory (OOXML) detection, so an 8KB peek would break the octet-stream rescue path;
- the proposed embed-queue backpressure can **livelock** the worker (every tick skips all connectors if embed falls behind, cursor never advances).

So this PR lands the **one safe, verified win** the review identified.

## Change

`_SqliteEntityGraphSink.buffer` staged entity signals with **N single-row `INSERT`s** in a Python loop. Replace with a single **`executemany`** — one prepared statement, one C-level bind loop — so a fast connector emitting thousands of signals per batch doesn't pay per-row Python/SQLite dispatch overhead.

Behaviour is identical (same rows, same order, `if not rows: return 0`, and still **no commit** — the caller's per-batch transaction owns it).

## Tests

Behaviour-preserving — covered by the existing `entity_signals`-asserting pipeline + neo4j-drain tests (**31 pass**). 41 staged fitness gates green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)