### PR TITLE
feat(deploy): auto-rollback apply-alpha.sh to the prior tag on a failed deploy

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -137,7 +137,7 @@
       {
         "type": "Secret Keyword",
         "filename": "docs/operations/MCP-DEPLOYMENT.md",
-        "hashed_secret": "7cb594bd4758481885f7e3e88331212e5ca69f51",
+        "hashed_secret": "0d32bede5dcd867cd8ba38a91df8b5f371b2c2e9",
         "is_verified": false,
         "line_number": 178
       }
@@ -376,5 +376,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-12T13:24:02Z"
+  "generated_at": "2026-06-28T12:51:02Z"
 }

--- a/scripts/deploy/apply-alpha.sh
+++ b/scripts/deploy/apply-alpha.sh
@@ -15,7 +15,9 @@
 #   <image-tag> may carry a leading 'v' (e.g. v2026.6.8a1); it is stripped
 #   to match the GHCR image tag convention (YYYY.M.D[.N]aN, no 'v').
 #
-# Sequence (each step fails the script non-zero on error, except 4a):
+# Sequence (each step fails the script non-zero on error; a container-health
+# failure at step (c)/(d) AUTO-ROLLS-BACK to the prior known-good tag — see
+# "Auto-rollback" below):
 #   (a) systemctl restart kairix-fetch-secrets.service  — NON-FATAL
 #   (b) persist KAIRIX_IMAGE_TAG into ./.env (idempotent, atomic)
 #   (c) docker compose pull + up -d --force-recreate --wait the kairix service
@@ -31,6 +33,19 @@
 # (docker-compose.yml), a single `kairix` service, container `app-kairix-1`,
 # compose dir /opt/kairix/app — matching the webhook's unified-container
 # config defaults.
+#
+# Auto-rollback: a failed deploy must never leave production DOWN (the
+# 2026-06-28 incident — `up --force-recreate --wait` failed and left the stack
+# stopped, with no path back). Before mutating anything we capture the prior
+# image TAG + DIGEST; an EXIT trap (on_exit) re-pins .env to that tag and
+# recreates the kairix service on the LOCALLY-CACHED prior image (no pull —
+# offline-resilient, the exact incident gap), then verifies it. Only
+# container-health failures (steps c/d) roll back; a step-(e) regression leaves
+# the HEALTHY build serving for a human call. The GitHub run still FAILS on the
+# non-zero exit — only the box end-state changes. Exit codes: 10 = auto-healed,
+# 11 = rollback impossible (manual), 12 = rollback failed / prod down (page).
+# deploy.go parity is a tracked follow-up (the webhook is the documented
+# fallback, not the active path).
 
 set -eu
 
@@ -50,7 +65,9 @@ IMAGE_TAG="${RAW_TAG#v}"
 
 # Operational constants — kept in lock-step with the webhook's config defaults
 # (internal/config/config.go).
-COMPOSE_DIR="/opt/kairix/app"
+# COMPOSE_DIR is overridable (KAIRIX_COMPOSE_DIR) purely as a test seam; the
+# prod default is unchanged. The webhook hardcodes /opt/kairix/app.
+COMPOSE_DIR="${KAIRIX_COMPOSE_DIR:-/opt/kairix/app}"
 COMPOSE_SERVICE="kairix"
 CONTAINER="app-kairix-1"
 BENCHMARK_SUITE="reflib"
@@ -66,6 +83,38 @@ cd "$COMPOSE_DIR" || {
 	exit 1
 }
 
+# --- rollback state: capture the prior known-good image before we mutate -----
+#
+# This is the only recoverable window: step (b) overwrites .env and step (c)
+# --force-recreate replaces the running container. Capture the prior TAG (what
+# compose interpolates) and the running image DIGEST (the rollback witness).
+PREV_TAG=""
+PREV_DIGEST=""
+ROLLBACK_DONE=0
+ROLLBACK_ARMED=0
+ROLLBACK_TMP=""
+# 1) Prefer the persisted .env tag.
+if [ -f .env ] && grep -q '^KAIRIX_IMAGE_TAG=' .env; then
+	PREV_TAG="$(grep '^KAIRIX_IMAGE_TAG=' .env | head -n1 | cut -d= -f2- | tr -d '\r' | sed 's/[[:space:]]*$//')"
+fi
+# 2) Capture the running container's resolved digest (the rollback witness) and,
+#    only if .env had no tag, its image reference as a fallback tag source.
+#    Reject a digest-pinned ref (...@sha256:...) — it carries no usable tag.
+PREV_DIGEST="$(docker inspect --format '{{ .Image }}' "$CONTAINER" 2>/dev/null || true)"
+if [ -z "$PREV_TAG" ]; then
+	_live_ref="$(docker inspect --format '{{ index .Config.Image }}' "$CONTAINER" 2>/dev/null || true)"
+	case "$_live_ref" in
+		*@sha256:*) : ;;
+		*:*) PREV_TAG="$(printf '%s' "$_live_ref" | sed 's/.*://')" ;;
+	esac
+fi
+# 3) Validate the tag grammar (alpha YYYY.M.D[.N]aN or a mutable channel);
+#    discard anything else so rollback is reported impossible, not fed garbage.
+if [ -n "$PREV_TAG" ] && ! printf '%s' "$PREV_TAG" | grep -Eq '^([0-9]{4}\.[0-9]+\.[0-9]+(\.[0-9]+)?a[0-9]+|main|latest)$'; then
+	echo "::warning::apply-alpha: prior tag '$PREV_TAG' is not a recognised tag; rollback will be treated as impossible" >&2
+	PREV_TAG=""
+fi
+
 # Compose -f file list. The kairix image TAG is interpolated in
 # docker-compose.override.yml (image: ...:${KAIRIX_IMAGE_TAG:-latest}); the base
 # docker-compose.yml pins :latest and the override also carries the /run/secrets
@@ -75,6 +124,93 @@ cd "$COMPOSE_DIR" || {
 # already captured above, so reusing the positional params here is safe.
 set -- -f docker-compose.yml
 [ -f docker-compose.override.yml ] && set -- "$@" -f docker-compose.override.yml
+
+# --- rollback machinery ----------------------------------------------------
+#
+# rollback_to_prev: re-pin .env to PREV_TAG and force-recreate the kairix
+# service on the cached prior image (NO pull), then verify the running digest
+# matches the prior good one and onboard passes. Returns: 0 = rolled back +
+# verified; 3 = impossible (no distinct prior tag); 4 = attempted but prod
+# still down. Idempotent (ROLLBACK_DONE) and set-e-safe (every write guarded).
+rollback_to_prev() {
+	if [ "$ROLLBACK_DONE" -eq 1 ]; then return 0; fi
+	ROLLBACK_DONE=1
+	_failed_tag="$IMAGE_TAG"
+	if [ -z "$PREV_TAG" ] || [ "$PREV_TAG" = "$_failed_tag" ]; then
+		echo "::error::apply-alpha: deploy of '$_failed_tag' FAILED and there is no distinct prior tag to roll back to (PREV_TAG='$PREV_TAG'). Box left on '$_failed_tag' — MANUAL INTERVENTION REQUIRED." >&2
+		return 3
+	fi
+	echo "::warning::apply-alpha: deploy of '$_failed_tag' FAILED — rolling back to prior tag '$PREV_TAG' (cached image, no re-pull)" >&2
+	# Atomic .env re-pin (same tmp-then-mv idiom as step b); guard every write.
+	_rb_tmp="$(mktemp "${COMPOSE_DIR}/.env.tmp.XXXXXX")" || {
+		echo "::error::apply-alpha: rollback mktemp failed — prod left on '$_failed_tag'. PAGE A HUMAN." >&2
+		return 4
+	}
+	ROLLBACK_TMP="$_rb_tmp"
+	if grep -q '^KAIRIX_IMAGE_TAG=' .env 2>/dev/null; then
+		if ! sed "s|^KAIRIX_IMAGE_TAG=.*|KAIRIX_IMAGE_TAG=${PREV_TAG}|" .env >"$_rb_tmp"; then
+			rm -f "$_rb_tmp"; ROLLBACK_TMP=""
+			echo "::error::apply-alpha: rollback .env rewrite failed. PAGE A HUMAN." >&2
+			return 4
+		fi
+	else
+		if ! { cat .env >"$_rb_tmp" 2>/dev/null && printf 'KAIRIX_IMAGE_TAG=%s\n' "$PREV_TAG" >>"$_rb_tmp"; }; then
+			rm -f "$_rb_tmp"; ROLLBACK_TMP=""
+			echo "::error::apply-alpha: rollback .env rewrite failed. PAGE A HUMAN." >&2
+			return 4
+		fi
+	fi
+	if ! mv "$_rb_tmp" .env; then
+		rm -f "$_rb_tmp"; ROLLBACK_TMP=""
+		echo "::error::apply-alpha: rollback .env mv failed. PAGE A HUMAN." >&2
+		return 4
+	fi
+	ROLLBACK_TMP=""
+	# Recreate on the prior tag — SAME -f args ($@) + up flags as step (c), but
+	# NO pull: the prior image is already in the local store.
+	if ! KAIRIX_IMAGE_TAG="$PREV_TAG" docker compose "$@" up -d --force-recreate --wait --wait-timeout 90 "$COMPOSE_SERVICE"; then
+		echo "::error::apply-alpha: ROLLBACK to '$PREV_TAG' FAILED at compose up — prod is DOWN. PAGE A HUMAN." >&2
+		return 4
+	fi
+	# Guard a mutable tag (e.g. 'main') that moved to the SAME bad digest.
+	_new_digest="$(docker inspect --format '{{ .Image }}' "$CONTAINER" 2>/dev/null || true)"
+	if [ -n "$PREV_DIGEST" ] && [ -n "$_new_digest" ] && [ "$_new_digest" != "$PREV_DIGEST" ]; then
+		echo "::error::apply-alpha: ROLLBACK resolved '$PREV_TAG' to a different digest than the prior good image — cannot confirm known-good binary. PAGE A HUMAN." >&2
+		return 4
+	fi
+	# Verify onboard fully_passed (don't trust --wait alone); jq->grep fallback.
+	_rb_json="$(docker exec "$CONTAINER" sh -c 'kairix onboard check --json 2>/dev/null' 2>/dev/null)" || _rb_json=""
+	_rb_ok=0
+	if command -v jq >/dev/null 2>&1; then
+		if [ "$(printf '%s' "$_rb_json" | jq -r '.fully_passed // false' 2>/dev/null)" = "true" ]; then _rb_ok=1; fi
+	else
+		if printf '%s' "$_rb_json" | grep -q '"fully_passed"[[:space:]]*:[[:space:]]*true'; then _rb_ok=1; fi
+	fi
+	if [ "$_rb_ok" -ne 1 ]; then
+		echo "::error::apply-alpha: ROLLBACK to '$PREV_TAG' came up but FAILED onboard check — prod DEGRADED/DOWN. PAGE A HUMAN." >&2
+		return 4
+	fi
+	echo "::warning::apply-alpha: rollback to '$PREV_TAG' SUCCEEDED — bad deploy '$_failed_tag' reverted, prod restored. Deploy still reported FAILED." >&2
+	return 0
+}
+
+# on_exit: the single EXIT trap. Rolls back ONLY for armed container-health
+# failures (steps c/d). Steps a/b never recreated the container; step (e) is a
+# regression of a HEALTHY build (leave it for a human). $@ is the compose -f
+# list (set below); the trap MUST forward it: `trap 'on_exit "$@"' EXIT`.
+on_exit() {
+	_st=$?
+	rm -f "$ROLLBACK_TMP" 2>/dev/null || true
+	if [ "$_st" -eq 0 ]; then exit 0; fi
+	if [ "$ROLLBACK_ARMED" -ne 1 ]; then exit "$_st"; fi
+	_rb=0
+	rollback_to_prev "$@" || _rb=$?
+	case "$_rb" in
+		0) exit 10 ;;
+		3) exit 11 ;;
+		*) exit 12 ;;
+	esac
+}
 
 echo "apply-alpha: deploying image tag '$IMAGE_TAG' from $COMPOSE_DIR"
 
@@ -109,12 +245,18 @@ else
 	printf 'KAIRIX_IMAGE_TAG=%s\n' "$IMAGE_TAG" >>"$tmp_env"
 fi
 mv "$tmp_env" .env
-trap - EXIT
+# Hand the EXIT trap from the step-(b) tmp-cleanup to on_exit, which now owns
+# rollback. A step-(b) abort before this point keeps the original tmp-cleanup
+# trap and triggers no rollback — the container was never touched.
+trap 'on_exit "$@"' EXIT
 
 # --- (c) docker compose pull + up -----------------------------------------
 #
 # The override's ${KAIRIX_IMAGE_TAG:-latest} resolves the alpha image once the
 # tag is exported (see the compose-file note above for why both files are passed).
+# Arm rollback: from here the container is (re)created, so a failure at step
+# (c)/(d) must restore the prior good tag.
+ROLLBACK_ARMED=1
 echo "apply-alpha: docker compose pull $COMPOSE_SERVICE (tag=$IMAGE_TAG)"
 if ! KAIRIX_IMAGE_TAG="$IMAGE_TAG" docker compose "$@" pull "$COMPOSE_SERVICE"; then
 	echo "FAIL apply-alpha: docker compose pull failed" >&2
@@ -171,6 +313,9 @@ if [ "$fully_passed" != "true" ]; then
 	exit 1
 fi
 echo "apply-alpha: onboard check fully_passed"
+# Disarm: the new build is healthy. A step-(e) regression is a HEALTHY build
+# scoring low — do NOT force-recreate it away; leave it for a human call.
+ROLLBACK_ARMED=0
 
 # --- (e) benchmark + regression gate --------------------------------------
 echo "apply-alpha: kairix benchmark run --suite $BENCHMARK_SUITE"
@@ -203,4 +348,5 @@ if awk -v w="$weighted" -v b="$BASELINE_WEIGHTED" -v tol="$REGRESSION_TOLERANCE"
 	exit 1
 fi
 
+trap - EXIT  # clean success — disarm rollback
 printf 'alpha %s validated — weighted=%s\n' "$IMAGE_TAG" "$weighted"

--- a/tests/deploy/test_apply_alpha_rollback.py
+++ b/tests/deploy/test_apply_alpha_rollback.py
@@ -1,0 +1,201 @@
+"""Behavioural tests for the auto-rollback in scripts/deploy/apply-alpha.sh.
+
+The script is driven via subprocess with a fake `docker` (and `systemctl`) on
+PATH, so we exercise the real shell — including the EXIT-trap exit-code dispatch
+that is easy to get subtly wrong under `set -e` (the trap must capture the
+rollback return with `rb=0; rollback_to_prev "$@" || rb=$?` and forward `$@`).
+
+Exit-code contract:
+  0  = clean success (no rollback)
+  10 = deploy failed, rolled back to the prior tag + verified (prod restored)
+  11 = deploy failed, rollback impossible (no distinct prior tag)
+  12 = deploy failed, rollback also failed (prod down / page a human)
+  (a step-(e) regression is NOT rolled back: it exits with the raw failure code)
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit  # fast, hermetic (all externals faked) — F8 category
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "deploy" / "apply-alpha.sh"
+PRIOR = "2026.6.25a1"  # the known-good tag already running before the deploy
+NEW = "2026.6.28a3"  # the tag we are deploying
+
+FAKE_DOCKER = r"""#!/usr/bin/env python3
+import os, sys
+argv = sys.argv[1:]
+tag = os.environ.get("KAIRIX_IMAGE_TAG", "")
+log = os.environ.get("FAKE_DOCKER_LOG")
+if log:
+    open(log, "a").write("TAG=%s :: %s\n" % (tag, " ".join(argv)))
+state = os.environ.get("FAKE_STATE_FILE")
+
+def fset(name):
+    return set(filter(None, os.environ.get(name, "").split(",")))
+
+def cur_digest():
+    if state and os.path.exists(state):
+        return open(state).read().strip()
+    return os.environ.get("FAKE_INITIAL_DIGEST", "")
+
+sub = argv[0] if argv else ""
+if sub == "inspect":
+    fmt = argv[2] if len(argv) > 2 else ""
+    if "Config" in fmt:           # {{ index .Config.Image }} -> image reference
+        sys.stdout.write(os.environ.get("FAKE_LIVE_REF", ""))
+    else:                          # {{ .Image }} -> resolved digest of running ctr
+        sys.stdout.write(cur_digest())
+    sys.exit(0)
+if sub == "compose":
+    if "pull" in argv:
+        sys.exit(1 if tag in fset("FAKE_PULL_FAIL_TAGS") else 0)
+    if "up" in argv:
+        if tag in fset("FAKE_UP_FAIL_TAGS"):
+            sys.exit(1)
+        if state:
+            open(state, "w").write("d-" + tag)   # successful up resolves the tag
+        sys.exit(0)
+    sys.exit(0)
+if sub == "exec":
+    joined = " ".join(argv)
+    if "onboard" in joined:
+        d = cur_digest()
+        curtag = d[2:] if d.startswith("d-") else ""
+        ok = "false" if curtag in fset("FAKE_ONBOARD_FAIL_TAGS") else "true"
+        sys.stdout.write('{"fully_passed": %s, "passed": 18, "total": 18}' % ok)
+        sys.exit(0)
+    if "benchmark" in joined:
+        sys.stdout.write("Weighted total: %s\n" % os.environ.get("FAKE_WEIGHTED", "0.810"))
+        sys.exit(0)
+    sys.exit(0)
+sys.exit(0)
+"""
+
+
+def _run(tmp_path: Path, tag: str, *, prior=PRIOR, initial_digest=None, **fake_env):
+    """Run apply-alpha.sh against a fake docker. Returns (proc, docker_log, env_text)."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    (bindir / "docker").write_text(FAKE_DOCKER)
+    (bindir / "docker").chmod(0o755)
+    (bindir / "systemctl").write_text("#!/bin/sh\nexit 0\n")
+    (bindir / "systemctl").chmod(0o755)
+
+    compose = tmp_path / "compose"
+    compose.mkdir()
+    (compose / "docker-compose.yml").write_text("services: {}\n")
+    if prior is not None:
+        (compose / ".env").write_text(f"KAIRIX_IMAGE_TAG={prior}\n")
+
+    log = tmp_path / "docker.log"
+    state = tmp_path / "state"  # intentionally absent until the first `up`
+
+    env = dict(os.environ)
+    env["PATH"] = "{}:{}".format(bindir, env["PATH"])
+    env["KAIRIX_COMPOSE_DIR"] = str(compose)
+    env["FAKE_DOCKER_LOG"] = str(log)
+    env["FAKE_STATE_FILE"] = str(state)
+    # The running container's digest before the deploy. Defaults to the prior
+    # tag's digest so a clean rollback verifies; override to force a mismatch.
+    env["FAKE_INITIAL_DIGEST"] = initial_digest if initial_digest is not None else (f"d-{prior}")
+    env["FAKE_LIVE_REF"] = "ghcr.io/three-cubes/kairix:%s" % (prior or "")
+    for k, v in fake_env.items():
+        env[k] = str(v)
+
+    proc = subprocess.run(
+        ["sh", str(SCRIPT), tag],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    env_text = (compose / ".env").read_text() if (compose / ".env").exists() else ""
+    return proc, (log.read_text() if log.exists() else ""), env_text
+
+
+def test_happy_path_no_rollback(tmp_path):
+    proc, dlog, env_text = _run(tmp_path, NEW)
+    assert proc.returncode == 0, proc.stderr
+    assert f"KAIRIX_IMAGE_TAG={NEW}" in env_text
+    assert "rolling back" not in proc.stderr.lower()
+    # exactly one `up`, for the new tag — no rollback up of the prior tag
+    ups = [ln for ln in dlog.splitlines() if " up " in ln]
+    assert len(ups) == 1 and (f"TAG={NEW}") in ups[0]
+
+
+def test_up_fail_rolls_back_and_exits_10(tmp_path):
+    proc, dlog, env_text = _run(tmp_path, NEW, FAKE_UP_FAIL_TAGS=NEW)
+    assert proc.returncode == 10, proc.stderr
+    assert f"KAIRIX_IMAGE_TAG={PRIOR}" in env_text  # .env restored
+    assert "SUCCEEDED" in proc.stderr
+    # the rollback `up` ran for the prior tag, forwarding the -f file list
+    rb_ups = [ln for ln in dlog.splitlines() if " up " in ln and (f"TAG={PRIOR}") in ln]
+    assert rb_ups and "-f docker-compose.yml" in rb_ups[0]
+
+
+def test_onboard_fail_rolls_back_and_exits_10(tmp_path):
+    proc, _dlog, env_text = _run(tmp_path, NEW, FAKE_ONBOARD_FAIL_TAGS=NEW)
+    assert proc.returncode == 10, proc.stderr
+    assert f"KAIRIX_IMAGE_TAG={PRIOR}" in env_text
+
+
+def test_offline_pull_fail_rolls_back_without_pulling(tmp_path):
+    proc, dlog, _env = _run(tmp_path, NEW, FAKE_PULL_FAIL_TAGS=NEW)
+    assert proc.returncode == 10, proc.stderr
+    # the ONLY pull was the (failed) new-tag pull; the rollback never pulls
+    pulls = [ln for ln in dlog.splitlines() if " pull " in ln]
+    assert len(pulls) == 1 and (f"TAG={NEW}") in pulls[0]
+    assert any(" up " in ln and (f"TAG={PRIOR}") in ln for ln in dlog.splitlines())
+
+
+def test_regression_does_not_roll_back(tmp_path):
+    # step (e) regression: a HEALTHY build scoring below baseline must NOT be
+    # rolled back — exit with the raw failure code, leave the new build serving.
+    proc, dlog, env_text = _run(tmp_path, NEW, FAKE_WEIGHTED="0.500")
+    assert proc.returncode == 1, proc.stderr
+    assert f"KAIRIX_IMAGE_TAG={NEW}" in env_text  # new build stays
+    assert "rolling back" not in proc.stderr.lower()
+    assert sum(1 for ln in dlog.splitlines() if " up " in ln) == 1  # no rollback up
+
+
+def test_same_tag_redeploy_rollback_impossible_exits_11(tmp_path):
+    proc, _dlog, _env = _run(tmp_path, PRIOR, FAKE_UP_FAIL_TAGS=PRIOR)
+    assert proc.returncode == 11, proc.stderr
+    assert "MANUAL INTERVENTION" in proc.stderr
+
+
+def test_fresh_host_no_prior_rollback_impossible_exits_11(tmp_path):
+    proc, _dlog, _env = _run(
+        tmp_path,
+        NEW,
+        prior=None,
+        initial_digest="",
+        FAKE_LIVE_REF="",
+        FAKE_UP_FAIL_TAGS=NEW,
+    )
+    assert proc.returncode == 11, proc.stderr
+
+
+def test_rollback_also_fails_exits_12(tmp_path):
+    proc, _dlog, _env = _run(tmp_path, NEW, FAKE_UP_FAIL_TAGS=f"{NEW},{PRIOR}")
+    assert proc.returncode == 12, proc.stderr
+    assert "PAGE A HUMAN" in proc.stderr
+
+
+def test_rollback_digest_mismatch_exits_12(tmp_path):
+    # rollback `up` succeeds but the prior tag resolved to a different digest
+    # than the one running before the deploy -> cannot confirm known-good binary.
+    proc, _dlog, _env = _run(
+        tmp_path,
+        NEW,
+        initial_digest="d-MOVED",
+        FAKE_UP_FAIL_TAGS=NEW,
+    )
+    assert proc.returncode == 12, proc.stderr
+    assert "different digest" in proc.stderr


### PR DESCRIPTION
## Why

The 2026-06-28 outage: the alpha deploy's `docker compose up -d --force-recreate --wait` failed and left the kairix + neo4j stack **stopped, with no path back** — because `apply-alpha.sh` (the active deploy path) had **no rollback**. A failed deploy must never leave production down.

## What

`apply-alpha.sh` now captures the prior known-good image **TAG + DIGEST** before mutating anything, and a single self-disarming `EXIT` trap (`on_exit`) restores it on a container-health failure:

- **Step (c)/(d) failure → roll back:** re-pin `.env` to the prior tag and force-recreate the kairix service on the **locally-cached** prior image — **no pull**. GHCR being unreachable is exactly the failure class that must still recover (the incident gap).
- **Step (e) regression → do NOT roll back:** a *healthy* build scoring below baseline is left serving for a human call (gated by `ROLLBACK_ARMED`). Force-recreating a healthy build away is more disruptive than the regression.
- **Distinct exit codes** (any non-zero still **fails** the GitHub run — only the box end-state changes):
  - `10` auto-healed — prod restored on the prior tag
  - `11` rollback impossible — no distinct prior tag (manual intervention)
  - `12` rollback also failed — prod down (page a human)
- **Verification, not just `--wait`:** after the rollback `up`, require the running digest to match the prior good one (catches a mutable `main` that re-resolved to a different/same bad digest — a false auto-heal) **and** `onboard check` `fully_passed`.
- **Edge cases handled:** digest-pinned running refs, unrecognised tag grammar, first deploy / fresh host (rollback reported impossible, not a doomed guess), and a rollback whose own `.env` rewrite or `up` fails (every write guarded, `set -e`-safe, no leaked tmp).

## The subtle bit

Under `set -e`, the trap dispatch is easy to get wrong (an upstream design review reproduced both failure modes):
- the rollback return **must** be captured as `rb=0; rollback_to_prev "$@" || rb=$?` — a bare `rb=$?` trips `set -e` and the `11`/`12` codes never emit;
- the trap **must** forward `$@` (the compose `-f` list) via `trap 'on_exit "$@"' EXIT`, or the rollback `compose` runs with no `-f` files.

Both are covered by tests.

## Tests

`tests/deploy/test_apply_alpha_rollback.py` — 9 scenarios drive the **real script** against a fake `docker` on `PATH`:

| scenario | exit |
|---|---|
| happy path (no rollback) | 0 |
| `up` fails → rollback good | 10 |
| `onboard` fails → rollback good | 10 |
| offline (`pull` fails) → rollback without pulling | 10 |
| regression (step e) → no rollback, new build stays | 1 |
| same-tag redeploy → impossible | 11 |
| fresh host / no prior tag → impossible | 11 |
| rollback `up` also fails | 12 |
| rollback digest mismatch | 12 |

`shellcheck -s sh` + `dash -n` clean. A small `KAIRIX_COMPOSE_DIR` env seam (prod default unchanged) makes the script testable off-box.

## Scope / follow-up

This lands rollback in the **active** deploy path (`apply-alpha.sh`). The `deploy.go` webhook is the *documented fallback*, not the active path; mirroring rollback into it entangles a pre-existing compose-shape drift (it defaults to a `kairix kairix-worker` two-file shape that no longer matches the box), so that's tracked as a separate follow-up rather than bundled here.