### PR TITLE
test(guardrails): F96 config round-trip + F99 chunker token budget (+ fix unbounded fallback chunker)

### DIFF
--- a/kairix/core/connectors/chunker_registry.py
+++ b/kairix/core/connectors/chunker_registry.py
@@ -51,6 +51,42 @@ MARKDOWN_MIME = "text/markdown"
 _TARGET_CHUNK_CHARS = 1000
 
 
+def _glue(items: list[str], target: int, sep: str) -> list[str]:
+    """Greedy-glue already-bounded items into chunks up to ``target`` chars (joined by ``sep``)."""
+    chunks: list[str] = []
+    current = ""
+    for item in items:
+        if not current:
+            current = item
+        elif len(current) + len(sep) + len(item) <= target:
+            current = current + sep + item
+        else:
+            chunks.append(current)
+            current = item
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def _atomize(word: str, target: int) -> list[str]:
+    """A word, or hard char-cut pieces when it is itself longer than ``target``."""
+    if len(word) <= target:
+        return [word]
+    return [word[i : i + target] for i in range(0, len(word), target)]
+
+
+def _split_oversized(paragraph: str, target: int) -> list[str]:
+    """Split a paragraph longer than ``target`` into pieces each <= ``target``.
+
+    Word boundaries first, then a hard char-cut for a single token longer than
+    ``target`` (a base64 blob, a minified line, an unbroken run). Mirrors the
+    bounding in ``silver._chunk_markdown`` so the fallback never emits a chunk
+    over the embed token budget regardless of input shape (F99).
+    """
+    atoms = [atom for word in paragraph.split() for atom in _atomize(word, target)]
+    return _glue(atoms, target, " ") or [paragraph[:target]]
+
+
 def _split_paragraphs(text: str) -> tuple[str, ...]:
     """Split ``text`` on blank-line boundaries, glue paragraphs up to budget.
 
@@ -61,23 +97,17 @@ def _split_paragraphs(text: str) -> tuple[str, ...]:
     stripped = text.strip()
     if not stripped:
         return ()
-    paragraphs = [p.strip() for p in re.split(r"\n\s*\n", stripped) if p.strip()]
-    if not paragraphs:
+    raw_paragraphs = [p.strip() for p in re.split(r"\n\s*\n", stripped) if p.strip()]
+    if not raw_paragraphs:
         return ()
-    chunks: list[str] = []
-    current = ""
-    for para in paragraphs:
-        if not current:
-            current = para
-            continue
-        if len(current) + len(para) + 2 <= _TARGET_CHUNK_CHARS:
-            current = current + "\n\n" + para
-        else:
-            chunks.append(current)
-            current = para
-    if current:
-        chunks.append(current)
-    return tuple(chunks)
+    # Expand any paragraph larger than the target into bounded pieces BEFORE the
+    # greedy-glue — otherwise a single oversized paragraph lands as one oversized
+    # chunk that truncates silently at the 8191-token embed limit. Mirrors
+    # silver._chunk_markdown (the docstring's "behaviour-identical" claim).
+    paragraphs: list[str] = []
+    for para in raw_paragraphs:
+        paragraphs.extend([para] if len(para) <= _TARGET_CHUNK_CHARS else _split_oversized(para, _TARGET_CHUNK_CHARS))
+    return tuple(_glue(paragraphs, _TARGET_CHUNK_CHARS, "\n\n"))
 
 
 class ParagraphFallbackChunker:

--- a/tests/contracts/test_chunker_token_budget.py
+++ b/tests/contracts/test_chunker_token_budget.py
@@ -1,0 +1,57 @@
+"""F99 contract: text chunkers never emit a chunk over the embedding budget.
+
+Guards the oversized-chunk bug class (kairix#624): a chunk over the
+text-embedding-3-large 8191-token limit silently truncates at embed time, so its
+tail never reaches retrieval. The chunkers that take arbitrary free text
+(MarkdownStructuralChunker on the cutover path + the ParagraphFallbackChunker the
+registry returns for any unregistered type) MUST bound their output regardless of
+input size.
+
+tiktoken is not a kairix dependency, so this uses the same char proxy as
+``chunk_stats`` (8191 tokens x ~4 chars = 32764 chars) — a conservative ceiling.
+
+Scope: free-text chunkers only. The page/unit chunkers (slide/sheet/docx/
+calendar/email/thread) chunk by inherent structural units and need format-specific
+oversized fixtures to exercise — covered separately (see Linear PLA-229).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kairix.core.connectors.chunker_registry import MARKDOWN_MIME, build_default_registry
+
+pytestmark = pytest.mark.contract
+
+# 8191-token embed limit at the production ~4 chars/token density.
+_EMBED_CHAR_BUDGET = 8191 * 4
+
+# Pathological input: a structured doc whose body is a single unsplittable
+# 400K-char run (no paragraph/sentence/word boundaries) PLUS a huge glued
+# paragraph — forces every chunker's hard-cut fallback to fire.
+_OVERSIZED_TEXT = "# Title\n\n" + ("lorem ipsum dolor sit amet consectetur " * 12000) + "\n\n" + ("x" * 400000)
+
+
+def _text_chunkers() -> dict[str, object]:
+    registry = build_default_registry()
+    markdown = registry.dispatch(kind="obsidian", mime=MARKDOWN_MIME, section_kind="text")
+    fallback = registry.dispatch(kind="__unregistered__", mime="__none__", section_kind="text")
+    return {
+        f"markdown_structural@{getattr(markdown, 'version', '?')}": markdown,
+        f"paragraph_fallback@{getattr(fallback, 'version', '?')}": fallback,
+    }
+
+
+_CHUNKERS = _text_chunkers()
+
+
+@pytest.mark.parametrize("chunker", list(_CHUNKERS.values()), ids=list(_CHUNKERS.keys()))
+def test_text_chunker_bounds_chunk_size(chunker: object) -> None:
+    chunks = chunker.chunk(text=_OVERSIZED_TEXT, section_kind="text", source_uri="src://oversized")  # type: ignore[attr-defined]  # chunk() is a Chunker-protocol method present on every registry chunker at runtime
+    assert chunks, "chunker produced no chunks for a large input"
+    oversized = [len(c.text) for c in chunks if len(c.text) > _EMBED_CHAR_BUDGET]
+    assert not oversized, (
+        f"{type(chunker).__name__} emitted {len(oversized)} chunk(s) over the "
+        f"{_EMBED_CHAR_BUDGET}-char embed budget (largest {max(oversized) if oversized else 0} chars); "
+        "chunks over the 8191-token limit truncate silently at embed time."
+    )

--- a/tests/contracts/test_topology_v2_config_round_trip.py
+++ b/tests/contracts/test_topology_v2_config_round_trip.py
@@ -1,0 +1,52 @@
+"""F96 contract: nested connector config round-trips losslessly (parse -> materialize).
+
+Guards the topology_v2 ``str()``-coercion bug class (kairix#621): any value in
+``connector_specific_config`` / ``extractor_config`` — including deeply nested
+lists/dicts, mixed scalars, unicode, None, large ints — must survive
+``parse_topology_v2`` -> ``config_pairs_to_mapping`` unchanged. A regression here
+silently strands any connector with nested config (SharePoint's ``drives:`` list
+was the production instance: it became a Python repr-string the connector
+rejected every sync tick).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from kairix.config import config_pairs_to_mapping, parse_topology_v2
+
+pytestmark = pytest.mark.contract
+
+_ADVERSARIAL_CONFIGS: list[dict[str, Any]] = [
+    # SharePoint-shape: a list of dicts (the exact production bug).
+    {"drives": [{"site_id": "tc.sharepoint.com,a,b", "exclude_paths": ["/Archive", "/Personal"]}]},
+    # Deeply nested: dict -> list -> dict -> list.
+    {"filters": {"include": [{"path": "/a", "tags": ["x", "y"]}], "exclude": [{"path": "/b", "tags": []}]}},
+    # Mixed scalar types (the str()-coercion silently flattens these).
+    {"max_items": 50, "recursive": True, "ratio": 1.5, "name": "x", "nothing": None},
+    # Unicode + symbols.
+    {"label": "café — déjà vu — 日本語", "marker": "checkmark-and-warn"},
+    # Empty nested containers.
+    {"drives": [], "settings": {}},
+    # Large int beyond 2^53 (JSON-float precision edge; preserved as a Python int).
+    {"big": 9007199254740993},
+]
+
+
+def _materialise(field: str, value: dict[str, Any]) -> dict[str, Any]:
+    parsed = parse_topology_v2(
+        {"topology_v2": {"connectors": [{"id": "c", "kind": "obsidian", "name": "c", field: value}]}}
+    )
+    return config_pairs_to_mapping(getattr(parsed.connectors[0], field))
+
+
+@pytest.mark.parametrize("value", _ADVERSARIAL_CONFIGS)
+def test_connector_specific_config_round_trips(value: dict[str, Any]) -> None:
+    assert _materialise("connector_specific_config", value) == value
+
+
+@pytest.mark.parametrize("value", _ADVERSARIAL_CONFIGS)
+def test_extractor_config_round_trips(value: dict[str, Any]) -> None:
+    assert _materialise("extractor_config", value) == value


### PR DESCRIPTION
Implements the regression guardrails for two bug classes the 2026-06 SharePoint/chunking engagement fixed (Linear **PLA-229**). The verify pass chose **contract tests** over static lints (lints are false-positive-prone for these), and the F99 test **found a real bug on day one**.

## F96 — nested config round-trips losslessly *(guards the #621 class)*
`tests/contracts/test_topology_v2_config_round_trip.py` — adversarially-nested `connector_specific_config`/`extractor_config` values (lists of dicts of lists, mixed scalars, unicode, None, 2^53+1 ints) survive `parse_topology_v2 → config_pairs_to_mapping` unchanged. This is the class the `topology_v2` `str()`-coercion bug belonged to (it stranded SharePoint for 3 weeks).

## F99 — no free-text chunker exceeds the embed budget *(guards the #624 class)*
`tests/contracts/test_chunker_token_budget.py` — `markdown_structural` + the paragraph fallback, fed a 400K-char pathological input, must emit chunks ≤ the budget (8191-token **char proxy**, since tiktoken isn't a kairix dep).

### …which caught a real bug
`ParagraphFallbackChunker._split_paragraphs` greedy-glued paragraphs but **never hard-cut a single oversized paragraph** (a base64 blob / minified line / unbroken run), despite its docstring claiming parity with `silver._chunk_markdown`. After the chunker-registry flip, an unregistered `(kind, mime)` hitting the fallback could emit a 400K-char chunk that truncates silently at embed. **Fixed:** `_split_oversized` now word-/char-bounds any paragraph (extracted a generic `_glue` + `_atomize`, keeping every function under the F16 ceiling).

## Not included (per the verified design)
- **F98** — redundant; `F55` part 2 already AST-checks `Chunk()` writes for `chunker_version=`.
- **F97** (per-source fault isolation) — deferred; a naive static check false-positives because `SourceConnector.list_changes` is a flat stream, not a per-source loop. Needs `HierarchyConnector` scoping (tracked in PLA-229 + PLA-230).

**54 staged fitness gates green; 32 contract + chunker/silver regression tests pass; ruff clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)