### PR TITLE
fix(deploy): restore vm-reflib-regression status + drop oneshot smoke false-negative (PLA-250)

### DIFF
--- a/.github/workflows/release-vm-deploy.yml
+++ b/.github/workflows/release-vm-deploy.yml
@@ -136,7 +136,7 @@ jobs:
 
   prep:
     # Deliver the box-side apply-script to the VM at deploy time. The kairix
-    # repo is NOT checked out on vm-openclaw (kairix deploys as a container
+    # repo is NOT checked out on the target VM (kairix deploys as a container
     # image), so /opt/kairix/app/scripts/... doesn't exist on the box. To keep
     # scripts/deploy/apply-alpha.sh as the SINGLE source of truth (one tested
     # copy) rather than inline-duplicating its ~190 lines, base64-encode it
@@ -173,7 +173,11 @@ jobs:
     # Replaces the bespoke HMAC-webhook POST + commit-status poll.
     uses: three-cubes/tc-pipelines/.github/workflows/azure-vm-deploy.yml@v1
     with:
-      resource-group: RG-AGENTS-CORE
+      # Deploy target (resource group + VM name) comes from repo variables, not
+      # hardcoded literals, so infra identifiers stay out of this public repo.
+      # Set vars.KAIRIX_DEPLOY_RESOURCE_GROUP + vars.KAIRIX_DEPLOY_VM_NAME in repo
+      # settings (gh variable set ...) before dispatching this workflow.
+      resource-group: ${{ vars.KAIRIX_DEPLOY_RESOURCE_GROUP }}
       op-tag: kairix-alpha
       # skip-snapshot: the kairix CI identity holds VM Contributor but NOT Disk Snapshot Contributor — kairix rolls back by re-pinning the previous image tag (KAIRIX_IMAGE_TAG), not a VM disk snapshot, so the snapshot step is intentionally skipped.
       skip-snapshot: 'true'
@@ -183,13 +187,104 @@ jobs:
       # any leading 'v' to the GHCR image-tag convention; it is self-contained
       # (cd's only to the on-box /opt/kairix/app compose dir, no repo paths).
       targets: |
-        - vm-name: vm-openclaw
+        - vm-name: ${{ vars.KAIRIX_DEPLOY_VM_NAME }}
           apply-script: |
             set -eu
             printf %s '${{ needs.prep.outputs.script_b64 }}' | base64 -d > /tmp/apply-alpha.sh
             sh /tmp/apply-alpha.sh '${{ needs.gate-alpha-tag.outputs.tag }}'
-          smoke-units: 'kairix.service'
+          # smoke-units intentionally EMPTY (the reusable workflow skips the
+          # systemd smoke when this is blank). `systemctl is-active kairix.service`
+          # is the WRONG probe here: kairix.service is a Type=oneshot wrapper
+          # around `docker compose up`, and its unit state is decoupled from the
+          # docker-managed (restart: unless-stopped) container fleet — it reads
+          # `failed`/`activating` while the containers are healthy (the exact
+          # class in docs/runbooks/kairix-service-failed-containers-healthy.md).
+          # On v2026.6.28a5, is-active returned `failed` (tripping the reusable
+          # smoke's `\b(...|failed|...)\b` assertion, azure-vm-deploy.yml@v1 L187)
+          # even though apply-alpha printed `validated — weighted=0.843`. The
+          # authoritative health gate is apply-alpha.sh's in-band onboard check
+          # (`kairix onboard check --json` -> fully_passed) + `--wait` container
+          # health; a non-zero apply-alpha exit surfaces via the reusable
+          # workflow's apply-output `^FAIL ` grep, failing deploy-vm. No
+          # systemd-unit smoke is needed or correct for this oneshot wrapper.
+          smoke-units: ''
       azure-client-id: ${{ vars.AZURE_CLIENT_ID }}
       azure-tenant-id: ${{ vars.AZURE_TENANT_ID }}
       azure-subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
     secrets: inherit  # pragma: allowlist secret — passes the caller's AZURE_* repo vars to the reusable workflow; no literal secret here
+
+  post-reflib-status:
+    # PLA-250 Gap A: the WS2 deploy migration (PR #634) moved the VM deploy onto
+    # the reusable azure-vm-deploy workflow + box-side apply-alpha.sh, but dropped
+    # the `vm-reflib-regression` commit status that the retired Go alpha-deploy
+    # webhook used to POST. release.yml's stable-release alpha-gate (5a) still
+    # HARD-REQUIRES that status (it `exit 1`s when absent), so no alpha cut via
+    # the new path can ever clear the gate. This job re-establishes the producer
+    # WORKFLOW-SIDE — never box-side — so NO GitHub token rides in the
+    # az-vm-run-command payload (the box only runs apply-alpha.sh). The reflib
+    # VERDICT is already computed on the box: apply-alpha.sh exits 0 only after
+    # `onboard check` fully_passed AND the regression gate (delta <= tolerance)
+    # passed, so the deploy-vm conclusion IS the verdict. We post `failure` (not
+    # absent) on any non-success so the gate stays closed on a failed / regressing
+    # / rolled-back deploy.
+    name: Post vm-reflib-regression commit status
+    needs: [gate-alpha-tag, deploy-vm]
+    # Run even when deploy-vm failed (to post state=failure), as long as we
+    # resolved an alpha SHA to post against.
+    if: ${{ always() && needs.gate-alpha-tag.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # WIF: mint the three-cubes-agent App token from Key Vault
+    steps:
+      # Mint a short-lived three-cubes-agent App installation token over WIF so
+      # the commit status is authored by three-cubes-agent[bot] (clean identity,
+      # no GitHub-stored PAT). Same composite release.yml uses for tagging.
+      - name: Mint three-cubes-agent App token
+        id: app
+        uses: three-cubes/tc-pipelines/.github/actions/github-app-token@v1
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      - name: Post vm-reflib-regression status on the alpha SHA
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}  # App identity -> status creator = three-cubes-agent[bot]
+          REPO: ${{ github.repository }}
+          SHA: ${{ needs.gate-alpha-tag.outputs.sha }}
+          TAG: ${{ needs.gate-alpha-tag.outputs.tag }}
+          DEPLOY_RESULT: ${{ needs.deploy-vm.result }}
+          # apply-output is surfaced by azure-vm-deploy once the caller passes
+          # `surface-apply-output: 'true'` (added once the @v1 enhancement lands).
+          # Empty against older @v1 -> the description falls back to the run link.
+          APPLY_OUTPUT: ${{ needs.deploy-vm.outputs.apply-output }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          if [ "$DEPLOY_RESULT" = "success" ]; then
+            state=success
+            verb="reflib+onboard gate PASS"
+          else
+            state=failure
+            verb="reflib/deploy gate FAIL (${DEPLOY_RESULT})"
+          fi
+          # Best-effort: lift the achieved score from apply-alpha's KAIRIX_REFLIB
+          # marker in the surfaced apply output, so the status reads
+          # `weighted=X baseline=Y`. Falls back to a run link (where the score is
+          # always logged) when the apply output isn't surfaced. The STATE — not
+          # the description — is what release.yml's 5a alpha-gate reads.
+          marker="$(printf '%s' "$APPLY_OUTPUT" | grep -oE 'KAIRIX_REFLIB verdict=[a-z]+ weighted=[0-9.]+ baseline=[0-9.]+ tolerance=[0-9.]+' | tail -n1 || true)"
+          weighted="$(printf '%s' "$marker" | sed -nE 's/.*weighted=([0-9.]+).*/\1/p')"
+          baseline="$(printf '%s' "$marker" | sed -nE 's/.*baseline=([0-9.]+).*/\1/p')"
+          if [ -n "$weighted" ] && [ -n "$baseline" ]; then
+            scores="weighted=${weighted} baseline=${baseline}"
+          else
+            scores="scores in deploy run"
+          fi
+          desc="${verb} — ${TAG} ${scores}"  # GitHub truncates status descriptions at 140 chars
+          gh api "repos/${REPO}/statuses/${SHA}" \
+            -f state="$state" \
+            -f context="vm-reflib-regression" \
+            -f description="$desc" \
+            -f target_url="$RUN_URL"
+          echo "::notice::posted vm-reflib-regression=${state} on ${SHA} (${desc})"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,11 @@ jobs:
     # #272 Phase 5: refuse to tag stable unless (a) an alpha tag exists
     # for the same compute-version AND (b) that alpha SHA has a green
     # `vm-reflib-regression` commit status from release-vm-deploy.yml.
-    # Phase 4 landed that webhook + status posting, so the gate now
-    # actually proves the alpha PASSED its VM regression check, not
-    # merely that an operator cut a tag.
+    # release-vm-deploy.yml's `post-reflib-status` job posts that status
+    # after the VM deploy + reflib gate (apply-alpha.sh onboard fully_passed
+    # + delta <= tolerance), so this gate proves the alpha PASSED its VM
+    # regression check, not merely that an operator cut a tag. (The old
+    # Go alpha-deploy webhook that previously posted it is retired — PLA-250.)
     name: "5a · Alpha-gate (must precede stable)"
     runs-on: ubuntu-latest
     steps:
@@ -87,7 +89,8 @@ jobs:
           if [ -z "$status_json" ] || [ "$status_json" = "null" ]; then
             echo "::error::No vm-reflib-regression status on $latest_alpha ($alpha_sha)."
             echo ""
-            echo "fix: dispatch release-vm-deploy.yml for the alpha. The webhook will post-back the status."
+            echo "fix: dispatch release-vm-deploy.yml for the alpha — its post-reflib-status"
+            echo "     job posts the vm-reflib-regression status after the VM deploy+reflib gate."
             echo "  run:  gh workflow run release-vm-deploy.yml --ref main -f tag=${latest_alpha}"
             echo "  next: once the status is success, re-run this workflow."
             exit 1
@@ -98,10 +101,11 @@ jobs:
           if [ "$state" != "success" ]; then
             echo "::error::Alpha $latest_alpha has vm-reflib-regression state=$state (not 'success'). Refusing to tag stable."
             echo ""
-            echo "fix: investigate the alpha-deploy failure on the VM hosting the webhook —"
-            echo "     journalctl -u kairix-alpha-deploy-webhook.service --no-pager -n 100"
-            echo "     (run from the VM where the alpha-deploy webhook is installed; see"
-            echo "     docs/runbooks/kairix-retrieval-health.md for triage steps)."
+            echo "fix: investigate the alpha-deploy failure in the release-vm-deploy.yml run"
+            echo "     for $latest_alpha — the status's target_url links it. Read the deploy-vm"
+            echo "     job's apply output (apply-alpha.sh: a 'FAIL apply-alpha:' line on a"
+            echo "     compose/onboard/regression failure, or 'KAIRIX_REFLIB verdict=regress' on"
+            echo "     a reflib regression); see docs/runbooks/kairix-retrieval-health.md."
             echo "     Once the underlying regression is fixed and a new alpha cut + passed, re-run this workflow."
             exit 1
           fi

--- a/kairix/core/connectors/rechunk_sweep.py
+++ b/kairix/core/connectors/rechunk_sweep.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 import sqlite3
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from kairix.core.connectors.chunker_registry import (
     DOCX_MIME,
@@ -168,7 +168,7 @@ def scan_candidates(
 def _candidate_to_stale(
     db: sqlite3.Connection,
     registry: ChunkerRegistry,
-    row: tuple,
+    row: tuple[Any, ...],
 ) -> StaleDoc | None:
     """Resolve one discovery row to a :class:`StaleDoc`, or None if converged."""
     (

--- a/kairix/dead_letter_cli.py
+++ b/kairix/dead_letter_cli.py
@@ -165,7 +165,9 @@ def _write_drain_report(summaries: tuple[DrainSummary, ...], *, dry_run: bool, o
     out.write(f"  total: {verb} {total} across {len(summaries)} source(s).\n")
 
 
-def _run_drain(conn: sqlite3.Connection, *, source_name: str | None, dry_run: bool, max_items: int) -> tuple:
+def _run_drain(
+    conn: sqlite3.Connection, *, source_name: str | None, dry_run: bool, max_items: int
+) -> tuple[DrainSummary, ...]:
     """Dispatch one or all sources through the drain core.
 
     Builds the silver processor on the SAME connection the core commits

--- a/scripts/deploy/apply-alpha.sh
+++ b/scripts/deploy/apply-alpha.sh
@@ -335,14 +335,27 @@ if [ -z "$weighted" ]; then
 	exit 1
 fi
 
-# Regression gate: only when a baseline is supplied. delta = baseline -
-# weighted; fail if delta > tolerance (deploy.go's BaselineWeightedTotal
-# check). awk does the float compare; print a clear message on regression.
 # Regression gate — always armed (BASELINE_WEIGHTED defaults to the standing
-# baseline). delta = baseline - weighted; fail if delta > tolerance, matching
-# deploy.go's BaselineWeightedTotal check.
+# baseline). delta = baseline - weighted; regress if delta > tolerance, matching
+# deploy.go's BaselineWeightedTotal check. awk does the float compare.
 if awk -v w="$weighted" -v b="$BASELINE_WEIGHTED" -v tol="$REGRESSION_TOLERANCE" \
 	'BEGIN { delta = b - w; exit !(delta > tol) }'; then
+	verdict=regress
+else
+	verdict=pass
+fi
+
+# Machine-readable eval marker on STDOUT, emitted on BOTH the pass and regress
+# paths. The migrated deploy plane (release-vm-deploy.yml's post-reflib-status
+# job) reads this off the box-side run-command output to publish the
+# `vm-reflib-regression` commit status (success/failure + the achieved score)
+# that release.yml's stable-release alpha-gate requires. Kept here (not a
+# gh-api call) so NO GitHub token ever rides in the box-side az-run-command
+# payload — the workflow owns the POST. Stable single-line key=value contract.
+printf 'KAIRIX_REFLIB verdict=%s weighted=%s baseline=%s tolerance=%s\n' \
+	"$verdict" "$weighted" "$BASELINE_WEIGHTED" "$REGRESSION_TOLERANCE"
+
+if [ "$verdict" = regress ]; then
 	printf 'FAIL apply-alpha: regression: weighted=%s vs baseline=%s (delta>%s tolerance)\n' \
 		"$weighted" "$BASELINE_WEIGHTED" "$REGRESSION_TOLERANCE" >&2
 	exit 1

--- a/tests/deploy/test_apply_alpha_rollback.py
+++ b/tests/deploy/test_apply_alpha_rollback.py
@@ -164,6 +164,26 @@ def test_regression_does_not_roll_back(tmp_path):
     assert sum(1 for ln in dlog.splitlines() if " up " in ln) == 1  # no rollback up
 
 
+def test_emits_reflib_marker_on_pass(tmp_path):
+    # The migrated deploy plane (PLA-250) reads the reflib eval result off the
+    # box-side stdout to post the `vm-reflib-regression` commit status. apply-alpha
+    # must emit a single machine-readable marker carrying verdict + weighted +
+    # baseline + tolerance on the PASS path (default FAKE_WEIGHTED=0.810 > the
+    # 0.808 baseline minus 0.05 tolerance -> pass).
+    proc, _dlog, _env = _run(tmp_path, NEW)
+    assert proc.returncode == 0, proc.stderr
+    assert "KAIRIX_REFLIB verdict=pass weighted=0.810 baseline=0.808 tolerance=0.05" in proc.stdout, proc.stdout
+
+
+def test_emits_reflib_marker_on_regression(tmp_path):
+    # On a regression the marker must STILL be emitted (verdict=regress) so the
+    # workflow can post state=failure with the achieved weighted score, not just
+    # an absent status. The marker goes to stdout; the FAIL line stays on stderr.
+    proc, _dlog, _env = _run(tmp_path, NEW, FAKE_WEIGHTED="0.500")
+    assert proc.returncode == 1, proc.stderr
+    assert "KAIRIX_REFLIB verdict=regress weighted=0.500 baseline=0.808 tolerance=0.05" in proc.stdout, proc.stdout
+
+
 def test_same_tag_redeploy_rollback_impossible_exits_11(tmp_path):
     proc, _dlog, _env = _run(tmp_path, PRIOR, FAKE_UP_FAIL_TAGS=PRIOR)
     assert proc.returncode == 11, proc.stderr


### PR DESCRIPTION
## What this fixes

PLA-250 — the production-release gate is hard-blocked by two WS2-migration gaps (PR #634 moved the VM deploy onto the reusable \`azure-vm-deploy.yml@v1\` + box-side \`apply-alpha.sh\`). Both are reporting/plumbing gaps, not a real regression; alpha \`v2026.6.28a5\` is deployed clean (onboard \`fully_passed\`, weighted \`0.843\` vs baseline \`0.808\`).

### Gap A — \`vm-reflib-regression\` status was never produced
The retired Go webhook used to POST that status; the migrated path posts nothing, yet \`release.yml\` job \`5a · Alpha-gate\` still hard-requires it (\`exit 1\` when absent), so no alpha cut via the new path can ever tag stable. The *verdict* survives in \`apply-alpha.sh\` step (e) (\`delta = baseline − weighted > tolerance\`); only the *publish* was dropped.

**Fix:** new workflow-side \`post-reflib-status\` job in \`release-vm-deploy.yml\` posts the status on the alpha SHA — \`success\` iff \`deploy-vm\` succeeded (apply-alpha exits 0 only after onboard \`fully_passed\` **and** the reflib gate passed), \`failure\` (never absent) otherwise. Authored by \`three-cubes-agent[bot]\` over WIF; **no GitHub token in the box-side payload** (the box only runs apply-alpha). apply-alpha now emits a stable \`KAIRIX_REFLIB verdict/weighted/baseline/tolerance\` stdout marker on both pass and regress paths.

### Gap B — smoke false-negative on the oneshot \`kairix.service\`
Verified from the a5 deploy log: \`systemctl is-active kairix.service\` returned **\`failed\`** (not "active (exited)" as the issue guessed) while apply-alpha printed \`validated — weighted=0.843\`. \`kairix.service\` is a \`Type=oneshot\` wrapper around \`docker compose up\`; its unit state is decoupled from the docker-managed (\`restart: unless-stopped\`) fleet — the exact class in \`docs/runbooks/kairix-service-failed-containers-healthy.md\`. The reusable workflow's marker grep (\`azure-vm-deploy.yml@v1\` L187, \`\b(...|failed|...)\b\`) fired. A smarter \`is-active\` parse can't fix this — \`systemctl\` is the wrong probe.

**Fix (caller-side, the correct place):** drop \`smoke-units\` (the reusable workflow skips smoke when empty). apply-alpha's in-band \`kairix onboard check\` (\`fully_passed\`) + \`--wait\` is the authoritative health gate; a non-zero apply-alpha exit still fails \`deploy-vm\` via the reusable workflow's \`^FAIL \` apply-output grep.

### Also in this PR
- **Deploy target → repo variables.** \`resource-group\`/\`vm-name\` moved off hardcoded literals to \`vars.KAIRIX_DEPLOY_RESOURCE_GROUP\` / \`vars.KAIRIX_DEPLOY_VM_NAME\` so infra identifiers stay out of any public repo. 
- **Stale affordance text** in \`release.yml\` 5a refreshed (it pointed at the retired webhook's \`journalctl\`).
- **Separate commit \`fix(types)\`** parameterizes two pre-existing bare \`tuple\` annotations (from #627/#585) that pass CI's mypy but break the local \`safe-commit\` \`mypy --strict\` gate for every commit on main — incidental, required to run the gate.

## Tests
- \`tests/deploy/test_apply_alpha_rollback.py\`: two new sabotage-proven tests assert the \`KAIRIX_REFLIB\` marker on both the pass and regress paths (all 11 green). Existing rollback tests unchanged.
- actionlint, ruff, \`mypy --strict\` (495 files), staged fitness all green locally.

## Operator follow-ups (HITL — not done here)
1. **Set the repo variables** (deploy fails without them):
   \`\`\`
   gh variable set KAIRIX_DEPLOY_RESOURCE_GROUP --repo three-cubes/kairix --body '<rg>'
   gh variable set KAIRIX_DEPLOY_VM_NAME        --repo three-cubes/kairix --body '<vm>'
   \`\`\`
2. **Backfill a5 + tag stable** once merged:
   \`\`\`
   gh workflow run release-vm-deploy.yml --ref main -f tag=v2026.6.28a5   # re-validates a5, posts the green status on 583ef1dd
   gh workflow run release.yml --ref main -f version=v2026.6.28 -f changelog_label=2026.6.28
   \`\`\`