### PR TITLE
fix(deploy): group /run/secrets to the container's group (kairix), not openclaw

### DIFF
--- a/docs/operations/secrets-configuration.md
+++ b/docs/operations/secrets-configuration.md
@@ -134,7 +134,7 @@ sudo chmod +x /etc/kairix/bin/fetch-secrets.sh
 sudo systemctl enable --now kairix-fetch-secrets.service
 
 # 3. Verify
-ls -la /run/secrets/kairix.env   # should be 0640, root:openclaw
+ls -la /run/secrets/kairix.env   # should be 0640, root:kairix
 sudo systemctl status kairix-fetch-secrets.service
 
 # 4. Start kairix — docker-compose mounts /run/secrets into the containers
@@ -148,6 +148,8 @@ after a reboot because the vault name was only exported in the operator's
 `.bashrc` — the etc-default file removes that footgun.
 
 The fetch-secrets script reads `az keyvault secret list --query "[?starts_with(name,'kairix-')]"` and writes each one to both `/run/secrets/<name>` (per-file) and `/run/secrets/kairix.env` (bundle). No per-secret list to maintain — adding `kairix-connector-newthing-api-key` to your KV makes it available on the next service restart, with no code change.
+
+> **Group/gid contract (load-bearing).** The secrets files are mode `0640` — group-readable only — and are group-owned by the **container's runtime group**, `kairix` (gid **985** in the published image). The kairix container runs as `uid 995 / gid 985` and reads the bundle via group-read, so the host's `kairix` group **must** be gid 985 to match the image. Grouping the files to a *different* group (e.g. the operator's `openclaw` group) means the container cannot read its own secrets and crash-loops on the next recreate — this caused the 2026-06-28 outage, where `openclaw` had drifted to gid 1001 while the container stayed gid 985. Override the group with `KAIRIX_SECRETS_GROUP` (default `kairix`) only if you point it at another group the container is in. The `openclaw` operator user is a member of the `kairix` group, so it retains read access for debugging. `fetch-secrets.sh` warns in its output if the chosen group's gid doesn't match `KAIRIX_CONTAINER_GID` (default 985).
 
 To rotate a secret: run `az keyvault secret set` with `--vault-name "$KAIRIX_KV_NAME"`, `--name "<canonical-name>"`, and the new value, then `sudo systemctl restart kairix-fetch-secrets && docker compose restart kairix`.
 

--- a/scripts/deploy/fetch-secrets.sh
+++ b/scripts/deploy/fetch-secrets.sh
@@ -36,6 +36,15 @@
 # Operator overrides:
 #   - $KAIRIX_KV_NAME  — the Key Vault to read from (required)
 #   - $KAIRIX_SECRETS_DIR  — where to write (default /run/secrets)
+#   - $KAIRIX_SECRETS_GROUP — group that owns the secrets files (default
+#                             `kairix`, the container's runtime group). MUST be
+#                             a group the kairix container is in (gid 985 in the
+#                             published image) or the container cannot read its
+#                             own /run/secrets/kairix.env. See the gid guard
+#                             below.
+#   - $KAIRIX_CONTAINER_GID — the gid the kairix container reads as (default
+#                             985, the published image's `kairix` group); used
+#                             only by the mismatch guard.
 #   - $KAIRIX_LEGACY_EXPORT=0  — skip the legacy env-var aliases
 #                                (turn on once Wave-2 lands)
 
@@ -45,12 +54,32 @@ VAULT_NAME="${KAIRIX_KV_NAME:-}"
 OUT_DIR="${KAIRIX_SECRETS_DIR:-/run/secrets}"
 OUT_FILE="${OUT_DIR}/kairix.env"
 LEGACY_EXPORT="${KAIRIX_LEGACY_EXPORT:-1}"
-SECRETS_GROUP="${KAIRIX_SECRETS_GROUP:-openclaw}"
+# The secrets files are group-readable (mode 0640). Group them to the
+# CONTAINER's runtime group — `kairix` (gid 985 in the published image) — NOT
+# the operator's `openclaw` group. The kairix container runs as uid 995 / gid
+# 985 and reads the bundle via group-read; grouping the files to a group the
+# container is not in makes it unable to read its own secrets and crash-loop on
+# the next recreate (the 2026-06-28 incident: `openclaw` had drifted to gid
+# 1001 while the container stayed gid 985, so a fetch-secrets re-run produced
+# files the container could no longer read). The `openclaw` operator user is a
+# member of the `kairix` group, so it keeps read access for debugging.
+SECRETS_GROUP="${KAIRIX_SECRETS_GROUP:-kairix}"
 
 if [[ -z "$VAULT_NAME" ]]; then
     echo "fetch-secrets: ERROR — KAIRIX_KV_NAME is not set" >&2
     echo "fix: set KAIRIX_KV_NAME=<your-vault-name> in /etc/default/kairix-fetch-secrets" >&2
     exit 1
+fi
+
+# Guard: the kairix container reads these files as gid $CONTAINER_GID (985 in
+# the published image). If the chosen secrets group resolves to a different
+# gid, the container will NOT be able to read /run/secrets/kairix.env and will
+# crash-loop on the next recreate. Warn loudly so a host group/gid mismatch
+# surfaces in the journal (and the deploy log) instead of as a silent outage.
+CONTAINER_GID="${KAIRIX_CONTAINER_GID:-985}"
+secrets_group_gid="$(getent group "$SECRETS_GROUP" | cut -d: -f3 || true)"
+if [[ -n "$secrets_group_gid" && "$secrets_group_gid" != "$CONTAINER_GID" ]]; then
+    echo "fetch-secrets: WARN — secrets group '${SECRETS_GROUP}' is gid ${secrets_group_gid} but the kairix container reads as gid ${CONTAINER_GID}; the container may be unable to read ${OUT_FILE}. Align the host '${SECRETS_GROUP}' group to gid ${CONTAINER_GID}, or set KAIRIX_SECRETS_GROUP to a group the container is in." >&2
 fi
 
 mkdir -p "$OUT_DIR"
@@ -214,4 +243,4 @@ for secret_name in "${WEBHOOK_SECRETS[@]}"; do
     chown "root:${WEBHOOK_GROUP}" "$target"
 done
 
-echo "fetch-secrets: wrote ${canonical_count} canonical secret(s) + ${legacy_count} legacy alias(es) to ${OUT_FILE}"
+echo "fetch-secrets: wrote ${canonical_count} canonical secret(s) + ${legacy_count} legacy alias(es) to ${OUT_FILE} ($(stat -c '%U:%G %a' "$OUT_FILE" 2>/dev/null || echo 'perms?'))"


### PR DESCRIPTION
## Root cause (2026-06-28 vm-openclaw outage)

`fetch-secrets.sh` wrote `/run/secrets/kairix.env` (and the per-file secrets) as **`root:openclaw` mode 0640** — group-readable only. But the kairix container runs as **`uid 995 / gid 985` (group `kairix`)** and reads the bundle via **group-read**.

The host gids had drifted: `openclaw` → **gid 1001** (the `kairix` system group took 985 when provisioned), while the container stayed **gid 985**. So `root:openclaw(1001)` files are **not readable** by the gid-985 container.

It stayed healthy for ~3 weeks only because the bundle hadn't been regenerated since **2026-06-07** (when `openclaw` was still gid 985). The first `systemctl restart kairix-fetch-secrets` since then — a routine deploy step — rewrote the files with the now-mismatched gid, and the container crash-looped on recreate (`01-onboard-check`'s `kairix init` failed to load secrets; the `02-operator-token` `OSError` was a non-fatal red herring).

## Fix

- **Default `KAIRIX_SECRETS_GROUP` `openclaw` → `kairix`** — the container's *own* runtime group, removing the fragile cross-group gid coupling. The `openclaw` operator user is a member of the `kairix` group, so operator read-access for debugging is preserved. This also matches the pip/systemd path, which was already documented as `root:kairix`, and the webhook secrets, which are already grouped to their consumer (`kairix-webhook`).
- **gid-mismatch guard** — `fetch-secrets.sh` now warns if the chosen secrets group's gid ≠ the container gid (`KAIRIX_CONTAINER_GID`, default `985`), so a host group/gid drift surfaces in the journal/deploy log instead of as a silent outage.
- **Observability** — the final log line now reports the bundle's resulting `owner:group mode`.
- **Docs** — `secrets-configuration.md`: `root:openclaw` → `root:kairix`, plus a "group/gid contract" note.

## Verification

- `bash -n` + `shellcheck` clean.
- **Applied + verified on vm-openclaw** as the box stopgap (`KAIRIX_SECRETS_GROUP=kairix` in the `kairix-fetch-secrets` systemd drop-in): after re-running fetch-secrets, both the bundle and per-file secrets are `root:kairix 640`, the container (uid 995/gid 985) **group-reads both**, and onboard check is **18/18 `fully_passed`**. The box now survives a reboot/redeploy.

This PR makes the default correct for all hosts (fresh installs + future deploys) so the box drop-in becomes belt-and-suspenders.

> Note: the box was already recovered before this PR; the deploy that triggered the outage had no auto-rollback, which is why a failed `up` left prod down. Auto image-tag rollback on a failed `apply-alpha.sh` is a recommended follow-up.