### PR TITLE
fix(neo4j): derive cypher session access mode from the query (DRY)

### DIFF
--- a/kairix/knowledge/entities/enrich.py
+++ b/kairix/knowledge/entities/enrich.py
@@ -183,15 +183,13 @@ def enrich_entity(
         )
 
     try:
-        # #416 — must pass write=True; default cypher() session is READ-only
-        # and Neo4j rejects SET on a READ session with AccessMode error.
-        # Also verify the write actually landed via a RETURN clause; without
-        # this check, a no-op MATCH (entity not found) would silently report
-        # updated=True.
+        # The SET routes to a WRITE session automatically (cypher() derives the
+        # access mode from the query — #416). The RETURN clause also verifies the
+        # write landed; without it a no-op MATCH (entity not found) would silently
+        # report updated=True.
         rows = neo4j_client.cypher(
             "MATCH (n {name: $name}) SET n.summary = $summary, n.summary_source = $source RETURN n.name AS name",
             {"name": name, "summary": summary.description, "source": summary.source},
-            write=True,
         )
     except Exception as exc:
         logger.warning("enrich_entity(%r): Neo4j write failed: %s", name, exc)

--- a/kairix/knowledge/graph/client.py
+++ b/kairix/knowledge/graph/client.py
@@ -17,6 +17,7 @@ are logged as warnings and are expected to be retried on the next crawl.
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 from kairix.knowledge.graph.models import (
@@ -40,6 +41,19 @@ _load_secrets()
 logging.getLogger("neo4j").setLevel(logging.ERROR)
 
 logger = logging.getLogger(__name__)
+
+# A Cypher write clause anywhere in the query routes it to a WRITE session.
+# Read-only queries (MATCH/RETURN/etc.) stay on READ and route to replicas.
+# Bias is intentionally toward WRITE: a false positive (e.g. the keyword inside
+# a string literal) just lands on the leader (harmless for reads), whereas a
+# missed write would be rejected on a READ session + swallowed = silent no-op.
+_WRITE_CLAUSE_RE = re.compile(r"\b(?:CREATE|MERGE|SET|DELETE|REMOVE|FOREACH)\b", re.IGNORECASE)
+
+
+def _is_write_query(query: str) -> bool:
+    """True when ``query`` contains a Cypher write clause (the single source of
+    truth for read/write session routing — see :meth:`Neo4jClient.cypher`)."""
+    return bool(_WRITE_CLAUSE_RE.search(query))
 
 
 def _get_neo4j_defaults() -> tuple[str, str, str]:
@@ -351,28 +365,22 @@ class Neo4jClient:
             logger.warning("find_by_name(%s): %s", name, e)
             return []
 
-    def cypher(
-        self,
-        query: str,
-        params: dict[str, Any] | None = None,
-        *,
-        write: bool = False,
-    ) -> list[dict[str, Any]]:
+    def cypher(self, query: str, params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
         """
-        Execute an arbitrary Cypher query.
+        Execute an arbitrary Cypher query. Returns [] on any error.
 
-        Intended for MCP kairix.graph_query tool (default: scoped reads).
-        Set ``write=True`` for callers that need to MERGE/SET/CREATE/DELETE —
-        without this kwarg the session opens with ``default_access_mode="READ"``
-        which Neo4j rejects with ``Neo.ClientError.Statement.AccessMode`` on
-        any write. Returns [] on any error.
-
-        Closes #416 — the enricher's ``SET n.summary = ...`` silently
-        failed because every cypher() call landed on a READ session.
+        The session access mode is derived from the QUERY (:func:`_is_write_query`),
+        not from the call site: a query containing a write clause
+        (MERGE/CREATE/SET/DELETE/REMOVE/FOREACH) opens a WRITE session; everything
+        else opens a READ session (which routes to read replicas). Deriving it here
+        is the single source of truth, so a write can never be silently routed to a
+        READ session — which Neo4j rejects with ``Neo.ClientError.Statement.AccessMode``
+        and ``cypher()`` then swallows, making the write a silent no-op (#416, and
+        the drain / summary-projector / entity-purge regressions this replaces).
         """
         if not self._driver:
             return []
-        access_mode = "WRITE" if write else "READ"
+        access_mode = "WRITE" if _is_write_query(query) else "READ"
         try:
             with self._driver.session(default_access_mode=access_mode) as session:
                 result = session.run(query, **(params or {}))

--- a/tests/contracts/test_entity_enrich.py
+++ b/tests/contracts/test_entity_enrich.py
@@ -369,17 +369,20 @@ def test_enrich_all_missing_rejects_zero_limit() -> None:
     assert batch.requested == 0
 
 
-def test_enrich_entity_set_cypher_uses_write_session() -> None:
-    """#416 — the SET cypher must be invoked with ``write=True`` so the
-    Neo4j driver opens a WRITE-mode session. Without this, every SET on a
-    READ session silently fails with ``Neo.ClientError.Statement.AccessMode``,
-    the enricher's ``cypher()`` call swallows the exception and returns [],
-    and the wrapper falsely reports ``updated=True`` because it didn't
-    check the return value.
+def test_enrich_entity_set_cypher_verifies_the_write_landed() -> None:
+    """#416 — the enricher's SET must reach Neo4j on a WRITE session and the
+    wrapper must confirm the write actually landed.
 
-    Sabotage-proof: remove the ``write=True`` kwarg in
-    ``enrich_entity`` → this test fails because the recorded ``write``
-    flag is False on the SET call. (Verified locally before commit.)
+    Write/read session routing is now derived from the query itself
+    (``Neo4jClient.cypher`` -> ``_is_write_query``; the session-mode wiring is
+    locked in ``tests/.../test_neo4j_client_access_mode.py``), so the enricher
+    no longer passes a call-site ``write=`` kwarg. What this test locks at the
+    enrich layer: exactly one ``SET n.summary`` cypher fires AND it carries a
+    ``RETURN`` clause so a no-op MATCH (entity not found) can't falsely report
+    ``updated=True``.
+
+    Sabotage-proof: drop the ``RETURN n.name`` clause and the wrapper would
+    report ``updated=True`` on an empty result.
     """
 
     def fake_get(url: str, **kwargs: Any) -> _FakeResponse:
@@ -389,13 +392,9 @@ def test_enrich_entity_set_cypher_uses_write_session() -> None:
     result = enrich_entity("Acme Corp", neo4j, http_get=fake_get)
 
     assert result.updated is True
-    set_calls = [(q, p, w) for q, p, w in neo4j.cypher_calls if "SET n.summary" in q]
+    set_calls = [q for q, _p, _w in neo4j.cypher_calls if "SET n.summary" in q]
     assert len(set_calls) == 1
-    _q, _p, write_flag = set_calls[0]
-    assert write_flag is True, (
-        "SET n.summary cypher must be invoked with write=True (#416); "
-        "READ-mode session rejects writes with AccessMode error."
-    )
+    assert "RETURN n.name AS name" in set_calls[0], "the SET cypher must RETURN so the enricher verifies the write"
 
 
 def test_enrich_entity_returns_error_when_set_match_returns_zero_rows() -> None:

--- a/tests/contracts/test_neo4j_client_access_mode.py
+++ b/tests/contracts/test_neo4j_client_access_mode.py
@@ -1,0 +1,70 @@
+"""Contract: ``Neo4jClient.cypher`` derives the session access mode from the
+QUERY, not from the call site.
+
+A query containing a Cypher write clause (MERGE/CREATE/SET/DELETE/REMOVE/FOREACH)
+opens a WRITE session; everything else opens a READ session (which routes to read
+replicas). This is the single source of truth for read/write routing — callers
+never pass a ``write=`` flag, so a write can never be silently routed to a READ
+session (which Neo4j rejects with ``Neo.ClientError.Statement.AccessMode`` and
+``cypher()`` then swallows = a silent no-op: the drain / summary-projector /
+entity-purge regression this design replaces).
+
+F1-clean: the driver is injected through the public ``driver_cls=`` constructor
+seam (no @patch / private-attr access on kairix internals).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from kairix.knowledge.graph.client import Neo4jClient
+
+pytestmark = pytest.mark.contract
+
+
+def _access_mode_for(query: str) -> str | None:
+    """Run ``cypher(query)`` against a mock driver; return the
+    ``default_access_mode`` the client opened the session with."""
+    driver = MagicMock()
+    driver.verify_connectivity.return_value = None
+    driver_cls = MagicMock()
+    driver_cls.driver.return_value = driver
+    client = Neo4jClient(
+        uri="bolt://test:7687",
+        user="test",
+        password="test",  # pragma: allowlist secret
+        driver_cls=driver_cls,
+    )
+    assert client.available
+    # _init_constraints() opened a session at connect time — ignore it.
+    driver.session.reset_mock()
+    client.cypher(query)
+    return driver.session.call_args.kwargs.get("default_access_mode")
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "MERGE (p:Person {name: $name}) SET p.x = 1 RETURN p.name",
+        "CREATE (n:Document {id: $id})",
+        "MATCH (n {name: $name}) SET n.summary = $summary RETURN n.name AS name",
+        "MATCH (n {id: $id}) DETACH DELETE n",
+        "MATCH (n) REMOVE n.stale_flag",
+    ],
+)
+def test_write_queries_open_a_write_session(query: str) -> None:
+    assert _access_mode_for(query) == "WRITE", f"write query must open a WRITE session: {query!r}"
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "MATCH (n {name: $name}) RETURN n.name AS name",
+        "MATCH (n) WHERE n.vault_path IS NOT NULL RETURN n.name",
+        "MATCH (n) RETURN labels(n) AS labels, count(n) AS count",
+    ],
+)
+def test_read_queries_open_a_read_session(query: str) -> None:
+    assert _access_mode_for(query) == "READ", f"read query must open a READ session: {query!r}"


### PR DESCRIPTION
## Summary

While monitoring the v2026.6.25a1 deploy I found the worker logging ~15k `Writing in read access mode not allowed` (`Neo.ClientError.Statement.AccessMode`) warnings/6h. Root cause is a **silent entity-graph write failure**: `Neo4jClient.cypher()` opened a READ session unless the caller passed `write=True`, and **swallows errors** (returns `[]`). So writes were rejected, hidden, and reported as success — `pushed=500 failed=0` while nothing landed:

- **drain** (`MERGE Person/Organisation`) — the 15k-warning source; entity nodes never persisted
- **summary projector** (`SET …summary_indexed_at`) — re-projected every tick forever
- **entity purge** (`DETACH DELETE`) — silently no-op'd

## Design

A first pass threaded `write=True` through every call site, the repository/client protocols, and ~20 test fakes. That's a **DRY violation** — the write-ness of a query is a property of the **query**, not the caller, and a flag you must remember is a flag you can forget (exactly how this bug happened).

Instead, decide it **once**: `cypher()` derives the session access mode from the query via `_is_write_query()` — a query containing a write clause (`CREATE/MERGE/SET/DELETE/REMOVE/FOREACH`) opens a WRITE session, everything else READ. **No caller passes `write=`** (the enricher's `write=True` from #416 is removed). A write can no longer be silently routed to a READ session. Bias is toward WRITE (a false positive just lands on the leader; a missed write would silently no-op).

## Test surface (simplified + extended)

The per-call-site write-flag assertions are replaced by **one parametrized public-surface contract test** (`tests/contracts/test_neo4j_client_access_mode.py`) that locks routing at the single decision point — write clauses → WRITE session, reads → READ — injecting the driver via the public `driver_cls=` seam (F1-clean).

## Verification
Net diff is 4 files. mypy (495) + ruff + arch-fitness clean; the changed suites (drain/projector/purge/enrich/protocols) + 5673 across the tree pass. The 2 pre-existing flaky `test_boosts_integration` failures reproduce identically on `main` (unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)